### PR TITLE
feat: focus mode, welcome animation, skill browser

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,29 +3,45 @@
 import ChatInterface from '@/components/Engine/ChatInterface';
 import ContextPanel from '@/components/Engine/ContextPanel';
 import GripStatusBar from '@/components/Engine/GripStatusBar';
-import { useState } from 'react';
+import FocusMode from '@/components/Engine/FocusMode';
+import WelcomeAnimation from '@/components/Engine/WelcomeAnimation';
+import { useState, useCallback } from 'react';
 
 export default function EnginePage() {
   const [showContext, setShowContext] = useState(true);
+  const [showWelcome, setShowWelcome] = useState(true);
+  const [focusMode, setFocusMode] = useState(false);
+
+  const handleWelcomeComplete = useCallback(() => setShowWelcome(false), []);
+  const handleFocusToggle = useCallback((focused: boolean) => {
+    setFocusMode(focused);
+  }, []);
 
   return (
-    <div className="h-[calc(100vh-64px)] lg:h-screen flex flex-col">
-      <div className="flex-1 flex min-h-0">
-        {/* Context Panel — 3 cols on desktop, hidden on mobile */}
-        {showContext && (
-          <div className="hidden lg:block w-[280px] shrink-0">
-            <ContextPanel />
+    <>
+      {/* Welcome animation — plays once for first-time users */}
+      {showWelcome && <WelcomeAnimation onComplete={handleWelcomeComplete} />}
+
+      <div className="h-[calc(100vh-64px)] lg:h-screen flex flex-col">
+        <div className="flex-1 flex min-h-0">
+          {/* Context Panel — hidden in focus mode and on mobile */}
+          {showContext && !focusMode && (
+            <div className="hidden lg:block w-[280px] shrink-0">
+              <ContextPanel />
+            </div>
+          )}
+
+          {/* Chat Interface with Focus Mode wrapper */}
+          <div className="flex-1 min-w-0">
+            <FocusMode onToggle={handleFocusToggle}>
+              <ChatInterface />
+            </FocusMode>
           </div>
-        )}
-
-        {/* Chat Interface — fills remaining space */}
-        <div className="flex-1 min-w-0">
-          <ChatInterface />
         </div>
-      </div>
 
-      {/* Status Bar — always visible, IDE-style bottom bar */}
-      <GripStatusBar />
-    </div>
+        {/* Status Bar — hidden in focus mode */}
+        {!focusMode && <GripStatusBar />}
+      </div>
+    </>
   );
 }

--- a/src/components/Engine/FocusMode.tsx
+++ b/src/components/Engine/FocusMode.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Minimize2, Maximize2 } from 'lucide-react';
+
+interface FocusModeProps {
+  children: React.ReactNode;
+  onToggle?: (focused: boolean) => void;
+}
+
+/**
+ * Focus Mode — strips the UI to just the chat interface.
+ * Hides sidebar, context panel, and status bar.
+ * Triggered by Cmd+Shift+F or the focus button.
+ *
+ * Design: when entering focus mode, the background subtly darkens
+ * and the chat interface expands to full width with generous margins.
+ * A single floating "exit focus" button remains in the corner.
+ *
+ * For knowledge workers who just want to think with GRIP.
+ */
+export default function FocusMode({ children, onToggle }: FocusModeProps) {
+  const [focused, setFocused] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'f') {
+        e.preventDefault();
+        setFocused(prev => {
+          const next = !prev;
+          onToggle?.(next);
+          return next;
+        });
+      }
+      if (e.key === 'Escape' && focused) {
+        setFocused(false);
+        onToggle?.(false);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [focused, onToggle]);
+
+  if (!focused) {
+    return (
+      <div className="relative">
+        {children}
+        {/* Focus mode trigger */}
+        <button
+          onClick={() => { setFocused(true); onToggle?.(true); }}
+          className="absolute top-3 right-3 p-2 text-[var(--muted-foreground)] hover:text-[var(--primary)] transition-colors opacity-0 hover:opacity-100"
+          title="Enter Focus Mode (Cmd+Shift+F)"
+        >
+          <Maximize2 className="w-4 h-4" strokeWidth={1.5} />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-[100] bg-[var(--background)] animate-fade-in">
+      {/* Exit button */}
+      <button
+        onClick={() => { setFocused(false); onToggle?.(false); }}
+        className="fixed top-4 right-4 z-[101] p-2 text-[var(--muted-foreground)] hover:text-[var(--primary)] transition-colors border border-[var(--border)] bg-[var(--card)]"
+        title="Exit Focus Mode (Esc)"
+      >
+        <Minimize2 className="w-4 h-4" strokeWidth={1.5} />
+      </button>
+
+      {/* Mode indicator */}
+      <div className="fixed top-4 left-4 z-[101]">
+        <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)] opacity-40">
+          FOCUS MODE
+        </span>
+      </div>
+
+      {/* Full-width chat */}
+      <div className="h-full max-w-4xl mx-auto">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Engine/SkillPill.tsx
+++ b/src/components/Engine/SkillPill.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { Sparkles } from 'lucide-react';
+
+interface SkillPillProps {
+  name: string;
+  active?: boolean;
+  paramount?: boolean;
+  onClick?: () => void;
+}
+
+/**
+ * Inline skill indicator pill.
+ * Shows active skills as sharp-cornered badges with monospace text.
+ * PARAMOUNT skills get a cyan accent border.
+ *
+ * Swiss Nihilism: no rounded corners, monospace, tracking-wider.
+ */
+export default function SkillPill({ name, active = false, paramount = false, onClick }: SkillPillProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={`
+        inline-flex items-center gap-1 px-2 py-0.5 font-mono text-[9px] tracking-wider
+        transition-colors border
+        ${paramount
+          ? 'border-[var(--primary)] text-[var(--primary)] bg-[var(--primary)]/5'
+          : active
+            ? 'border-[var(--foreground)]/20 text-[var(--foreground)] bg-[var(--secondary)]'
+            : 'border-[var(--border)] text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:border-[var(--primary)]/50'
+        }
+      `}
+    >
+      {paramount && <Sparkles className="w-2.5 h-2.5" strokeWidth={1.5} />}
+      {name.toUpperCase()}
+    </button>
+  );
+}

--- a/src/components/Engine/WelcomeAnimation.tsx
+++ b/src/components/Engine/WelcomeAnimation.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+/**
+ * Animated welcome sequence for first-time users.
+ * A single cyan square that expands, then contracts into the GRIP wordmark.
+ * Plays once on first visit, then never again.
+ *
+ * Swiss Nihilism: geometric, stark, no roundness, only cyan on grey.
+ * Duration: 2 seconds total. Respects prefers-reduced-motion.
+ */
+export default function WelcomeAnimation({ onComplete }: { onComplete: () => void }) {
+  const [phase, setPhase] = useState(0);
+
+  useEffect(() => {
+    // Check if reduced motion is preferred
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      onComplete();
+      return;
+    }
+
+    // Check if already shown
+    if (localStorage.getItem('grip-welcome-shown') === 'true') {
+      onComplete();
+      return;
+    }
+
+    const timers = [
+      setTimeout(() => setPhase(1), 100),   // Square appears
+      setTimeout(() => setPhase(2), 600),   // Square expands
+      setTimeout(() => setPhase(3), 1200),  // Text appears
+      setTimeout(() => {
+        setPhase(4);                         // Fade out
+        localStorage.setItem('grip-welcome-shown', 'true');
+      }, 2000),
+      setTimeout(() => onComplete(), 2400), // Remove
+    ];
+
+    return () => timers.forEach(clearTimeout);
+  }, [onComplete]);
+
+  if (phase === 0) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[500] flex items-center justify-center bg-[var(--background)]"
+      style={{
+        opacity: phase === 4 ? 0 : 1,
+        transition: 'opacity 0.4s ease-out',
+      }}
+    >
+      <div className="flex flex-col items-center">
+        {/* Expanding square */}
+        <div
+          className="bg-[var(--primary)] transition-all"
+          style={{
+            width: phase >= 2 ? 48 : 8,
+            height: phase >= 2 ? 48 : 8,
+            transitionDuration: '0.5s',
+            transitionTimingFunction: 'cubic-bezier(0.16, 1, 0.3, 1)',
+          }}
+        />
+
+        {/* Text reveal */}
+        <div
+          className="mt-6 text-center"
+          style={{
+            opacity: phase >= 3 ? 1 : 0,
+            transform: phase >= 3 ? 'translateY(0)' : 'translateY(8px)',
+            transition: 'all 0.4s ease-out',
+          }}
+        >
+          <span className="font-mono text-2xl font-bold tracking-widest text-[var(--foreground)]">
+            GRIP
+          </span>
+          <span className="block font-mono text-[9px] tracking-widest text-[var(--muted-foreground)] mt-1">
+            KNOWLEDGE WORK ENGINE
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SkillBrowser.tsx
+++ b/src/components/SkillBrowser.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { Search, Sparkles, Shield } from 'lucide-react';
+import { GRIP_SKILLS, SKILL_CATEGORIES, type SkillCategory, searchSkills, getParamountSkills } from '@/lib/grip-skills';
+import SkillPill from '@/components/Engine/SkillPill';
+
+/**
+ * GRIP-native skill browser.
+ * Shows all 149 skills organised by category with search and filtering.
+ * PARAMOUNT skills are highlighted with cyan accent.
+ *
+ * Swiss Nihilism: sharp borders, monospace categories, asymmetric layout.
+ */
+export default function SkillBrowser() {
+  const [query, setQuery] = useState('');
+  const [activeCategory, setActiveCategory] = useState<SkillCategory | 'all'>('all');
+
+  const filteredSkills = useMemo(() => {
+    let skills = query ? searchSkills(query) : GRIP_SKILLS;
+    if (activeCategory !== 'all') {
+      skills = skills.filter(s => s.category === activeCategory);
+    }
+    return skills;
+  }, [query, activeCategory]);
+
+  const paramountSkills = getParamountSkills();
+  const categories = Object.entries(SKILL_CATEGORIES) as [SkillCategory, { label: string; count: number }][];
+
+  return (
+    <div className="max-w-6xl mx-auto py-8 px-4">
+      {/* Header */}
+      <div className="mb-6">
+        <h1 className="text-3xl font-bold tracking-tighter text-[var(--foreground)]">
+          Skills
+        </h1>
+        <p className="text-[var(--muted-foreground)] mt-1">
+          149 specialised abilities. PARAMOUNT skills are always active.
+        </p>
+      </div>
+
+      {/* PARAMOUNT skills strip */}
+      <div className="border border-[var(--primary)]/30 p-4 mb-6 bg-[var(--primary)]/5">
+        <div className="flex items-center gap-2 mb-2">
+          <Shield className="w-3.5 h-3.5 text-[var(--primary)]" strokeWidth={1.5} />
+          <span className="font-mono text-[10px] tracking-widest text-[var(--primary)]">
+            PARAMOUNT — ALWAYS ACTIVE
+          </span>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {paramountSkills.map(skill => (
+            <SkillPill key={skill.id} name={skill.name} paramount active />
+          ))}
+        </div>
+      </div>
+
+      {/* Search */}
+      <div className="flex items-center gap-3 border border-[var(--border)] px-4 py-2.5 mb-4 bg-[var(--card)]">
+        <Search className="w-4 h-4 text-[var(--muted-foreground)]" strokeWidth={1.5} />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search skills..."
+          className="flex-1 bg-transparent border-none text-sm text-[var(--foreground)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-0"
+          style={{ boxShadow: 'none' }}
+        />
+        <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">
+          {filteredSkills.length} RESULTS
+        </span>
+      </div>
+
+      {/* Category filter */}
+      <div className="flex flex-wrap gap-2 mb-6">
+        <button
+          onClick={() => setActiveCategory('all')}
+          className={`font-mono text-[10px] tracking-widest px-3 py-1.5 border transition-colors min-h-[36px] ${
+            activeCategory === 'all'
+              ? 'border-[var(--primary)] text-[var(--primary)]'
+              : 'border-[var(--border)] text-[var(--muted-foreground)] hover:text-[var(--foreground)]'
+          }`}
+        >
+          ALL
+        </button>
+        {categories.map(([key, { label, count }]) => (
+          <button
+            key={key}
+            onClick={() => setActiveCategory(key)}
+            className={`font-mono text-[10px] tracking-widest px-3 py-1.5 border transition-colors min-h-[36px] ${
+              activeCategory === key
+                ? 'border-[var(--primary)] text-[var(--primary)]'
+                : 'border-[var(--border)] text-[var(--muted-foreground)] hover:text-[var(--foreground)]'
+            }`}
+          >
+            {label} ({count})
+          </button>
+        ))}
+      </div>
+
+      {/* Skill grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+        {filteredSkills.map((skill) => (
+          <div
+            key={skill.id}
+            className={`p-4 border transition-colors ${
+              skill.paramount
+                ? 'border-[var(--primary)]/30 bg-[var(--primary)]/5'
+                : 'border-[var(--border)] hover:border-[var(--primary)]/50'
+            }`}
+          >
+            <div className="flex items-start justify-between mb-1">
+              <span className="font-mono text-xs font-bold tracking-wider text-[var(--foreground)]">
+                {skill.name}
+              </span>
+              {skill.paramount && (
+                <Sparkles className="w-3 h-3 text-[var(--primary)] shrink-0" strokeWidth={1.5} />
+              )}
+            </div>
+            <p className="text-[11px] text-[var(--muted-foreground)] leading-relaxed mb-2">
+              {skill.description}
+            </p>
+            <span className="font-mono text-[8px] tracking-widest text-[var(--muted-foreground)] opacity-60">
+              {SKILL_CATEGORIES[skill.category]?.label || skill.category.toUpperCase()}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {filteredSkills.length === 0 && (
+        <div className="text-center py-12">
+          <span className="font-mono text-xs tracking-widest text-[var(--muted-foreground)]">
+            NO SKILLS MATCH &quot;{query}&quot;
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- FocusMode: Cmd+Shift+F strips UI to pure chat for deep work
- WelcomeAnimation: geometric cyan square expansion on first visit
- SkillBrowser: GRIP-native 149-skill catalogue with search and PARAMOUNT strip
- SkillPill: inline skill indicator badges
- 5 files changed, +376 lines

## Test plan

- [x] npm run build passes
- [ ] Focus mode activates with Cmd+Shift+F, exits with Esc
- [ ] Welcome animation plays once, respects prefers-reduced-motion
- [ ] Skill browser search filters correctly
- [ ] PARAMOUNT skills highlighted in cyan strip