### PR TITLE
feat: markdown rendering, model selector, chat polish

### DIFF
--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -3,6 +3,8 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { Send, Sparkles, Terminal as TerminalIcon, Square } from 'lucide-react';
 import { sendToGrip, type GripMessage, type GripMetrics } from '@/lib/grip-session';
+import MarkdownContent from './MarkdownContent';
+import ModelSelector from './ModelSelector';
 
 const SUGGESTED_PROMPTS = [
   { text: 'What can GRIP help me with?', icon: '?' },
@@ -16,6 +18,7 @@ export default function ChatInterface() {
   const [input, setInput] = useState('');
   const [isStreaming, setIsStreaming] = useState(false);
   const [sessionId, setSessionId] = useState<string | undefined>();
+  const [model, setModel] = useState('sonnet');
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -51,7 +54,7 @@ export default function ChatInterface() {
     let metrics: GripMetrics | undefined;
 
     try {
-      for await (const event of sendToGrip(input.trim(), sessionId)) {
+      for await (const event of sendToGrip(input.trim(), sessionId, model)) {
         if (event.type === 'text') {
           fullText += event.data as string;
           setMessages(prev => {
@@ -177,7 +180,7 @@ export default function ChatInterface() {
                       ? 'bg-[var(--primary)] text-[var(--primary-foreground)]'
                       : 'border border-[var(--border)] text-[var(--foreground)]'
                   }`}>
-                    <p className="text-sm whitespace-pre-wrap leading-relaxed">{msg.content}</p>
+                    <MarkdownContent content={msg.content} />
                     {msg.streaming && (
                       <span className="inline-block w-2 h-4 bg-[var(--primary)] animate-pulse ml-0.5" />
                     )}
@@ -262,9 +265,12 @@ export default function ChatInterface() {
             )}
           </div>
           <div className="flex items-center justify-between mt-2">
-            <p className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] opacity-50">
-              ENTER TO SEND | SHIFT+ENTER FOR NEW LINE | CMD+K FOR COMMANDS
-            </p>
+            <div className="flex items-center gap-3">
+              <ModelSelector value={model} onChange={setModel} compact />
+              <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] opacity-50">
+                ENTER TO SEND | CMD+K
+              </span>
+            </div>
             {sessionId && (
               <span className="font-mono text-[8px] tracking-wider text-[var(--primary)] opacity-60">
                 SESSION: {sessionId.slice(0, 8)}

--- a/src/components/Engine/MarkdownContent.tsx
+++ b/src/components/Engine/MarkdownContent.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+/**
+ * Lightweight markdown renderer for GRIP chat messages.
+ * No external dependencies — uses regex-based parsing.
+ *
+ * Supports:
+ * - **bold** and *italic*
+ * - `inline code` and ```code blocks```
+ * - # headings (h1-h3)
+ * - - bullet lists
+ * - [links](url)
+ * - > blockquotes
+ *
+ * Swiss Nihilism: code blocks have black bg, monospace, no rounded corners.
+ */
+
+interface MarkdownContentProps {
+  content: string;
+}
+
+export default function MarkdownContent({ content }: MarkdownContentProps) {
+  const blocks = content.split('\n');
+  const elements: React.ReactNode[] = [];
+  let inCodeBlock = false;
+  let codeBuffer: string[] = [];
+  let codeLanguage = '';
+
+  for (let i = 0; i < blocks.length; i++) {
+    const line = blocks[i];
+
+    // Code block toggle
+    if (line.startsWith('```')) {
+      if (inCodeBlock) {
+        elements.push(
+          <pre key={`code-${i}`} className="bg-black text-[var(--primary)] p-4 font-mono text-xs overflow-x-auto my-2 border border-[var(--border)]">
+            {codeLanguage && (
+              <span className="font-mono text-[8px] tracking-widest text-[var(--muted-foreground)] block mb-2">
+                {codeLanguage.toUpperCase()}
+              </span>
+            )}
+            <code>{codeBuffer.join('\n')}</code>
+          </pre>
+        );
+        codeBuffer = [];
+        codeLanguage = '';
+        inCodeBlock = false;
+      } else {
+        inCodeBlock = true;
+        codeLanguage = line.slice(3).trim();
+      }
+      continue;
+    }
+
+    if (inCodeBlock) {
+      codeBuffer.push(line);
+      continue;
+    }
+
+    // Empty line
+    if (!line.trim()) {
+      elements.push(<div key={`br-${i}`} className="h-2" />);
+      continue;
+    }
+
+    // Headings
+    if (line.startsWith('### ')) {
+      elements.push(
+        <h3 key={`h3-${i}`} className="text-sm font-bold tracking-tighter text-[var(--foreground)] mt-3 mb-1">
+          {renderInline(line.slice(4))}
+        </h3>
+      );
+      continue;
+    }
+    if (line.startsWith('## ')) {
+      elements.push(
+        <h2 key={`h2-${i}`} className="text-base font-bold tracking-tighter text-[var(--foreground)] mt-3 mb-1">
+          {renderInline(line.slice(3))}
+        </h2>
+      );
+      continue;
+    }
+    if (line.startsWith('# ')) {
+      elements.push(
+        <h1 key={`h1-${i}`} className="text-lg font-bold tracking-tighter text-[var(--foreground)] mt-3 mb-1">
+          {renderInline(line.slice(2))}
+        </h1>
+      );
+      continue;
+    }
+
+    // Blockquote
+    if (line.startsWith('> ')) {
+      elements.push(
+        <blockquote key={`bq-${i}`} className="border-l-2 border-[var(--primary)] pl-3 text-[var(--muted-foreground)] italic text-sm my-1">
+          {renderInline(line.slice(2))}
+        </blockquote>
+      );
+      continue;
+    }
+
+    // Bullet list
+    if (line.match(/^[-*] /)) {
+      elements.push(
+        <div key={`li-${i}`} className="flex items-start gap-2 text-sm">
+          <span className="text-[var(--primary)] font-mono mt-0.5 shrink-0">-</span>
+          <span>{renderInline(line.slice(2))}</span>
+        </div>
+      );
+      continue;
+    }
+
+    // Regular paragraph
+    elements.push(
+      <p key={`p-${i}`} className="text-sm leading-relaxed">
+        {renderInline(line)}
+      </p>
+    );
+  }
+
+  // Handle unclosed code block
+  if (inCodeBlock && codeBuffer.length > 0) {
+    elements.push(
+      <pre key="code-unclosed" className="bg-black text-[var(--primary)] p-4 font-mono text-xs overflow-x-auto my-2 border border-[var(--border)]">
+        <code>{codeBuffer.join('\n')}</code>
+      </pre>
+    );
+  }
+
+  return <div className="space-y-0.5">{elements}</div>;
+}
+
+/**
+ * Render inline markdown: bold, italic, code, links.
+ */
+function renderInline(text: string): React.ReactNode {
+  const parts: React.ReactNode[] = [];
+  let remaining = text;
+  let key = 0;
+
+  while (remaining.length > 0) {
+    // Inline code
+    const codeMatch = remaining.match(/^`([^`]+)`/);
+    if (codeMatch) {
+      parts.push(
+        <code key={key++} className="font-mono text-xs bg-[var(--secondary)] text-[var(--primary)] px-1 py-0.5">
+          {codeMatch[1]}
+        </code>
+      );
+      remaining = remaining.slice(codeMatch[0].length);
+      continue;
+    }
+
+    // Bold
+    const boldMatch = remaining.match(/^\*\*([^*]+)\*\*/);
+    if (boldMatch) {
+      parts.push(<strong key={key++} className="font-bold">{boldMatch[1]}</strong>);
+      remaining = remaining.slice(boldMatch[0].length);
+      continue;
+    }
+
+    // Italic
+    const italicMatch = remaining.match(/^\*([^*]+)\*/);
+    if (italicMatch) {
+      parts.push(<em key={key++} className="italic">{italicMatch[1]}</em>);
+      remaining = remaining.slice(italicMatch[0].length);
+      continue;
+    }
+
+    // Link — but don't generate URLs we're not confident about
+    const linkMatch = remaining.match(/^\[([^\]]+)\]\(([^)]+)\)/);
+    if (linkMatch) {
+      parts.push(
+        <span key={key++} className="text-[var(--primary)] underline underline-offset-2">
+          {linkMatch[1]}
+        </span>
+      );
+      remaining = remaining.slice(linkMatch[0].length);
+      continue;
+    }
+
+    // Plain text — consume until next special character
+    const nextSpecial = remaining.search(/[`*\[]/);
+    if (nextSpecial === -1) {
+      parts.push(remaining);
+      break;
+    } else if (nextSpecial === 0) {
+      // Special char that didn't match a pattern — consume it as text
+      parts.push(remaining[0]);
+      remaining = remaining.slice(1);
+    } else {
+      parts.push(remaining.slice(0, nextSpecial));
+      remaining = remaining.slice(nextSpecial);
+    }
+  }
+
+  return <>{parts}</>;
+}

--- a/src/components/Engine/ModelSelector.tsx
+++ b/src/components/Engine/ModelSelector.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+
+interface ModelSelectorProps {
+  value: string;
+  onChange: (model: string) => void;
+  compact?: boolean;
+}
+
+const MODELS = [
+  { id: 'sonnet', label: 'SONNET', description: 'Fast, capable', badge: 'DEFAULT' },
+  { id: 'opus', label: 'OPUS', description: 'Most capable, slower', badge: 'DEEP' },
+  { id: 'haiku', label: 'HAIKU', description: 'Fastest, lightweight', badge: 'QUICK' },
+];
+
+/**
+ * Model selector for the chat input area.
+ * Swiss Nihilism: monospace, tracking-widest, sharp dropdown.
+ */
+export default function ModelSelector({ value, onChange, compact = false }: ModelSelectorProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const current = MODELS.find(m => m.id === value) || MODELS[0];
+
+  if (compact) {
+    return (
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="relative font-mono text-[9px] tracking-widest text-[var(--muted-foreground)] hover:text-[var(--primary)] transition-colors flex items-center gap-1"
+      >
+        {current.label}
+        <ChevronDown className={`w-2.5 h-2.5 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+        {isOpen && (
+          <div className="absolute bottom-full left-0 mb-1 border border-[var(--border)] bg-[var(--card)] z-50 min-w-[140px] animate-fade-in">
+            {MODELS.map(model => (
+              <button
+                key={model.id}
+                onClick={(e) => { e.stopPropagation(); onChange(model.id); setIsOpen(false); }}
+                className={`w-full text-left px-3 py-2 flex items-center justify-between transition-colors ${
+                  model.id === value
+                    ? 'text-[var(--primary)]'
+                    : 'text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--secondary)]'
+                }`}
+              >
+                <span className="font-mono text-[9px] tracking-widest">{model.label}</span>
+                <span className="font-mono text-[7px] tracking-wider opacity-50">{model.badge}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </button>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-2 px-2 py-1 border border-[var(--border)] hover:border-[var(--primary)]/50 transition-colors"
+      >
+        <span className="font-mono text-[10px] tracking-widest text-[var(--foreground)]">
+          {current.label}
+        </span>
+        <ChevronDown className={`w-3 h-3 text-[var(--muted-foreground)] transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+      </button>
+
+      {isOpen && (
+        <div className="absolute bottom-full left-0 mb-1 border border-[var(--border)] bg-[var(--card)] z-50 min-w-[180px] animate-fade-in">
+          {MODELS.map(model => (
+            <button
+              key={model.id}
+              onClick={() => { onChange(model.id); setIsOpen(false); }}
+              className={`w-full text-left px-3 py-2.5 transition-colors ${
+                model.id === value
+                  ? 'text-[var(--primary)] bg-[var(--primary)]/5'
+                  : 'text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--secondary)]'
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-mono text-[10px] tracking-widest">{model.label}</span>
+                <span className="font-mono text-[8px] tracking-wider opacity-50">{model.badge}</span>
+              </div>
+              <span className="text-[9px] opacity-60 block mt-0.5">{model.description}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- MarkdownContent: lightweight regex markdown renderer (bold, italic, code blocks, headings, lists, blockquotes) with Swiss Nihilism styling
- ModelSelector: compact Opus/Sonnet/Haiku dropdown in chat input
- Chat messages now render rich markdown instead of plain text
- 3 files, +300 lines

## Test plan

- [x] npm run build passes
- [ ] Code blocks render with black background and cyan text
- [ ] Bold, italic, headings render correctly
- [ ] Model selector switches between Opus/Sonnet/Haiku