### PR TITLE
feat: chat session persistence and history sidebar

### DIFF
--- a/src/components/Engine/ChatHistory.tsx
+++ b/src/components/Engine/ChatHistory.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Plus, Trash2, MessageSquare } from 'lucide-react';
+import {
+  getChatSessions,
+  getActiveChatId,
+  setActiveChatId,
+  createChatSession,
+  deleteChatSession,
+  type ChatSession,
+} from '@/lib/chat-storage';
+
+interface ChatHistoryProps {
+  onSessionChange: (chatId: string) => void;
+  onNewChat: () => void;
+  currentModel: string;
+}
+
+/**
+ * Chat history sidebar showing previous conversations.
+ * Each session shows title, timestamp, and message count.
+ * Swiss Nihilism: monospace, sharp borders, minimal hover states.
+ */
+export default function ChatHistory({ onSessionChange, onNewChat, currentModel }: ChatHistoryProps) {
+  const [sessions, setSessions] = useState<ChatSession[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSessions(getChatSessions());
+    setActiveId(getActiveChatId());
+  }, []);
+
+  const handleNewChat = () => {
+    const session = createChatSession(currentModel);
+    setSessions(getChatSessions());
+    setActiveId(session.id);
+    onNewChat();
+    onSessionChange(session.id);
+  };
+
+  const handleSelectChat = (chatId: string) => {
+    setActiveChatId(chatId);
+    setActiveId(chatId);
+    onSessionChange(chatId);
+  };
+
+  const handleDeleteChat = (e: React.MouseEvent, chatId: string) => {
+    e.stopPropagation();
+    deleteChatSession(chatId);
+    const updated = getChatSessions();
+    setSessions(updated);
+    if (activeId === chatId) {
+      const newActive = updated[0]?.id || null;
+      setActiveId(newActive);
+      if (newActive) onSessionChange(newActive);
+      else onNewChat();
+    }
+  };
+
+  const formatTime = (iso: string) => {
+    const date = new Date(iso);
+    const now = new Date();
+    const diff = now.getTime() - date.getTime();
+    if (diff < 60000) return 'JUST NOW';
+    if (diff < 3600000) return `${Math.floor(diff / 60000)}M AGO`;
+    if (diff < 86400000) return `${Math.floor(diff / 3600000)}H AGO`;
+    return date.toLocaleDateString('en-GB', { day: '2-digit', month: 'short' });
+  };
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* New chat button */}
+      <button
+        onClick={handleNewChat}
+        className="w-full flex items-center gap-2 px-3 py-2.5 border border-[var(--border)] hover:border-[var(--primary)] transition-colors mb-2"
+      >
+        <Plus className="w-3.5 h-3.5 text-[var(--primary)]" strokeWidth={1.5} />
+        <span className="font-mono text-[10px] tracking-widest text-[var(--foreground)]">NEW CHAT</span>
+      </button>
+
+      {/* Session list */}
+      <div className="flex-1 overflow-y-auto space-y-0.5">
+        {sessions.length === 0 ? (
+          <div className="text-center py-8">
+            <MessageSquare className="w-5 h-5 text-[var(--muted-foreground)] mx-auto mb-2 opacity-30" />
+            <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)] opacity-50">
+              NO CHATS YET
+            </span>
+          </div>
+        ) : (
+          sessions.map(session => (
+            <button
+              key={session.id}
+              onClick={() => handleSelectChat(session.id)}
+              className={`w-full text-left px-3 py-2 group transition-colors ${
+                session.id === activeId
+                  ? 'border-l-2 border-[var(--primary)] bg-[var(--primary)]/5 text-[var(--foreground)]'
+                  : 'border-l-2 border-transparent text-[var(--muted-foreground)] hover:text-[var(--foreground)]'
+              }`}
+            >
+              <div className="flex items-start justify-between">
+                <span className="text-xs truncate flex-1 pr-2">
+                  {session.title}
+                </span>
+                <button
+                  onClick={(e) => handleDeleteChat(e, session.id)}
+                  className="opacity-0 group-hover:opacity-100 transition-opacity p-0.5 text-[var(--muted-foreground)] hover:text-[var(--danger)]"
+                >
+                  <Trash2 className="w-3 h-3" strokeWidth={1.5} />
+                </button>
+              </div>
+              <div className="flex items-center gap-2 mt-0.5">
+                <span className="font-mono text-[8px] tracking-wider text-[var(--muted-foreground)] opacity-60">
+                  {formatTime(session.updatedAt)}
+                </span>
+                <span className="font-mono text-[8px] tracking-wider text-[var(--muted-foreground)] opacity-40">
+                  {session.messageCount} MSG
+                </span>
+                <span className="font-mono text-[7px] tracking-wider text-[var(--muted-foreground)] opacity-30">
+                  {session.model.toUpperCase()}
+                </span>
+              </div>
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/chat-storage.ts
+++ b/src/lib/chat-storage.ts
@@ -1,0 +1,171 @@
+/**
+ * Chat Storage — persist chat history across page reloads.
+ *
+ * Uses localStorage for browser, could be extended to
+ * SQLite (via Electron IPC) for desktop app.
+ *
+ * Structure:
+ * - grip-chats: Array of ChatSession metadata
+ * - grip-chat-{id}: Individual chat message history
+ * - grip-active-chat: Currently active chat ID
+ */
+
+import type { GripMessage, GripMetrics } from './grip-session';
+
+export interface ChatSession {
+  id: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  messageCount: number;
+  model: string;
+  sessionId?: string;  // Claude session ID for --resume
+}
+
+const CHATS_KEY = 'grip-chats';
+const ACTIVE_KEY = 'grip-active-chat';
+const CHAT_PREFIX = 'grip-chat-';
+const MAX_CHATS = 50;
+
+/**
+ * Get all chat sessions (metadata only).
+ */
+export function getChatSessions(): ChatSession[] {
+  try {
+    const raw = localStorage.getItem(CHATS_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Get the active chat ID.
+ */
+export function getActiveChatId(): string | null {
+  return localStorage.getItem(ACTIVE_KEY);
+}
+
+/**
+ * Set the active chat ID.
+ */
+export function setActiveChatId(id: string | null): void {
+  if (id) {
+    localStorage.setItem(ACTIVE_KEY, id);
+  } else {
+    localStorage.removeItem(ACTIVE_KEY);
+  }
+}
+
+/**
+ * Get messages for a specific chat.
+ */
+export function getChatMessages(chatId: string): GripMessage[] {
+  try {
+    const raw = localStorage.getItem(CHAT_PREFIX + chatId);
+    if (!raw) return [];
+    const messages = JSON.parse(raw);
+    // Restore Date objects
+    return messages.map((m: GripMessage) => ({
+      ...m,
+      timestamp: new Date(m.timestamp),
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Save messages for a specific chat.
+ */
+export function saveChatMessages(chatId: string, messages: GripMessage[]): void {
+  localStorage.setItem(CHAT_PREFIX + chatId, JSON.stringify(messages));
+
+  // Update session metadata
+  const sessions = getChatSessions();
+  const idx = sessions.findIndex(s => s.id === chatId);
+  if (idx >= 0) {
+    sessions[idx].updatedAt = new Date().toISOString();
+    sessions[idx].messageCount = messages.length;
+    localStorage.setItem(CHATS_KEY, JSON.stringify(sessions));
+  }
+}
+
+/**
+ * Create a new chat session.
+ */
+export function createChatSession(model: string = 'sonnet'): ChatSession {
+  const session: ChatSession = {
+    id: crypto.randomUUID(),
+    title: 'New Chat',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    messageCount: 0,
+    model,
+  };
+
+  const sessions = getChatSessions();
+  sessions.unshift(session);
+
+  // Prune old chats beyond limit
+  if (sessions.length > MAX_CHATS) {
+    const removed = sessions.splice(MAX_CHATS);
+    for (const s of removed) {
+      localStorage.removeItem(CHAT_PREFIX + s.id);
+    }
+  }
+
+  localStorage.setItem(CHATS_KEY, JSON.stringify(sessions));
+  setActiveChatId(session.id);
+
+  return session;
+}
+
+/**
+ * Update chat session title (auto-generated from first message).
+ */
+export function updateChatTitle(chatId: string, title: string): void {
+  const sessions = getChatSessions();
+  const idx = sessions.findIndex(s => s.id === chatId);
+  if (idx >= 0) {
+    sessions[idx].title = title.slice(0, 60);
+    localStorage.setItem(CHATS_KEY, JSON.stringify(sessions));
+  }
+}
+
+/**
+ * Update session ID for resumption.
+ */
+export function updateSessionId(chatId: string, sessionId: string): void {
+  const sessions = getChatSessions();
+  const idx = sessions.findIndex(s => s.id === chatId);
+  if (idx >= 0) {
+    sessions[idx].sessionId = sessionId;
+    localStorage.setItem(CHATS_KEY, JSON.stringify(sessions));
+  }
+}
+
+/**
+ * Delete a chat session.
+ */
+export function deleteChatSession(chatId: string): void {
+  const sessions = getChatSessions().filter(s => s.id !== chatId);
+  localStorage.setItem(CHATS_KEY, JSON.stringify(sessions));
+  localStorage.removeItem(CHAT_PREFIX + chatId);
+
+  if (getActiveChatId() === chatId) {
+    setActiveChatId(sessions[0]?.id || null);
+  }
+}
+
+/**
+ * Auto-generate a title from the first user message.
+ */
+export function generateTitle(firstMessage: string): string {
+  const cleaned = firstMessage
+    .replace(/\n/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (cleaned.length <= 50) return cleaned;
+  return cleaned.slice(0, 47) + '...';
+}


### PR DESCRIPTION
## Summary

- Chat storage: localStorage persistence with session metadata, message history, auto-title, session ID tracking for `--resume`, 50-chat limit with auto-pruning
- ChatHistory sidebar: previous conversations with timestamps, counts, model badges, new/delete
- 2 files, +301 lines

## Test plan

- [x] npm run build passes
- [ ] Chat sessions persist across page reloads
- [ ] History sidebar shows previous chats
- [ ] New chat creates fresh session
- [ ] Delete removes chat from storage