### PR TITLE
feat: wire chat persistence and history into Engine

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,44 +2,96 @@
 
 import ChatInterface from '@/components/Engine/ChatInterface';
 import ContextPanel from '@/components/Engine/ContextPanel';
+import ChatHistory from '@/components/Engine/ChatHistory';
 import GripStatusBar from '@/components/Engine/GripStatusBar';
 import FocusMode from '@/components/Engine/FocusMode';
 import WelcomeAnimation from '@/components/Engine/WelcomeAnimation';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
+import {
+  getChatSessions,
+  getActiveChatId,
+  createChatSession,
+  getChatMessages,
+  type ChatSession,
+} from '@/lib/chat-storage';
 
 export default function EnginePage() {
-  const [showContext, setShowContext] = useState(true);
   const [showWelcome, setShowWelcome] = useState(true);
   const [focusMode, setFocusMode] = useState(false);
+  const [model, setModel] = useState('sonnet');
+  const [activeChatId, setActiveChatId] = useState<string | null>(null);
+  const [chatKey, setChatKey] = useState(0); // Force re-mount ChatInterface on session switch
+
+  // Initialise: load or create active chat
+  useEffect(() => {
+    const existingId = getActiveChatId();
+    if (existingId) {
+      setActiveChatId(existingId);
+    } else {
+      const sessions = getChatSessions();
+      if (sessions.length > 0) {
+        setActiveChatId(sessions[0].id);
+      }
+      // Don't auto-create — let ChatInterface create on first message
+    }
+  }, []);
 
   const handleWelcomeComplete = useCallback(() => setShowWelcome(false), []);
   const handleFocusToggle = useCallback((focused: boolean) => {
     setFocusMode(focused);
   }, []);
 
+  const handleSessionChange = useCallback((chatId: string) => {
+    setActiveChatId(chatId);
+    setChatKey(prev => prev + 1); // Force ChatInterface to re-mount with new session data
+  }, []);
+
+  const handleNewChat = useCallback(() => {
+    const session = createChatSession(model);
+    setActiveChatId(session.id);
+    setChatKey(prev => prev + 1);
+  }, [model]);
+
   return (
     <>
-      {/* Welcome animation — plays once for first-time users */}
       {showWelcome && <WelcomeAnimation onComplete={handleWelcomeComplete} />}
 
       <div className="h-[calc(100vh-64px)] lg:h-screen flex flex-col">
         <div className="flex-1 flex min-h-0">
-          {/* Context Panel — hidden in focus mode and on mobile */}
-          {showContext && !focusMode && (
-            <div className="hidden lg:block w-[280px] shrink-0">
-              <ContextPanel />
+          {/* Left Panel — Context + Chat History, hidden in focus mode */}
+          {!focusMode && (
+            <div className="hidden lg:flex w-[280px] shrink-0 flex-col border-r border-[var(--border)] bg-[var(--card)]">
+              {/* Context Panel — top half */}
+              <div className="flex-1 min-h-0 overflow-y-auto">
+                <ContextPanel />
+              </div>
+
+              {/* Chat History — bottom section */}
+              <div className="h-[240px] shrink-0 border-t border-[var(--border)] p-3 overflow-hidden">
+                <span className="grip-label block mb-2">HISTORY</span>
+                <div className="h-[calc(100%-24px)]">
+                  <ChatHistory
+                    onSessionChange={handleSessionChange}
+                    onNewChat={handleNewChat}
+                    currentModel={model}
+                  />
+                </div>
+              </div>
             </div>
           )}
 
-          {/* Chat Interface with Focus Mode wrapper */}
+          {/* Chat Interface */}
           <div className="flex-1 min-w-0">
             <FocusMode onToggle={handleFocusToggle}>
-              <ChatInterface />
+              <ChatInterface
+                key={chatKey}
+                chatId={activeChatId}
+                onModelChange={setModel}
+              />
             </FocusMode>
           </div>
         </div>
 
-        {/* Status Bar — hidden in focus mode */}
         {!focusMode && <GripStatusBar />}
       </div>
     </>

--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -3,6 +3,17 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { Send, Sparkles, Terminal as TerminalIcon, Square } from 'lucide-react';
 import { sendToGrip, type GripMessage, type GripMetrics } from '@/lib/grip-session';
+import {
+  getChatMessages,
+  saveChatMessages,
+  createChatSession,
+  updateChatTitle,
+  updateSessionId,
+  generateTitle,
+  getActiveChatId,
+  setActiveChatId,
+  getChatSessions,
+} from '@/lib/chat-storage';
 import MarkdownContent from './MarkdownContent';
 import ModelSelector from './ModelSelector';
 
@@ -13,12 +24,35 @@ const SUGGESTED_PROMPTS = [
   { text: 'Analyse this business decision', icon: 'D' },
 ];
 
-export default function ChatInterface() {
+interface ChatInterfaceProps {
+  chatId?: string | null;
+  onModelChange?: (model: string) => void;
+}
+
+export default function ChatInterface({ chatId, onModelChange }: ChatInterfaceProps) {
+  const [currentChatId, setCurrentChatId] = useState<string | null>(chatId || null);
   const [messages, setMessages] = useState<GripMessage[]>([]);
   const [input, setInput] = useState('');
   const [isStreaming, setIsStreaming] = useState(false);
   const [sessionId, setSessionId] = useState<string | undefined>();
   const [model, setModel] = useState('sonnet');
+
+  // Load persisted messages on mount or chat switch
+  useEffect(() => {
+    if (currentChatId) {
+      const stored = getChatMessages(currentChatId);
+      setMessages(stored);
+      // Restore session ID for --resume
+      const sessions = getChatSessions();
+      const session = sessions.find(s => s.id === currentChatId);
+      if (session?.sessionId) setSessionId(session.sessionId);
+    }
+  }, [currentChatId]);
+
+  // Update currentChatId when prop changes
+  useEffect(() => {
+    if (chatId !== undefined) setCurrentChatId(chatId);
+  }, [chatId]);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -29,6 +63,15 @@ export default function ChatInterface() {
 
   const handleSend = useCallback(async () => {
     if (!input.trim() || isStreaming) return;
+
+    // Ensure we have a chat session
+    let chatId = currentChatId;
+    if (!chatId) {
+      const session = createChatSession(model);
+      chatId = session.id;
+      setCurrentChatId(chatId);
+      setActiveChatId(chatId);
+    }
 
     const userMessage: GripMessage = {
       id: crypto.randomUUID(),
@@ -45,9 +88,18 @@ export default function ChatInterface() {
       streaming: true,
     };
 
-    setMessages(prev => [...prev, userMessage, assistantMessage]);
+    const newMessages = [...messages, userMessage, assistantMessage];
+    setMessages(newMessages);
     setInput('');
     setIsStreaming(true);
+
+    // Persist and auto-title
+    if (chatId) {
+      saveChatMessages(chatId, newMessages);
+      if (messages.length === 0) {
+        updateChatTitle(chatId, generateTitle(input.trim()));
+      }
+    }
 
     // Stream response from real GRIP backend
     let fullText = '';
@@ -86,7 +138,7 @@ export default function ChatInterface() {
       fullText += `\n[Connection error: ${err instanceof Error ? err.message : String(err)}]`;
     }
 
-    // Finalise the message
+    // Finalise the message and persist
     setMessages(prev => {
       const updated = [...prev];
       const lastMsg = updated[updated.length - 1];
@@ -97,10 +149,15 @@ export default function ChatInterface() {
         lastMsg.detectedMode = detectMode(userMessage.content);
         lastMsg.detectedSkills = detectSkills(userMessage.content);
       }
+      if (chatId) saveChatMessages(chatId, updated);
       return [...updated];
     });
+    // Store session ID for --resume ultra-fast responses
+    if (metrics?.sessionId && chatId) {
+      updateSessionId(chatId, metrics.sessionId);
+    }
     setIsStreaming(false);
-  }, [input, isStreaming, sessionId]);
+  }, [input, isStreaming, sessionId, model, currentChatId, messages]);
 
   const handleStop = useCallback(() => {
     abortRef.current?.abort();


### PR DESCRIPTION
## Summary

- ChatInterface loads/saves messages to localStorage on mount and after each message
- Auto-creates sessions, auto-titles from first message, stores --resume session ID
- ChatHistory sidebar wired into Engine left panel with session switching
- 2 files, +123 lines

## Test plan

- [x] npm run build passes
- [ ] Messages persist across page reloads
- [ ] Chat history shows in left sidebar
- [ ] Session switching loads correct messages
- [ ] New chat creates fresh session