### PR TITLE
fix: QA round 1 — raw JSON, ANSI escapes, Dorothy updater

### DIFF
--- a/electron/handlers/grip-engine-handlers.ts
+++ b/electron/handlers/grip-engine-handlers.ts
@@ -13,6 +13,7 @@
  */
 import { ipcMain, BrowserWindow } from 'electron';
 import * as pty from 'node-pty';
+import { spawn as cpSpawn } from 'child_process';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -118,7 +119,8 @@ export function registerGripEngineHandlers() {
 
   /**
    * Send a prompt (non-interactive, one-shot).
-   * Uses `claude -p` with stream-json for structured output.
+   * Uses child_process.spawn (NOT pty) with stream-json for clean JSONL output.
+   * PTY adds ANSI escape codes that corrupt the JSON stream.
    */
   ipcMain.handle('grip:prompt', async (_event, options: {
     prompt: string;
@@ -132,22 +134,38 @@ export function registerGripEngineHandlers() {
     args.push(prompt);
 
     try {
-      const ptyProcess = pty.spawn('claude', args, {
-        name: 'xterm-256color',
-        cols: 120,
-        rows: 40,
+      const proc = cpSpawn('claude', args, {
         cwd: GRIP_DIR,
         env: { ...process.env, HOME: os.homedir() },
       });
 
       const promptSessionId = crypto.randomUUID();
 
-      ptyProcess.onData((data: string) => {
-        sendToRenderer('grip:promptOutput', { sessionId: promptSessionId, data });
+      proc.stdout.on('data', (data: Buffer) => {
+        sendToRenderer('grip:promptOutput', { sessionId: promptSessionId, data: data.toString() });
       });
 
-      ptyProcess.onExit(({ exitCode }) => {
-        sendToRenderer('grip:promptDone', { sessionId: promptSessionId, exitCode });
+      proc.stderr.on('data', (data: Buffer) => {
+        // Log stderr but don't forward raw errors to renderer
+        const text = data.toString();
+        if (text.includes('Error') || text.includes('error')) {
+          sendToRenderer('grip:promptOutput', {
+            sessionId: promptSessionId,
+            data: JSON.stringify({ type: 'error', message: text.trim() }) + '\n',
+          });
+        }
+      });
+
+      proc.on('close', (exitCode) => {
+        sendToRenderer('grip:promptDone', { sessionId: promptSessionId, exitCode: exitCode || 0 });
+      });
+
+      proc.on('error', (err) => {
+        sendToRenderer('grip:promptOutput', {
+          sessionId: promptSessionId,
+          data: JSON.stringify({ type: 'error', message: err.message }) + '\n',
+        });
+        sendToRenderer('grip:promptDone', { sessionId: promptSessionId, exitCode: 1 });
       });
 
       return { success: true, sessionId: promptSessionId };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -88,7 +88,9 @@ import { registerVaultHandlers } from './handlers/vault-handlers';
 import { registerWorldHandlers } from './handlers/world-handlers';
 import { registerGripEngineHandlers } from './handlers/grip-engine-handlers';
 import { initVaultDb, closeVaultDb } from './services/vault-db';
-import { initAutoUpdater, checkForUpdates, setMainWindowGetter } from './services/update-checker';
+// Auto-updater disabled — was pointing to Dorothy GitHub (Charlie85270/Dorothy)
+// TODO: Re-enable with GRIP-specific update mechanism (CodeTonight-SA/GRIP-GUI)
+// import { initAutoUpdater, checkForUpdates, setMainWindowGetter } from './services/update-checker';
 import { initKanbanAutomation, findMatchingAgent, createAgentForTask, startAgentForTask } from './services/kanban-automation';
 
 // Utils
@@ -548,18 +550,10 @@ app.whenReady().then(async () => {
   await setupMcpOrchestrator(appSettings);
   await configureStatusHooks();
 
-  // Initialize electron-updater (wires up IPC events for progress, downloaded, error)
-  initAutoUpdater(getMainWindow);
-  setMainWindowGetter(getMainWindow);
-
-  // Auto-check for updates on startup (electron-updater sends 'app:update-available' automatically)
-  if (appSettings.autoCheckUpdates !== false) {
-    setTimeout(() => {
-      checkForUpdates().catch((err) => {
-        console.error('Auto-update check failed:', err);
-      });
-    }, 5000);
-  }
+  // Auto-updater disabled — was pointing to Dorothy GitHub
+  // TODO: Re-enable with GRIP-specific update mechanism
+  // initAutoUpdater(getMainWindow);
+  // setMainWindowGetter(getMainWindow);
 
   console.log('App initialization complete');
 });

--- a/src/lib/grip-session.ts
+++ b/src/lib/grip-session.ts
@@ -52,24 +52,52 @@ export interface StreamEvent {
 }
 
 /**
+ * Strip ANSI escape codes and terminal control sequences from text.
+ * These leak through when PTY is used instead of child_process.
+ */
+export function stripAnsi(text: string): string {
+  return text
+    // Standard ANSI escape sequences
+    .replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '')
+    // OSC sequences (title setting, etc.)
+    .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, '')
+    // Other escape sequences
+    .replace(/\x1b[^[(\x1b]*(?:\x1b|$)/g, '')
+    // Remaining control characters (except newline, tab)
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, '')
+    // Common terminal bracket sequences that slip through
+    .replace(/\[\?[0-9;]*[a-zA-Z]/g, '')
+    .replace(/\][0-9];[^\x07]*\x07?/g, '')
+    .replace(/\[<u/g, '')
+    .trim();
+}
+
+/**
  * Extract text content from a stream-json event.
  * Handles multiple event shapes from Claude CLI output.
  */
 export function extractTextFromEvent(event: StreamEvent): string | null {
+  // Skip non-text events entirely — these should NEVER be shown to the user
+  const skipTypes = ['system', 'init', 'tool_use', 'tool_result', 'content_block_start',
+    'content_block_stop', 'message_start', 'message_stop', 'ping'];
+  if (skipTypes.includes(event.type)) return null;
+  // Also skip if event has subtype 'init' (system init events)
+  if ((event as unknown as Record<string, unknown>).subtype === 'init') return null;
+
   // Message with content blocks (assistant turn complete)
   if (event.message?.content) {
     const texts = event.message.content
       .filter((b) => b.type === 'text')
-      .map((b) => b.text || '');
+      .map((b) => stripAnsi(b.text || ''));
     if (texts.length) return texts.join('');
   }
   // Text delta (streaming chunk)
   if (event.delta?.type === 'text_delta' && event.delta.text) {
-    return event.delta.text;
+    return stripAnsi(event.delta.text);
   }
   // Plain text event
   if (event.type === 'assistant' && typeof event.text === 'string') {
-    return event.text;
+    return stripAnsi(event.text);
   }
   return null;
 }
@@ -157,9 +185,10 @@ export async function* sendToGrip(
             yield { type: 'metrics', data: metrics };
           }
         } catch {
-          // Non-JSON line — forward as raw text
-          if (line.trim()) {
-            yield { type: 'text', data: line };
+          // Non-JSON line — strip ANSI, skip raw JSON fragments
+          const cleaned = stripAnsi(line);
+          if (cleaned && !cleaned.startsWith('{') && !cleaned.startsWith('[')) {
+            yield { type: 'text', data: cleaned };
           }
         }
       }
@@ -228,9 +257,11 @@ async function* sendToGripElectron(
             if (resolve) { resolve(); resolve = null; }
           }
         } catch {
-          // Raw text output
-          if (line.trim()) {
-            chunks.push({ type: 'text', data: line });
+          // Non-JSON line — strip ANSI and only forward if it has real content
+          const cleaned = stripAnsi(line);
+          // Skip raw JSON objects that failed to parse (init events, etc.)
+          if (cleaned && !cleaned.startsWith('{') && !cleaned.startsWith('[')) {
+            chunks.push({ type: 'text', data: cleaned });
             if (resolve) { resolve(); resolve = null; }
           }
         }


### PR DESCRIPTION
## Summary

5 critical bugs from V>> QA testing:
1. Removed Dorothy auto-update checker (was downloading Dorothy-1.2.4-arm64.dmg)
2. Changed grip:prompt from pty.spawn to child_process.spawn (no ANSI in JSONL)
3. Added stripAnsi() utility for defense-in-depth ANSI removal
4. Filter non-text stream events (system/init/tool_use/ping)
5. Skip raw JSON fragments in non-JSON catch blocks

## Test plan

- [x] npm run build passes
- [ ] No Dorothy update dialog on launch
- [ ] Chat shows clean text, no raw JSON or ANSI codes
- [ ] [RL++] and response text render correctly
- [ ] No {type:system,subtype:init,...} visible in chat