### PR TITLE
perf: wave 10+13 — RAF stream debounce, scroll throttle, MarkdownContent memo

### DIFF
--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -56,9 +56,18 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const rafIdRef = useRef<number | null>(null);
+  const pendingContentRef = useRef('');
+  const scrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    if (scrollTimerRef.current) clearTimeout(scrollTimerRef.current);
+    scrollTimerRef.current = setTimeout(() => {
+      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }, 80);
+    return () => {
+      if (scrollTimerRef.current) clearTimeout(scrollTimerRef.current);
+    };
   }, [messages]);
 
   const handleSend = useCallback(async () => {
@@ -109,14 +118,10 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
       for await (const event of sendToGrip(input.trim(), sessionId, model)) {
         if (event.type === 'text') {
           fullText += event.data as string;
-          setMessages(prev => {
-            const updated = [...prev];
-            const lastMsg = updated[updated.length - 1];
-            if (lastMsg.role === 'assistant') {
-              lastMsg.content = fullText;
-            }
-            return [...updated];
-          });
+          pendingContentRef.current = fullText;
+          if (rafIdRef.current === null) {
+            rafIdRef.current = requestAnimationFrame(flushStreamUpdate);
+          }
         } else if (event.type === 'metrics') {
           metrics = event.data as GripMetrics;
           if (metrics.sessionId) {
@@ -124,18 +129,20 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
           }
         } else if (event.type === 'error') {
           fullText += `\n[GRIP Error: ${event.data}]`;
-          setMessages(prev => {
-            const updated = [...prev];
-            const lastMsg = updated[updated.length - 1];
-            if (lastMsg.role === 'assistant') {
-              lastMsg.content = fullText;
-            }
-            return [...updated];
-          });
+          pendingContentRef.current = fullText;
+          if (rafIdRef.current === null) {
+            rafIdRef.current = requestAnimationFrame(flushStreamUpdate);
+          }
         }
       }
     } catch (err) {
       fullText += `\n[Connection error: ${err instanceof Error ? err.message : String(err)}]`;
+    }
+
+    // Flush any pending RAF update before finalising
+    if (rafIdRef.current !== null) {
+      cancelAnimationFrame(rafIdRef.current);
+      rafIdRef.current = null;
     }
 
     // Finalise the message and persist
@@ -157,11 +164,24 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
       updateSessionId(chatId, metrics.sessionId);
     }
     setIsStreaming(false);
-  }, [input, isStreaming, sessionId, model, currentChatId, messages]);
+  }, [input, isStreaming, sessionId, model, currentChatId, messages, flushStreamUpdate]);
 
   const handleStop = useCallback(() => {
     abortRef.current?.abort();
     setIsStreaming(false);
+  }, []);
+
+  const flushStreamUpdate = useCallback(() => {
+    rafIdRef.current = null;
+    const text = pendingContentRef.current;
+    setMessages(prev => {
+      const updated = [...prev];
+      const lastMsg = updated[updated.length - 1];
+      if (lastMsg?.role === 'assistant') {
+        lastMsg.content = text;
+      }
+      return updated;
+    });
   }, []);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/src/components/Engine/MarkdownContent.tsx
+++ b/src/components/Engine/MarkdownContent.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import React, { useMemo, memo } from 'react';
+
 /**
  * Lightweight markdown renderer for GRIP chat messages.
  * No external dependencies — uses regex-based parsing.
@@ -19,116 +21,122 @@ interface MarkdownContentProps {
   content: string;
 }
 
-export default function MarkdownContent({ content }: MarkdownContentProps) {
-  const blocks = content.split('\n');
-  const elements: React.ReactNode[] = [];
-  let inCodeBlock = false;
-  let codeBuffer: string[] = [];
-  let codeLanguage = '';
+function MarkdownContent({ content }: MarkdownContentProps) {
+  const elements = useMemo(() => {
+    const blocks = content.split('\n');
+    const result: React.ReactNode[] = [];
+    let inCodeBlock = false;
+    let codeBuffer: string[] = [];
+    let codeLanguage = '';
 
-  for (let i = 0; i < blocks.length; i++) {
-    const line = blocks[i];
+    for (let i = 0; i < blocks.length; i++) {
+      const line = blocks[i];
 
-    // Code block toggle
-    if (line.startsWith('```')) {
-      if (inCodeBlock) {
-        elements.push(
-          <pre key={`code-${i}`} className="bg-black text-[var(--primary)] p-4 font-mono text-xs overflow-x-auto my-2 border border-[var(--border)]">
-            {codeLanguage && (
-              <span className="font-mono text-[8px] tracking-widest text-[var(--muted-foreground)] block mb-2">
-                {codeLanguage.toUpperCase()}
-              </span>
-            )}
-            <code>{codeBuffer.join('\n')}</code>
-          </pre>
-        );
-        codeBuffer = [];
-        codeLanguage = '';
-        inCodeBlock = false;
-      } else {
-        inCodeBlock = true;
-        codeLanguage = line.slice(3).trim();
+      // Code block toggle
+      if (line.startsWith('```')) {
+        if (inCodeBlock) {
+          result.push(
+            <pre key={`code-${i}`} className="bg-black text-[var(--primary)] p-4 font-mono text-xs overflow-x-auto my-2 border border-[var(--border)]">
+              {codeLanguage && (
+                <span className="font-mono text-[8px] tracking-widest text-[var(--muted-foreground)] block mb-2">
+                  {codeLanguage.toUpperCase()}
+                </span>
+              )}
+              <code>{codeBuffer.join('\n')}</code>
+            </pre>
+          );
+          codeBuffer = [];
+          codeLanguage = '';
+          inCodeBlock = false;
+        } else {
+          inCodeBlock = true;
+          codeLanguage = line.slice(3).trim();
+        }
+        continue;
       }
-      continue;
-    }
 
-    if (inCodeBlock) {
-      codeBuffer.push(line);
-      continue;
-    }
+      if (inCodeBlock) {
+        codeBuffer.push(line);
+        continue;
+      }
 
-    // Empty line
-    if (!line.trim()) {
-      elements.push(<div key={`br-${i}`} className="h-2" />);
-      continue;
-    }
+      // Empty line
+      if (!line.trim()) {
+        result.push(<div key={`br-${i}`} className="h-2" />);
+        continue;
+      }
 
-    // Headings
-    if (line.startsWith('### ')) {
-      elements.push(
-        <h3 key={`h3-${i}`} className="text-sm font-bold tracking-tighter text-[var(--foreground)] mt-3 mb-1">
-          {renderInline(line.slice(4))}
-        </h3>
+      // Headings
+      if (line.startsWith('### ')) {
+        result.push(
+          <h3 key={`h3-${i}`} className="text-sm font-bold tracking-tighter text-[var(--foreground)] mt-3 mb-1">
+            {renderInline(line.slice(4))}
+          </h3>
+        );
+        continue;
+      }
+      if (line.startsWith('## ')) {
+        result.push(
+          <h2 key={`h2-${i}`} className="text-base font-bold tracking-tighter text-[var(--foreground)] mt-3 mb-1">
+            {renderInline(line.slice(3))}
+          </h2>
+        );
+        continue;
+      }
+      if (line.startsWith('# ')) {
+        result.push(
+          <h1 key={`h1-${i}`} className="text-lg font-bold tracking-tighter text-[var(--foreground)] mt-3 mb-1">
+            {renderInline(line.slice(2))}
+          </h1>
+        );
+        continue;
+      }
+
+      // Blockquote
+      if (line.startsWith('> ')) {
+        result.push(
+          <blockquote key={`bq-${i}`} className="border-l-2 border-[var(--primary)] pl-3 text-[var(--muted-foreground)] italic text-sm my-1">
+            {renderInline(line.slice(2))}
+          </blockquote>
+        );
+        continue;
+      }
+
+      // Bullet list
+      if (line.match(/^[-*] /)) {
+        result.push(
+          <div key={`li-${i}`} className="flex items-start gap-2 text-sm">
+            <span className="text-[var(--primary)] font-mono mt-0.5 shrink-0">-</span>
+            <span>{renderInline(line.slice(2))}</span>
+          </div>
+        );
+        continue;
+      }
+
+      // Regular paragraph
+      result.push(
+        <p key={`p-${i}`} className="text-sm leading-relaxed">
+          {renderInline(line)}
+        </p>
       );
-      continue;
-    }
-    if (line.startsWith('## ')) {
-      elements.push(
-        <h2 key={`h2-${i}`} className="text-base font-bold tracking-tighter text-[var(--foreground)] mt-3 mb-1">
-          {renderInline(line.slice(3))}
-        </h2>
-      );
-      continue;
-    }
-    if (line.startsWith('# ')) {
-      elements.push(
-        <h1 key={`h1-${i}`} className="text-lg font-bold tracking-tighter text-[var(--foreground)] mt-3 mb-1">
-          {renderInline(line.slice(2))}
-        </h1>
-      );
-      continue;
     }
 
-    // Blockquote
-    if (line.startsWith('> ')) {
-      elements.push(
-        <blockquote key={`bq-${i}`} className="border-l-2 border-[var(--primary)] pl-3 text-[var(--muted-foreground)] italic text-sm my-1">
-          {renderInline(line.slice(2))}
-        </blockquote>
+    // Handle unclosed code block
+    if (inCodeBlock && codeBuffer.length > 0) {
+      result.push(
+        <pre key="code-unclosed" className="bg-black text-[var(--primary)] p-4 font-mono text-xs overflow-x-auto my-2 border border-[var(--border)]">
+          <code>{codeBuffer.join('\n')}</code>
+        </pre>
       );
-      continue;
     }
 
-    // Bullet list
-    if (line.match(/^[-*] /)) {
-      elements.push(
-        <div key={`li-${i}`} className="flex items-start gap-2 text-sm">
-          <span className="text-[var(--primary)] font-mono mt-0.5 shrink-0">-</span>
-          <span>{renderInline(line.slice(2))}</span>
-        </div>
-      );
-      continue;
-    }
-
-    // Regular paragraph
-    elements.push(
-      <p key={`p-${i}`} className="text-sm leading-relaxed">
-        {renderInline(line)}
-      </p>
-    );
-  }
-
-  // Handle unclosed code block
-  if (inCodeBlock && codeBuffer.length > 0) {
-    elements.push(
-      <pre key="code-unclosed" className="bg-black text-[var(--primary)] p-4 font-mono text-xs overflow-x-auto my-2 border border-[var(--border)]">
-        <code>{codeBuffer.join('\n')}</code>
-      </pre>
-    );
-  }
+    return result;
+  }, [content]);
 
   return <div className="space-y-0.5">{elements}</div>;
 }
+
+export default memo(MarkdownContent);
 
 /**
  * Render inline markdown: bold, italic, code, links.


### PR DESCRIPTION
## Summary
- Replace per-token setMessages() with requestAnimationFrame batching (16ms frame budget)
- Debounce scrollIntoView to 80ms — eliminates layout thrash during streaming
- Wrap MarkdownContent parsing in useMemo + memo() — parse runs once per RAF frame, not per token

## Impact
Expected ~60x fewer React reconciliations during active streaming. Smooth 60fps scrolling.

## Test plan
- [ ] Send a long message and observe smooth token streaming with no visible jank
- [ ] Scroll stays at bottom during streaming without layout stutter
- [ ] Existing chat functionality (user messages, error states, metrics) still works