### PR TITLE
feat: wave 16 — typography pass (Geist Mono, Syne, Instrument Sans, 17px)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -67,6 +67,10 @@
   --chart-5: #000000;
 }
 
+html {
+  font-size: 17px;
+}
+
 /* ============================================
    DARK MODE
    ============================================ */
@@ -162,9 +166,10 @@
   --color-input: var(--input);
   --color-ring: var(--ring);
 
-  /* Typography — System fonts. Swiss Nihilism Law 1. */
-  --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+  /* Typography */
+  --font-sans: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif;
+  --font-mono: 'Geist Mono', 'GeistMono', ui-monospace, monospace;
+  --font-display: 'Syne', ui-sans-serif, sans-serif;
 }
 
 /* ============================================
@@ -177,8 +182,8 @@
   body {
     background: var(--background);
     color: var(--foreground);
-    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-    font-size: 14px;
+    font-family: var(--font-sans);
+    font-size: 17px;
     line-height: 1.5;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -188,9 +193,9 @@
   td, th, code, pre {
     font-variant-numeric: tabular-nums;
   }
-  /* Headings — System sans, bold, tight tracking. Swiss Nihilism Law 5. */
+  /* Headings — Syne for display. Swiss Nihilism Law 5. */
   h1, h2, h3, h4, h5, h6 {
-    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-family: var(--font-display);
     font-weight: 700;
     letter-spacing: -0.025em;
   }
@@ -384,8 +389,8 @@ input, textarea, select {
   background: var(--input);
   border: 1px solid var(--border);
   color: var(--foreground);
-  font-family: inherit;
-  font-size: 14px;
+  font-family: var(--font-sans);
+  font-size: 1rem;
   transition: border-color 0.15s ease;
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,24 @@
 import type { Metadata, Viewport } from "next";
 import "./globals.css";
+import { Syne, Instrument_Sans, Geist_Mono } from "next/font/google";
 import ClientLayout from "@/components/ClientLayout";
+
+const syne = Syne({
+  subsets: ["latin"],
+  variable: "--font-display",
+  weight: ["400", "500", "600", "700"],
+});
+
+const instrumentSans = Instrument_Sans({
+  subsets: ["latin"],
+  variable: "--font-sans",
+  weight: ["400", "500", "600"],
+});
+
+const geistMono = Geist_Mono({
+  subsets: ["latin"],
+  variable: "--font-mono",
+});
 
 export const metadata: Metadata = {
   title: "GRIP | Knowledge Work Engine",
@@ -31,7 +49,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${syne.variable} ${instrumentSans.variable} ${geistMono.variable}`}>
       <head>
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
         <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -183,7 +183,7 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
         {messages.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full max-w-xl mx-auto">
             <div className="w-12 h-12 bg-[var(--primary)] mb-6" />
-            <h1 className="text-3xl font-bold tracking-tighter text-[var(--foreground)] mb-2">
+            <h1 className="text-3xl font-bold tracking-tighter text-[var(--foreground)] mb-2" style={{ fontFamily: 'var(--font-display)' }}>
               GRIP
             </h1>
             <p className="font-mono text-xs tracking-widest text-[var(--muted-foreground)] mb-8">


### PR DESCRIPTION
## Summary
- 17px base font size for improved readability
- Geist Mono for all monospace/code/terminal elements
- Syne for display and GRIP branding labels
- Instrument Sans for body text and inputs

## Test plan
- [ ] Chat input uses Instrument Sans, readable at 17px
- [ ] Code blocks in MarkdownContent use Geist Mono
- [ ] GRIP branding uses Syne
- [ ] No layout breakage from font size change