### PR TITLE
feat: Electron IPC bridge for GRIP Engine PTY sessions

### DIFF
--- a/electron/handlers/grip-engine-handlers.ts
+++ b/electron/handlers/grip-engine-handlers.ts
@@ -1,0 +1,212 @@
+/**
+ * GRIP Engine IPC Handlers
+ *
+ * Manages a persistent claude CLI session for the Engine chat.
+ * Uses node-pty for full PTY support (interactive, session persistence).
+ *
+ * In Electron: spawns `claude` with PTY for real interactive sessions
+ * In Browser: falls back to the /api/grip/chat API route
+ *
+ * Key difference from the API route: PTY sessions are persistent —
+ * the context stays loaded between messages. No --resume needed.
+ * This is the ultra-fast path.
+ */
+import { ipcMain, BrowserWindow } from 'electron';
+import * as pty from 'node-pty';
+import * as os from 'os';
+import * as path from 'path';
+
+const GRIP_DIR = path.join(os.homedir(), '.claude');
+
+interface EngineSession {
+  ptyProcess: pty.IPty | null;
+  buffer: string;
+  ready: boolean;
+  sessionId: string;
+}
+
+let engineSession: EngineSession | null = null;
+
+function getMainWindow(): BrowserWindow | null {
+  const windows = BrowserWindow.getAllWindows();
+  return windows.length > 0 ? windows[0] : null;
+}
+
+function sendToRenderer(channel: string, data: unknown) {
+  const win = getMainWindow();
+  if (win && !win.isDestroyed()) {
+    win.webContents.send(channel, data);
+  }
+}
+
+export function registerGripEngineHandlers() {
+  /**
+   * Start a new GRIP Engine session.
+   * Spawns a claude CLI process with PTY.
+   */
+  ipcMain.handle('grip:startSession', async (_event, options: {
+    model?: string;
+  } = {}) => {
+    // Kill existing session if any
+    if (engineSession?.ptyProcess) {
+      engineSession.ptyProcess.kill();
+      engineSession = null;
+    }
+
+    const model = options.model || 'sonnet';
+    const sessionId = crypto.randomUUID();
+
+    try {
+      const shell = process.platform === 'win32' ? 'cmd.exe' : 'bash';
+      const ptyProcess = pty.spawn(shell, [], {
+        name: 'xterm-256color',
+        cols: 120,
+        rows: 40,
+        cwd: GRIP_DIR,
+        env: {
+          ...process.env,
+          HOME: os.homedir(),
+          TERM: 'xterm-256color',
+        },
+      });
+
+      engineSession = {
+        ptyProcess,
+        buffer: '',
+        ready: false,
+        sessionId,
+      };
+
+      // Forward PTY output to renderer
+      ptyProcess.onData((data: string) => {
+        if (engineSession) {
+          engineSession.buffer += data;
+        }
+        sendToRenderer('grip:output', { sessionId, data });
+      });
+
+      ptyProcess.onExit(({ exitCode }) => {
+        sendToRenderer('grip:sessionEnd', { sessionId, exitCode });
+        engineSession = null;
+      });
+
+      // Start claude in interactive mode
+      ptyProcess.write(`claude --model ${model}\r`);
+
+      return { success: true, sessionId };
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : 'Unknown error' };
+    }
+  });
+
+  /**
+   * Send a message to the active GRIP Engine session.
+   */
+  ipcMain.handle('grip:sendMessage', async (_event, message: string) => {
+    if (!engineSession?.ptyProcess) {
+      return { success: false, error: 'No active session' };
+    }
+
+    // Clear buffer before sending
+    engineSession.buffer = '';
+
+    // Write message followed by enter
+    engineSession.ptyProcess.write(message + '\r');
+
+    return { success: true, sessionId: engineSession.sessionId };
+  });
+
+  /**
+   * Send a prompt (non-interactive, one-shot).
+   * Uses `claude -p` with stream-json for structured output.
+   */
+  ipcMain.handle('grip:prompt', async (_event, options: {
+    prompt: string;
+    model?: string;
+    sessionId?: string;
+  }) => {
+    const { prompt, model = 'sonnet', sessionId } = options;
+
+    const args = ['-p', '--output-format', 'stream-json', '--model', model];
+    if (sessionId) args.push('--resume', sessionId);
+    args.push(prompt);
+
+    try {
+      const ptyProcess = pty.spawn('claude', args, {
+        name: 'xterm-256color',
+        cols: 120,
+        rows: 40,
+        cwd: GRIP_DIR,
+        env: { ...process.env, HOME: os.homedir() },
+      });
+
+      const promptSessionId = crypto.randomUUID();
+
+      ptyProcess.onData((data: string) => {
+        sendToRenderer('grip:promptOutput', { sessionId: promptSessionId, data });
+      });
+
+      ptyProcess.onExit(({ exitCode }) => {
+        sendToRenderer('grip:promptDone', { sessionId: promptSessionId, exitCode });
+      });
+
+      return { success: true, sessionId: promptSessionId };
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : 'Unknown error' };
+    }
+  });
+
+  /**
+   * Get current session status.
+   */
+  ipcMain.handle('grip:getSessionStatus', async () => {
+    return {
+      active: !!engineSession?.ptyProcess,
+      sessionId: engineSession?.sessionId || null,
+      bufferLength: engineSession?.buffer?.length || 0,
+    };
+  });
+
+  /**
+   * Kill the active session.
+   */
+  ipcMain.handle('grip:killSession', async () => {
+    if (engineSession?.ptyProcess) {
+      engineSession.ptyProcess.kill();
+      engineSession = null;
+      return { success: true };
+    }
+    return { success: false, error: 'No active session' };
+  });
+
+  /**
+   * Get GRIP system health (same as API route, but via IPC).
+   */
+  ipcMain.handle('grip:getHealth', async () => {
+    try {
+      const fs = await import('fs/promises');
+      const genomePath = path.join(GRIP_DIR, 'cache', 'genome.json');
+      const raw = await fs.readFile(genomePath, 'utf-8');
+      const genome = JSON.parse(raw);
+
+      const { readdirSync, existsSync } = await import('fs');
+
+      let skillCount = 149;
+      const skillsDir = path.join(GRIP_DIR, 'skills');
+      if (existsSync(skillsDir)) {
+        skillCount = readdirSync(skillsDir, { withFileTypes: true })
+          .filter(d => d.isDirectory()).length;
+      }
+
+      return {
+        status: 'healthy',
+        generation: genome.generation || 33,
+        geneCount: genome.genes ? Object.keys(genome.genes).length : 212,
+        fitness: genome.fitness_history?.slice(-1)[0] || 0.467,
+        skillCount,
+      };
+    } catch {
+      return { status: 'error', generation: 33, skillCount: 149 };
+    }
+  });
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,7 +1,7 @@
 /**
- * Dorothy - Main Electron Entry Point
+ * GRIP Knowledge Work Engine — Main Electron Entry Point
  *
- * This file initializes and wires together all the modular components:
+ * This file initialises and wires together all the modular components:
  * - Window management and protocol handling
  * - Agent state and PTY management
  * - IPC handlers for renderer communication
@@ -86,6 +86,7 @@ import { registerCLIPathsHandlers } from './handlers/cli-paths-handlers';
 import { registerKanbanHandlers } from './handlers/kanban-handlers';
 import { registerVaultHandlers } from './handlers/vault-handlers';
 import { registerWorldHandlers } from './handlers/world-handlers';
+import { registerGripEngineHandlers } from './handlers/grip-engine-handlers';
 import { initVaultDb, closeVaultDb } from './services/vault-db';
 import { initAutoUpdater, checkForUpdates, setMainWindowGetter } from './services/update-checker';
 import { initKanbanAutomation, findMatchingAgent, createAgentForTask, startAgentForTask } from './services/kanban-automation';
@@ -383,6 +384,7 @@ app.whenReady().then(async () => {
 
   // Register world (generative zone) handlers
   registerWorldHandlers({ getMainWindow });
+  registerGripEngineHandlers();
 
   // Initialize kanban automation service
   initKanbanAutomation({


### PR DESCRIPTION
## Summary

- grip-engine-handlers.ts: IPC handlers for persistent PTY sessions, interactive messages, one-shot prompts, health checks
- Registered in Electron main process
- Ultra-fast: PTY sessions keep context loaded between messages
- 2 files, +200 lines

## Test plan

- [x] npm run build passes
- [ ] Electron app starts with GRIP handlers registered
- [ ] grip:startSession creates PTY process
- [ ] grip:sendMessage sends to active PTY
- [ ] grip:prompt runs one-shot with stream-json