### PR TITLE
fix: strip query string in app:// protocol, resolve RSC 404s

### DIFF
--- a/electron/core/window-manager.ts
+++ b/electron/core/window-manager.ts
@@ -30,9 +30,9 @@ export function createWindow() {
     height: 1000,
     minWidth: 1200,
     minHeight: 800,
-    title: 'Dorothy',
+    title: 'GRIP',
     titleBarStyle: 'hiddenInset',
-    backgroundColor: '#F0E8D5',
+    backgroundColor: '#EAEAEA',
     webPreferences: {
       preload: path.join(__dirname, '..', 'preload.js'),
       contextIsolation: true,
@@ -134,6 +134,12 @@ export function setupProtocolHandler() {
         urlPath = urlPath.substring(slashIndex);
       } else {
         urlPath = '/';
+      }
+
+      // Strip query string — Next.js RSC adds ?_rsc=... to prefetch requests
+      const queryIndex = urlPath.indexOf('?');
+      if (queryIndex !== -1) {
+        urlPath = urlPath.substring(0, queryIndex);
       }
 
       // Default to index.html for directory requests


### PR DESCRIPTION
## Summary

Root cause found: Next.js 16 RSC prefetch requests append `?_rsc=...` query params to `__next._tree.txt` URLs. The `app://` protocol handler was not stripping query strings before file path resolution, so every RSC prefetch returned 404.

Fix: strip query string before path lookup in `protocol.handle('app', ...)`.
Also: window title Dorothy -> GRIP, backgroundColor to paper-grey #EAEAEA.

## Test plan

- [x] npm run build passes
- [ ] No more __next._tree.txt 404s in Electron console
- [ ] Client-side navigation works between pages
- [ ] Window title shows GRIP