### PR TITLE
feat: rename to GRIP Commander, add no-sign build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
     "electron:dev": "concurrently \"npm run dev\" \"npm run electron:start\"",
     "electron:start": "wait-on http://localhost:3000 && tsc -p electron/tsconfig.json && NODE_ENV=development electron .",
     "electron:build": "bash -c 'set -e; mv src/app/api src/app/_api_backup; mv src/app/icon.tsx src/app/_icon_backup.tsx 2>/dev/null || true; trap \"mv src/app/_api_backup src/app/api 2>/dev/null; mv src/app/_icon_backup.tsx src/app/icon.tsx 2>/dev/null\" EXIT; ELECTRON_BUILD=1 next build; tsc -p electron/tsconfig.json; cd mcp-orchestrator && npm install && npm run build && cd ..; cd mcp-telegram && npm install && npm run build && cd ..; cd mcp-kanban && npm install && npm run build && cd ..; cd mcp-vault && npm install && npm run build && cd ..; cd mcp-socialdata && npm install && npm run build && cd ..; cd mcp-x && npm install && npm run build && cd ..; cd mcp-world && npm install && npm run build && cd ..; electron-builder --mac'",
-    "electron:pack": "tsc -p electron/tsconfig.json && cd mcp-orchestrator && npm install && npm run build && cd .. && cd mcp-telegram && npm install && npm run build && cd .. && cd mcp-kanban && npm install && npm run build && cd .. && cd mcp-vault && npm install && npm run build && cd .. && cd mcp-socialdata && npm install && npm run build && cd .. && cd mcp-x && npm install && npm run build && cd .. && cd mcp-world && npm install && npm run build && cd .. && electron-builder --dir --mac"
+    "electron:pack": "tsc -p electron/tsconfig.json && cd mcp-orchestrator && npm install && npm run build && cd .. && cd mcp-telegram && npm install && npm run build && cd .. && cd mcp-kanban && npm install && npm run build && cd .. && cd mcp-vault && npm install && npm run build && cd .. && cd mcp-socialdata && npm install && npm run build && cd .. && cd mcp-x && npm install && npm run build && cd .. && cd mcp-world && npm install && npm run build && cd .. && electron-builder --dir --mac",
+    "commander:dev": "concurrently \"npm run dev\" \"npm run electron:start\"",
+    "commander:pack": "SKIP_NOTARIZE=1 CSC_IDENTITY_AUTO_DISCOVERY=false bash -c 'set -e; mv src/app/api src/app/_api_backup; mv src/app/icon.tsx src/app/_icon_backup.tsx 2>/dev/null || true; trap \"mv src/app/_api_backup src/app/api 2>/dev/null; mv src/app/_icon_backup.tsx src/app/icon.tsx 2>/dev/null\" EXIT; ELECTRON_BUILD=1 next build; tsc -p electron/tsconfig.json; cd mcp-orchestrator && npm install && npm run build && cd ..; cd mcp-telegram && npm install && npm run build && cd ..; cd mcp-kanban && npm install && npm run build && cd ..; cd mcp-vault && npm install && npm run build && cd ..; cd mcp-socialdata && npm install && npm run build && cd ..; cd mcp-x && npm install && npm run build && cd ..; cd mcp-world && npm install && npm run build && cd ..; electron-builder --mac --dir'"
   },
   "build": {
     "appId": "co.codetonight.grip",
-    "productName": "GRIP",
+    "productName": "GRIP Commander",
     "publish": {
       "provider": "github",
       "owner": "CodeTonight-SA",
@@ -118,7 +120,7 @@
       ]
     },
     "dmg": {
-      "title": "GRIP",
+      "title": "GRIP Commander",
       "contents": [
         {
           "x": 130,


### PR DESCRIPTION
## Summary
- Renames product from `GRIP` → **GRIP Commander** (`productName`, `dmg.title`)
- Adds `commander:dev` — clean alias for `electron:dev`
- Adds `commander:pack` — full build with `SKIP_NOTARIZE=1 CSC_IDENTITY_AUTO_DISCOVERY=false`, outputs unpacked `.app` via `--dir`

## Why
Previous `electron:build` failed at notarization without an Apple Developer certificate. `commander:pack` bypasses this entirely for development builds while the existing signed build path remains untouched.

## Test plan
- [ ] `npm run commander:dev` — launches Next.js + Electron with HMR
- [ ] `npm run commander:pack` — produces `release/mac-arm64/GRIP Commander.app` without signing errors
- [ ] App launches cleanly with V8 `--jitless` workaround intact