### PR TITLE
feat: production fixes — mode activation, Electron preload, Dorothy cleanup

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -609,6 +609,44 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getToken: () => ipcRenderer.invoke('api:getToken') as Promise<string>,
   },
 
+  // GRIP Engine — persistent PTY sessions for Knowledge Work Engine
+  grip: {
+    startSession: (options?: { model?: string }) =>
+      ipcRenderer.invoke('grip:startSession', options),
+    sendMessage: (message: string) =>
+      ipcRenderer.invoke('grip:sendMessage', message),
+    prompt: (options: { prompt: string; model?: string; sessionId?: string }) =>
+      ipcRenderer.invoke('grip:prompt', options),
+    getSessionStatus: () =>
+      ipcRenderer.invoke('grip:getSessionStatus'),
+    killSession: () =>
+      ipcRenderer.invoke('grip:killSession'),
+    getHealth: () =>
+      ipcRenderer.invoke('grip:getHealth'),
+
+    // Event listeners for streaming output
+    onOutput: (callback: (event: { sessionId: string; data: string }) => void) => {
+      const handler = (_: unknown, event: { sessionId: string; data: string }) => callback(event);
+      ipcRenderer.on('grip:output', handler);
+      return () => { ipcRenderer.removeListener('grip:output', handler); };
+    },
+    onSessionEnd: (callback: (event: { sessionId: string; exitCode: number }) => void) => {
+      const handler = (_: unknown, event: { sessionId: string; exitCode: number }) => callback(event);
+      ipcRenderer.on('grip:sessionEnd', handler);
+      return () => { ipcRenderer.removeListener('grip:sessionEnd', handler); };
+    },
+    onPromptOutput: (callback: (event: { sessionId: string; data: string }) => void) => {
+      const handler = (_: unknown, event: { sessionId: string; data: string }) => callback(event);
+      ipcRenderer.on('grip:promptOutput', handler);
+      return () => { ipcRenderer.removeListener('grip:promptOutput', handler); };
+    },
+    onPromptDone: (callback: (event: { sessionId: string; exitCode: number }) => void) => {
+      const handler = (_: unknown, event: { sessionId: string; exitCode: number }) => callback(event);
+      ipcRenderer.on('grip:promptDone', handler);
+      return () => { ipcRenderer.removeListener('grip:promptDone', handler); };
+    },
+  },
+
   // Platform info
   platform: process.platform,
 });

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "electron:pack": "tsc -p electron/tsconfig.json && cd mcp-orchestrator && npm install && npm run build && cd .. && cd mcp-telegram && npm install && npm run build && cd .. && cd mcp-kanban && npm install && npm run build && cd .. && cd mcp-vault && npm install && npm run build && cd .. && cd mcp-socialdata && npm install && npm run build && cd .. && cd mcp-x && npm install && npm run build && cd .. && cd mcp-world && npm install && npm run build && cd .. && electron-builder --dir --mac"
   },
   "build": {
-    "appId": "io.dorothy.app",
-    "productName": "Dorothy",
+    "appId": "co.codetonight.grip",
+    "productName": "GRIP",
     "publish": {
       "provider": "github",
-      "owner": "Charlie85270",
-      "repo": "dorothy"
+      "owner": "CodeTonight-SA",
+      "repo": "GRIP-GUI"
     },
     "directories": {
       "output": "release"
@@ -118,7 +118,7 @@
       ]
     },
     "dmg": {
-      "title": "Dorothy",
+      "title": "GRIP",
       "contents": [
         {
           "x": 130,

--- a/src/app/api/grip/modes/route.ts
+++ b/src/app/api/grip/modes/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { readFile, writeFile } from 'fs/promises';
+import { homedir } from 'os';
+import { join } from 'path';
+
+const ACTIVE_MODES_FILE = join(homedir(), '.claude', '.active-modes');
+
+/**
+ * GRIP Modes API — read and write active modes.
+ * Reads/writes ~/.claude/.active-modes (newline-separated mode IDs).
+ * This is the same file that `bash ~/.claude/lib/mode-loader.sh` uses.
+ */
+export async function GET() {
+  try {
+    const content = await readFile(ACTIVE_MODES_FILE, 'utf-8');
+    const modes = content.trim().split('\n').filter(Boolean);
+    return NextResponse.json({ modes });
+  } catch {
+    return NextResponse.json({ modes: [] });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { modes } = await req.json();
+    if (!Array.isArray(modes) || modes.length > 3) {
+      return NextResponse.json({ error: 'Invalid modes (max 3)' }, { status: 400 });
+    }
+
+    // Validate mode IDs (alphanumeric + hyphens only)
+    for (const mode of modes) {
+      if (typeof mode !== 'string' || !/^[a-z0-9-]+$/.test(mode)) {
+        return NextResponse.json({ error: `Invalid mode ID: ${mode}` }, { status: 400 });
+      }
+    }
+
+    await writeFile(ACTIVE_MODES_FILE, modes.join('\n') + '\n', 'utf-8');
+    return NextResponse.json({ modes, saved: true });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Write failed' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/modes/page.tsx
+++ b/src/app/modes/page.tsx
@@ -1,25 +1,53 @@
 'use client';
 
-import { useState } from 'react';
-import { GRIP_MODES, MODE_CATEGORIES, type ModeCategory, type GripMode } from '@/lib/grip-modes';
-import { Check } from 'lucide-react';
+import { useState, useEffect, useCallback } from 'react';
+import { GRIP_MODES, MODE_CATEGORIES, type ModeCategory } from '@/lib/grip-modes';
+import { Check, Loader2 } from 'lucide-react';
 
 export default function ModesPage() {
-  const [activeModes, setActiveModes] = useState<string[]>(['code']);
+  const [activeModes, setActiveModes] = useState<string[]>([]);
   const [activeCategory, setActiveCategory] = useState<ModeCategory | 'all'>('all');
+  const [saving, setSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
 
-  const toggleMode = (modeId: string) => {
+  // Load active modes from real ~/.claude/.active-modes
+  useEffect(() => {
+    fetch('/api/grip/modes')
+      .then(res => res.json())
+      .then(data => {
+        if (data.modes?.length) setActiveModes(data.modes);
+        setLoaded(true);
+      })
+      .catch(() => setLoaded(true));
+  }, []);
+
+  // Save modes to real file when selection changes
+  const saveModes = useCallback(async (modes: string[]) => {
+    setSaving(true);
+    try {
+      await fetch('/api/grip/modes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ modes }),
+      });
+    } catch { /* silent fail */ }
+    setSaving(false);
+  }, []);
+
+  const toggleMode = useCallback((modeId: string) => {
     setActiveModes(prev => {
+      let next: string[];
       if (prev.includes(modeId)) {
-        return prev.filter(m => m !== modeId);
+        next = prev.filter(m => m !== modeId);
+      } else if (prev.length >= 3) {
+        next = [...prev.slice(1), modeId];
+      } else {
+        next = [...prev, modeId];
       }
-      if (prev.length >= 3) {
-        // Replace oldest
-        return [...prev.slice(1), modeId];
-      }
-      return [...prev, modeId];
+      saveModes(next);
+      return next;
     });
-  };
+  }, [saveModes]);
 
   const filteredModes = activeCategory === 'all'
     ? GRIP_MODES
@@ -48,6 +76,10 @@ export default function ModesPage() {
             <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">
               ({activeModes.length}/3)
             </span>
+            {saving && <Loader2 className="w-3 h-3 text-[var(--primary)] animate-spin" />}
+            {loaded && !saving && activeModes.length > 0 && (
+              <span className="font-mono text-[8px] tracking-widest text-[var(--success)]">SAVED</span>
+            )}
           </div>
         )}
       </div>
@@ -56,7 +88,7 @@ export default function ModesPage() {
       <div className="flex flex-wrap gap-2 mb-6">
         <button
           onClick={() => setActiveCategory('all')}
-          className={`font-mono text-[10px] tracking-widest px-3 py-1.5 border transition-colors ${
+          className={`font-mono text-[10px] tracking-widest px-3 py-1.5 border transition-colors min-h-[44px] ${
             activeCategory === 'all'
               ? 'border-[var(--primary)] text-[var(--primary)]'
               : 'border-[var(--border)] text-[var(--muted-foreground)] hover:text-[var(--foreground)]'
@@ -70,7 +102,7 @@ export default function ModesPage() {
             <button
               key={key}
               onClick={() => setActiveCategory(key)}
-              className={`font-mono text-[10px] tracking-widest px-3 py-1.5 border transition-colors ${
+              className={`font-mono text-[10px] tracking-widest px-3 py-1.5 border transition-colors min-h-[44px] ${
                 activeCategory === key
                   ? 'border-[var(--primary)] text-[var(--primary)]'
                   : 'border-[var(--border)] text-[var(--muted-foreground)] hover:text-[var(--foreground)]'
@@ -82,7 +114,7 @@ export default function ModesPage() {
         })}
       </div>
 
-      {/* Mode Grid — Asymmetric: 5+7 split */}
+      {/* Mode Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {filteredModes.map((mode) => {
           const isActive = activeModes.includes(mode.id);
@@ -90,7 +122,7 @@ export default function ModesPage() {
             <button
               key={mode.id}
               onClick={() => toggleMode(mode.id)}
-              className={`text-left p-5 border transition-all ${
+              className={`text-left p-5 border transition-all min-h-[44px] ${
                 isActive
                   ? 'border-[var(--primary)] bg-[var(--primary)]/5'
                   : 'border-[var(--border)] hover:border-[var(--primary)]/50'

--- a/src/components/Settings/GeneralSection.tsx
+++ b/src/components/Settings/GeneralSection.tsx
@@ -146,7 +146,7 @@ export const GeneralSection = ({ info, appSettings, onSaveAppSettings }: General
             <Settings className="w-6 h-6 text-muted-foreground" />
           </div>
           <div>
-            <h3 className="font-medium">Dorothy</h3>
+            <h3 className="font-medium">GRIP</h3>
             <p className="text-sm text-muted-foreground">
               Version {updateInfo?.currentVersion || '1.2.2'}
             </p>
@@ -157,7 +157,7 @@ export const GeneralSection = ({ info, appSettings, onSaveAppSettings }: General
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm font-medium">Auto-check for updates</p>
-              <p className="text-xs text-muted-foreground">Check for new versions when Dorothy starts</p>
+              <p className="text-xs text-muted-foreground">Check for new versions when GRIP starts</p>
             </div>
             <Toggle
               enabled={appSettings.autoCheckUpdates !== false}
@@ -190,7 +190,7 @@ export const GeneralSection = ({ info, appSettings, onSaveAppSettings }: General
             <CheckCircle className="w-5 h-5 text-green-700 shrink-0" />
             <div>
               <p className="text-sm font-medium text-green-700">You&apos;re up to date!</p>
-              <p className="text-xs text-muted-foreground">Dorothy {updateInfo?.currentVersion} is the latest version.</p>
+              <p className="text-xs text-muted-foreground">GRIP {updateInfo?.currentVersion} is the latest version.</p>
             </div>
           </div>
         )}
@@ -201,7 +201,7 @@ export const GeneralSection = ({ info, appSettings, onSaveAppSettings }: General
               <div className="flex items-start justify-between mb-2">
                 <div>
                   <p className="text-sm font-medium text-blue-400">
-                    Dorothy {updateInfo.latestVersion} is available
+                    GRIP {updateInfo.latestVersion} is available
                   </p>
                   <p className="text-xs text-muted-foreground">
                     You&apos;re currently on version {updateInfo.currentVersion}


### PR DESCRIPTION
## Summary

Critical fixes for production readiness:
- Modes page NOW ACTIVATES REAL MODES (reads/writes ~/.claude/.active-modes)
- Electron preload exposes all grip: IPC channels to renderer
- Dorothy branding removed from package.json, settings UI, DMG title
- /api/grip/modes route for mode persistence
- 5 files changed

## Test plan

- [x] npm run build passes
- [ ] Selecting modes writes to ~/.claude/.active-modes
- [ ] Loading modes page reads current active modes
- [ ] Electron preload exposes window.electronAPI.grip
- [ ] No "Dorothy" in user-facing settings UI