### PR TITLE
perf: GRIP Commander ultra-fast sprint — V8 JIT, persistent session, UX delight

### DIFF
--- a/electron/core/window-manager.ts
+++ b/electron/core/window-manager.ts
@@ -1,8 +1,11 @@
-import { BrowserWindow, protocol, app } from 'electron';
+import { BrowserWindow, protocol, app, shell } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
 import { getAppBasePath } from '../utils';
 import { MIME_TYPES } from '../constants';
+
+// Allowed origins for in-app navigation
+const ALLOWED_ORIGINS = ['http://localhost', 'app://-'];
 
 // Global reference to the main window
 let mainWindow: BrowserWindow | null = null;
@@ -53,6 +56,25 @@ export function createWindow() {
 
   mainWindow.on('closed', () => {
     mainWindow = null;
+  });
+
+  // Navigation guards — prevent external URLs loading in the Electron window
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    const isAllowed = ALLOWED_ORIGINS.some(origin => url.startsWith(origin));
+    if (!isAllowed) {
+      event.preventDefault();
+      if (url.startsWith('http://') || url.startsWith('https://')) {
+        shell.openExternal(url);
+      }
+    }
+  });
+
+  // Block all new-window requests — open external links in system browser
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      shell.openExternal(url);
+    }
+    return { action: 'deny' };
   });
 
   // Handle loading errors

--- a/electron/handlers/grip-engine-handlers.ts
+++ b/electron/handlers/grip-engine-handlers.ts
@@ -332,6 +332,11 @@ export function registerGripEngineHandlers() {
     const proc = activePrompts.get(sessionId);
     if (proc) {
       proc.kill('SIGTERM');
+      // Force kill after 3s if SIGTERM doesn't work
+      const killTimeout = setTimeout(() => {
+        try { proc.kill('SIGKILL'); } catch { /* already dead */ }
+      }, 3000);
+      proc.once('exit', () => clearTimeout(killTimeout));
       activePrompts.delete(sessionId);
       return { success: true };
     }
@@ -358,6 +363,9 @@ export function registerGripEngineHandlers() {
    * Send a message through the persistent stream-json session.
    * The session stays alive between messages — no cold start.
    * Output is forwarded via grip:promptOutput events (same as one-shot).
+   *
+   * Uses line-based parsing to detect end-of-message (result event),
+   * with explicit cleanup of all listeners to prevent leaks.
    */
   ipcMain.handle('grip:streamMessage', async (_event, options: {
     prompt: string;
@@ -375,10 +383,21 @@ export function registerGripEngineHandlers() {
     }
 
     const messageId = crypto.randomUUID();
-
-    // Set up output forwarding for this message
+    const currentSession = streamSession;
+    let lineBuffer = '';
     let outputBuffer = '';
     let flushTimer: ReturnType<typeof setTimeout> | null = null;
+    let messageComplete = false;
+    let cleaned = false;
+
+    // Explicit cleanup — called once from any exit path
+    const cleanup = () => {
+      if (cleaned) return;
+      cleaned = true;
+      if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
+      currentSession.proc.stdout?.removeListener('data', onData);
+      currentSession.proc.removeListener('close', onClose);
+    };
 
     const flushOutput = () => {
       if (outputBuffer) {
@@ -388,40 +407,60 @@ export function registerGripEngineHandlers() {
       flushTimer = null;
     };
 
-    // Track whether this message's response is complete
-    let messageComplete = false;
-
     const onData = (data: Buffer) => {
-      const text = data.toString();
-      outputBuffer += text;
+      if (messageComplete) return; // Ignore data after completion
 
-      // Check if this chunk contains a result event (end of message response)
-      if (text.includes('"type":"result"') || text.includes('"type": "result"')) {
-        messageComplete = true;
+      const text = data.toString();
+      lineBuffer += text;
+
+      // Parse complete lines (JSONL: one JSON object per line)
+      const lines = lineBuffer.split('\n');
+      lineBuffer = lines.pop() || ''; // Keep incomplete line
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        outputBuffer += line + '\n';
+
+        // Detect result event by parsing the line as JSON
+        try {
+          const parsed = JSON.parse(line);
+          if (parsed.type === 'result') {
+            messageComplete = true;
+          }
+        } catch { /* not valid JSON, forward anyway */ }
       }
 
+      // Batch flush every 16ms
       if (!flushTimer) {
         flushTimer = setTimeout(() => {
           flushOutput();
           if (messageComplete) {
+            // Flush any remaining line buffer
+            if (lineBuffer.trim()) {
+              sendToRenderer('grip:promptOutput', { sessionId: messageId, data: lineBuffer + '\n' });
+              lineBuffer = '';
+            }
+            cleanup();
             sendToRenderer('grip:promptDone', { sessionId: messageId, exitCode: 0 });
-            streamSession?.proc.stdout?.removeListener('data', onData);
           }
         }, 16);
       }
     };
 
-    streamSession.proc.stdout?.on('data', onData);
-
-    // Handle process death during this message
     const onClose = () => {
-      if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
       flushOutput();
+      if (lineBuffer.trim()) {
+        sendToRenderer('grip:promptOutput', { sessionId: messageId, data: lineBuffer + '\n' });
+        lineBuffer = '';
+      }
+      cleanup();
       if (!messageComplete) {
         sendToRenderer('grip:promptDone', { sessionId: messageId, exitCode: 1 });
       }
     };
-    streamSession.proc.once('close', onClose);
+
+    currentSession.proc.stdout?.on('data', onData);
+    currentSession.proc.once('close', onClose);
 
     // Write the message as JSON to stdin
     const inputEvent = JSON.stringify({
@@ -430,11 +469,10 @@ export function registerGripEngineHandlers() {
     }) + '\n';
 
     try {
-      streamSession.proc.stdin.write(inputEvent);
+      currentSession.proc.stdin.write(inputEvent);
       return { success: true, sessionId: messageId };
     } catch (err) {
-      streamSession.proc.stdout?.removeListener('data', onData);
-      streamSession.proc.removeListener('close', onClose);
+      cleanup();
       return { success: false, error: err instanceof Error ? err.message : 'Write failed' };
     }
   });

--- a/electron/handlers/grip-engine-handlers.ts
+++ b/electron/handlers/grip-engine-handlers.ts
@@ -55,6 +55,77 @@ interface EngineSession {
 
 let engineSession: EngineSession | null = null;
 
+/**
+ * Persistent streaming session — a long-lived `claude -p` process that uses
+ * stream-json on both stdin and stdout. Context stays loaded between messages,
+ * eliminating the 2-3s cold start per turn. This is the ultra-fast path.
+ */
+interface StreamSession {
+  proc: ChildProcess;
+  model: string;
+  sessionId: string;
+  alive: boolean;
+}
+
+let streamSession: StreamSession | null = null;
+
+function killStreamSession() {
+  if (streamSession?.proc) {
+    streamSession.alive = false;
+    streamSession.proc.kill('SIGTERM');
+    streamSession = null;
+  }
+}
+
+function startStreamSession(model: string = 'sonnet'): StreamSession {
+  killStreamSession();
+
+  const args = ['-p', '--input-format', 'stream-json', '--output-format', 'stream-json', '--model', model];
+  const proc = cpSpawn('claude', args, {
+    cwd: GRIP_DIR,
+    env: { ...process.env, HOME: os.homedir(), PATH: buildClaudePath() },
+  });
+
+  const sessionId = crypto.randomUUID();
+  const session: StreamSession = { proc, model, sessionId, alive: true };
+
+  proc.on('close', () => {
+    session.alive = false;
+    if (streamSession === session) {
+      streamSession = null;
+      console.log('Stream session closed');
+    }
+  });
+
+  proc.on('error', (err) => {
+    console.error('Stream session error:', err.message);
+    session.alive = false;
+    if (streamSession === session) streamSession = null;
+  });
+
+  proc.stderr?.on('data', (data: Buffer) => {
+    // Log but don't forward stderr from the persistent session
+    const text = data.toString().trim();
+    if (text) console.error('[stream-session stderr]', text);
+  });
+
+  streamSession = session;
+  console.log(`Stream session started: model=${model}, sessionId=${sessionId}`);
+  return session;
+}
+
+/**
+ * Pre-warm a GRIP session for instant first response.
+ * Called from main.ts after app init.
+ */
+export function preWarmSession(model: string = 'sonnet') {
+  try {
+    startStreamSession(model);
+  } catch (err) {
+    console.error('Failed to pre-warm session:', err);
+  }
+}
+
 function getMainWindow(): BrowserWindow | null {
   const windows = BrowserWindow.getAllWindows();
   return windows.length > 0 ? windows[0] : null;
@@ -265,6 +336,115 @@ export function registerGripEngineHandlers() {
       return { success: true };
     }
     return { success: false, error: 'No active prompt with that ID' };
+  });
+
+  /**
+   * Start a persistent stream-json session.
+   * This keeps a claude -p process alive with --input-format stream-json
+   * for ultra-fast follow-up messages (no cold start).
+   */
+  ipcMain.handle('grip:startStreamSession', async (_event, options: {
+    model?: string;
+  } = {}) => {
+    try {
+      const session = startStreamSession(options.model);
+      return { success: true, sessionId: session.sessionId };
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : 'Unknown error' };
+    }
+  });
+
+  /**
+   * Send a message through the persistent stream-json session.
+   * The session stays alive between messages — no cold start.
+   * Output is forwarded via grip:promptOutput events (same as one-shot).
+   */
+  ipcMain.handle('grip:streamMessage', async (_event, options: {
+    prompt: string;
+    model?: string;
+  }) => {
+    const { prompt, model = 'sonnet' } = options;
+
+    // Start or restart session if needed
+    if (!streamSession?.alive || (model && streamSession.model !== model)) {
+      startStreamSession(model);
+    }
+
+    if (!streamSession?.alive || !streamSession.proc.stdin) {
+      return { success: false, error: 'Failed to start stream session' };
+    }
+
+    const messageId = crypto.randomUUID();
+
+    // Set up output forwarding for this message
+    let outputBuffer = '';
+    let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const flushOutput = () => {
+      if (outputBuffer) {
+        sendToRenderer('grip:promptOutput', { sessionId: messageId, data: outputBuffer });
+        outputBuffer = '';
+      }
+      flushTimer = null;
+    };
+
+    // Track whether this message's response is complete
+    let messageComplete = false;
+
+    const onData = (data: Buffer) => {
+      const text = data.toString();
+      outputBuffer += text;
+
+      // Check if this chunk contains a result event (end of message response)
+      if (text.includes('"type":"result"') || text.includes('"type": "result"')) {
+        messageComplete = true;
+      }
+
+      if (!flushTimer) {
+        flushTimer = setTimeout(() => {
+          flushOutput();
+          if (messageComplete) {
+            sendToRenderer('grip:promptDone', { sessionId: messageId, exitCode: 0 });
+            streamSession?.proc.stdout?.removeListener('data', onData);
+          }
+        }, 16);
+      }
+    };
+
+    streamSession.proc.stdout?.on('data', onData);
+
+    // Handle process death during this message
+    const onClose = () => {
+      if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
+      flushOutput();
+      if (!messageComplete) {
+        sendToRenderer('grip:promptDone', { sessionId: messageId, exitCode: 1 });
+      }
+    };
+    streamSession.proc.once('close', onClose);
+
+    // Write the message as JSON to stdin
+    const inputEvent = JSON.stringify({
+      type: 'user_message',
+      content: prompt,
+    }) + '\n';
+
+    try {
+      streamSession.proc.stdin.write(inputEvent);
+      return { success: true, sessionId: messageId };
+    } catch (err) {
+      streamSession.proc.stdout?.removeListener('data', onData);
+      streamSession.proc.removeListener('close', onClose);
+      return { success: false, error: err instanceof Error ? err.message : 'Write failed' };
+    }
+  });
+
+  /**
+   * Kill the persistent stream session.
+   */
+  ipcMain.handle('grip:killStreamSession', async () => {
+    killStreamSession();
+    return { success: true };
   });
 
   /**

--- a/electron/handlers/grip-engine-handlers.ts
+++ b/electron/handlers/grip-engine-handlers.ts
@@ -13,15 +13,18 @@
  */
 import { ipcMain, BrowserWindow } from 'electron';
 import * as pty from 'node-pty';
-import { spawn as cpSpawn } from 'child_process';
+import { spawn as cpSpawn, ChildProcess } from 'child_process';
 import * as os from 'os';
 import * as path from 'path';
 
 /**
  * Build a PATH string that includes common claude installation directories.
  * The Electron process PATH may not include nvm/homebrew paths.
+ * Cached after first call — PATH doesn't change at runtime.
  */
+let cachedClaudePath: string | null = null;
 function buildClaudePath(): string {
+  if (cachedClaudePath) return cachedClaudePath;
   const home = os.homedir();
   const extras = [
     path.join(home, '.local', 'bin'),
@@ -32,10 +35,14 @@ function buildClaudePath(): string {
   ];
   const existing = (process.env.PATH || '').split(':');
   const seen = new Set<string>();
-  return [...extras, ...existing]
+  cachedClaudePath = [...extras, ...existing]
     .filter(p => { if (!p || seen.has(p)) return false; seen.add(p); return true; })
     .join(':');
+  return cachedClaudePath;
 }
+
+// Track active one-shot prompt processes for cancellation
+const activePrompts = new Map<string, ChildProcess>();
 
 const GRIP_DIR = path.join(os.homedir(), '.claude');
 
@@ -166,9 +173,25 @@ export function registerGripEngineHandlers() {
       });
 
       const promptSessionId = crypto.randomUUID();
+      activePrompts.set(promptSessionId, proc);
+
+      // Buffer stdout chunks for 16ms before sending to reduce IPC call count
+      let outputBuffer = '';
+      let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+      const flushOutput = () => {
+        if (outputBuffer) {
+          sendToRenderer('grip:promptOutput', { sessionId: promptSessionId, data: outputBuffer });
+          outputBuffer = '';
+        }
+        flushTimer = null;
+      };
 
       proc.stdout.on('data', (data: Buffer) => {
-        sendToRenderer('grip:promptOutput', { sessionId: promptSessionId, data: data.toString() });
+        outputBuffer += data.toString();
+        if (!flushTimer) {
+          flushTimer = setTimeout(flushOutput, 16);
+        }
       });
 
       proc.stderr.on('data', (data: Buffer) => {
@@ -183,10 +206,15 @@ export function registerGripEngineHandlers() {
       });
 
       proc.on('close', (exitCode) => {
+        // Flush any remaining buffered output
+        if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
+        flushOutput();
+        activePrompts.delete(promptSessionId);
         sendToRenderer('grip:promptDone', { sessionId: promptSessionId, exitCode: exitCode || 0 });
       });
 
       proc.on('error', (err) => {
+        activePrompts.delete(promptSessionId);
         sendToRenderer('grip:promptOutput', {
           sessionId: promptSessionId,
           data: JSON.stringify({ type: 'error', message: err.message }) + '\n',
@@ -221,6 +249,22 @@ export function registerGripEngineHandlers() {
       return { success: true };
     }
     return { success: false, error: 'No active session' };
+  });
+
+  /**
+   * Kill a running one-shot prompt by session ID.
+   */
+  ipcMain.handle('grip:killPrompt', async (_event, sessionId: string) => {
+    if (typeof sessionId !== 'string') {
+      return { success: false, error: 'Invalid session ID' };
+    }
+    const proc = activePrompts.get(sessionId);
+    if (proc) {
+      proc.kill('SIGTERM');
+      activePrompts.delete(sessionId);
+      return { success: true };
+    }
+    return { success: false, error: 'No active prompt with that ID' };
   });
 
   /**

--- a/electron/handlers/ipc-handlers.ts
+++ b/electron/handlers/ipc-handlers.ts
@@ -1485,6 +1485,8 @@ function registerUpdateHandlers(): void {
   });
 
   // Save clipboard data (e.g. pasted image) to a temp file
+  const ALLOWED_IMAGE_EXTS = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'svg'];
+
   ipcMain.handle('app:saveTemp', async (_event, dataUrl: string) => {
     if (typeof dataUrl !== 'string' || !dataUrl.startsWith('data:')) {
       return { success: false, error: 'Invalid data URL' };
@@ -1493,7 +1495,11 @@ function registerUpdateHandlers(): void {
       const match = dataUrl.match(/^data:image\/(\w+);base64,(.+)$/);
       if (!match) return { success: false, error: 'Not a valid image data URL' };
 
-      const ext = match[1] === 'jpeg' ? 'jpg' : match[1];
+      const rawExt = match[1].toLowerCase();
+      if (!ALLOWED_IMAGE_EXTS.includes(rawExt)) {
+        return { success: false, error: `Image type not allowed: ${rawExt}` };
+      }
+      const ext = rawExt === 'jpeg' ? 'jpg' : rawExt;
       const buffer = Buffer.from(match[2], 'base64');
       const tmpDir = path.join(os.tmpdir(), 'grip-commander');
       const fs = await import('fs');

--- a/electron/handlers/ipc-handlers.ts
+++ b/electron/handlers/ipc-handlers.ts
@@ -1476,8 +1476,35 @@ function registerUpdateHandlers(): void {
   });
 
   ipcMain.handle('app:openExternal', async (_event, url: string) => {
-    shell.openExternal(url);
-    return { success: true };
+    // Only allow http/https URLs — block file://, javascript:, data:, etc.
+    if (typeof url === 'string' && (url.startsWith('http://') || url.startsWith('https://'))) {
+      shell.openExternal(url);
+      return { success: true };
+    }
+    return { success: false, error: 'Blocked: only http/https URLs allowed' };
+  });
+
+  // Save clipboard data (e.g. pasted image) to a temp file
+  ipcMain.handle('app:saveTemp', async (_event, dataUrl: string) => {
+    if (typeof dataUrl !== 'string' || !dataUrl.startsWith('data:')) {
+      return { success: false, error: 'Invalid data URL' };
+    }
+    try {
+      const match = dataUrl.match(/^data:image\/(\w+);base64,(.+)$/);
+      if (!match) return { success: false, error: 'Not a valid image data URL' };
+
+      const ext = match[1] === 'jpeg' ? 'jpg' : match[1];
+      const buffer = Buffer.from(match[2], 'base64');
+      const tmpDir = path.join(os.tmpdir(), 'grip-commander');
+      const fs = await import('fs');
+      if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir, { recursive: true });
+
+      const filePath = path.join(tmpDir, `paste-${Date.now()}.${ext}`);
+      fs.writeFileSync(filePath, buffer);
+      return filePath;
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : 'Unknown error' };
+    }
   });
 }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -14,12 +14,18 @@ import { app, BrowserWindow } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
 
-// V8 stability flags for unsigned development builds.
-// The ad-hoc code signing on macOS can cause V8's memory protection
+// V8 stability: ad-hoc code signing on macOS can cause V8's memory protection
 // (ThreadIsolation::WriteProtectMemory) to crash with EXC_BREAKPOINT.
-// These flags mitigate the issue until proper Apple Developer signing.
-app.commandLine.appendSwitch('js-flags', '--jitless');
-app.commandLine.appendSwitch('disable-gpu-sandbox');
+// --jitless disables JIT entirely (10-100x slower), so we only use it as a fallback.
+// In development: JIT enabled (no signing needed).
+// In production: try without jitless; env var GRIP_JITLESS=1 to force if crashes occur.
+if (process.env.GRIP_JITLESS === '1') {
+  app.commandLine.appendSwitch('js-flags', '--jitless');
+  app.commandLine.appendSwitch('disable-gpu-sandbox');
+} else if (process.env.NODE_ENV !== 'development' && process.platform === 'darwin') {
+  // Less aggressive mitigation that keeps JIT enabled
+  app.commandLine.appendSwitch('js-flags', '--no-v8-untrusted-code-mitigations');
+}
 
 // Crash recovery: log uncaught exceptions instead of silently dying
 process.on('uncaughtException', (error) => {
@@ -558,24 +564,26 @@ app.whenReady().then(async () => {
     saveAgents,
   });
 
-  // Initialize services
-  initTelegramBot();
-  initSlackBot(appSettings, (settings) => {
-    appSettings = settings;
-    saveAppSettingsToFile(settings);
-  }, getMainWindow());
-  initApiServer();
+  // Pre-warm a GRIP Engine session for instant first response (2s delay to not block window)
+  setTimeout(() => {
+    const { preWarmSession } = require('./handlers/grip-engine-handlers');
+    preWarmSession('sonnet');
+  }, 2000);
 
-  // Setup MCP orchestrator and hooks
-  await setupMcpOrchestrator(appSettings);
-  await configureStatusHooks();
+  // Defer non-essential services to speed up window appearance
+  setTimeout(async () => {
+    initTelegramBot();
+    initSlackBot(appSettings, (settings) => {
+      appSettings = settings;
+      saveAppSettingsToFile(settings);
+    }, getMainWindow());
+    initApiServer();
+    await setupMcpOrchestrator(appSettings);
+    await configureStatusHooks();
+    console.log('Deferred services initialized');
+  }, 3000);
 
-  // Auto-updater disabled — was pointing to Dorothy GitHub
-  // TODO: Re-enable with GRIP-specific update mechanism
-  // initAutoUpdater(getMainWindow);
-  // setMainWindowGetter(getMainWindow);
-
-  console.log('App initialization complete');
+  console.log('App initialization complete (core services ready)');
 });
 
 // Quit when all windows are closed (except on macOS)

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -626,6 +626,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getHealth: () =>
       ipcRenderer.invoke('grip:getHealth'),
 
+    // Persistent stream-json session (ultra-fast follow-up messages)
+    startStreamSession: (options?: { model?: string }) =>
+      ipcRenderer.invoke('grip:startStreamSession', options),
+    streamMessage: (options: { prompt: string; model?: string }) =>
+      ipcRenderer.invoke('grip:streamMessage', options),
+    killStreamSession: () =>
+      ipcRenderer.invoke('grip:killStreamSession'),
+
     // Event listeners for streaming output
     onOutput: (callback: (event: { sessionId: string; data: string }) => void) => {
       const handler = (_: unknown, event: { sessionId: string; data: string }) => callback(event);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -621,6 +621,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('grip:getSessionStatus'),
     killSession: () =>
       ipcRenderer.invoke('grip:killSession'),
+    killPrompt: (sessionId: string) =>
+      ipcRenderer.invoke('grip:killPrompt', sessionId),
     getHealth: () =>
       ipcRenderer.invoke('grip:getHealth'),
 
@@ -646,6 +648,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
       return () => { ipcRenderer.removeListener('grip:promptDone', handler); };
     },
   },
+
+  // Temp file operations (for clipboard image paste)
+  saveTemp: (dataUrl: string) =>
+    ipcRenderer.invoke('app:saveTemp', dataUrl),
 
   // Platform info
   platform: process.platform,

--- a/next.config.ts
+++ b/next.config.ts
@@ -17,6 +17,11 @@ const nextConfig: NextConfig = {
   // Allow cross-origin requests from Tailscale network for remote access
   allowedDevOrigins: ['http://100.92.4.122:3000'],
 
+  // Tree-shake large libraries — only bundle the icons/components actually used
+  experimental: {
+    optimizePackageImports: ['framer-motion', 'lucide-react'],
+  },
+
   // No assetPrefix needed - we use custom app:// protocol that handles absolute paths
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import FocusMode from '@/components/Engine/FocusMode';
 import WelcomeAnimation from '@/components/Engine/WelcomeAnimation';
 import MobileToolbar from '@/components/Engine/MobileToolbar';
 import { useState, useCallback, useEffect } from 'react';
+import { isElectronEnv } from '@/lib/grip-session';
 import {
   getChatSessions,
   getActiveChatId,
@@ -17,12 +18,40 @@ import {
   type ChatSession,
 } from '@/lib/chat-storage';
 
+interface HealthData {
+  skillCount: number;
+  generation: number;
+  fitness: number;
+}
+
 export default function EnginePage() {
   const [showWelcome, setShowWelcome] = useState(true);
   const [focusMode, setFocusMode] = useState(false);
   const [model, setModel] = useState('sonnet');
   const [activeChatId, setActiveChatId] = useState<string | null>(null);
   const [chatKey, setChatKey] = useState(0); // Force re-mount ChatInterface on session switch
+  const [health, setHealth] = useState<HealthData>({ skillCount: 5, generation: 33, fitness: 0.467 });
+
+  // Fetch GRIP health data for live status bar
+  useEffect(() => {
+    const fetchHealth = async () => {
+      if (!isElectronEnv()) return;
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const data = await (window as any).electronAPI?.grip?.getHealth();
+        if (data?.status === 'healthy') {
+          setHealth({
+            skillCount: data.skillCount ?? 5,
+            generation: data.generation ?? 33,
+            fitness: data.fitness ?? 0.467,
+          });
+        }
+      } catch { /* silently fail — status bar shows defaults */ }
+    };
+    fetchHealth();
+    const interval = setInterval(fetchHealth, 30000);
+    return () => clearInterval(interval);
+  }, []);
 
   // Initialise: migrate storage, load or create active chat
   useEffect(() => {
@@ -96,7 +125,7 @@ export default function EnginePage() {
           )}
         </div>
 
-        {!focusMode && <GripStatusBar />}
+        {!focusMode && <GripStatusBar skillCount={health.skillCount} />}
       </div>
 
       {/* Mobile bottom toolbar — visible on small screens only */}

--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback, type ClipboardEvent, type DragEvent } from 'react';
 import { Send, Sparkles, Square, X, Image as ImageIcon } from 'lucide-react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { sendToGrip, type GripMessage, type GripMetrics } from '@/lib/grip-session';
 import TypingIndicator from './TypingIndicator';
 import {
@@ -59,6 +59,7 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
   }, [chatId]);
   const [pastedImage, setPastedImage] = useState<{ dataUrl: string; tempPath?: string } | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
+  const reduceMotion = useReducedMotion();
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   // Tracks the Electron IPC prompt session ID so the stop button can kill it
@@ -375,9 +376,9 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
             {messages.map((msg) => (
               <motion.div
                 key={msg.id}
-                initial={{ opacity: 0, x: msg.role === 'user' ? 12 : -12 }}
+                initial={reduceMotion ? false : { opacity: 0, x: msg.role === 'user' ? 12 : -12 }}
                 animate={{ opacity: 1, x: 0 }}
-                transition={{ duration: msg.role === 'user' ? 0.2 : 0.25, ease: [0.16, 1, 0.3, 1] }}
+                transition={reduceMotion ? { duration: 0 } : { duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
                 className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
               >
                 <div className="max-w-[85%]">
@@ -455,7 +456,7 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
       >
         {/* Drag-and-drop overlay */}
         {isDragOver && (
-          <div className="absolute inset-0 z-10 flex items-center justify-center border-2 border-dashed border-[var(--primary)] bg-[var(--primary)]/5">
+          <div className="absolute inset-0 z-10 flex items-center justify-center border-2 border-dashed border-[var(--primary)] bg-[var(--primary)]/10">
             <div className="flex items-center gap-2">
               <ImageIcon className="w-4 h-4 text-[var(--primary)]" />
               <span className="font-mono text-xs tracking-widest text-[var(--primary)]">

--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, useRef, useEffect, useCallback } from 'react';
-import { Send, Sparkles, Terminal as TerminalIcon, Square } from 'lucide-react';
+import { useState, useRef, useEffect, useCallback, type ClipboardEvent, type DragEvent } from 'react';
+import { Send, Sparkles, Terminal as TerminalIcon, Square, X, Image as ImageIcon } from 'lucide-react';
 import { sendToGrip, type GripMessage, type GripMetrics } from '@/lib/grip-session';
 import {
   getChatMessages,
@@ -55,9 +55,12 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
   useEffect(() => {
     if (chatId !== undefined) setCurrentChatId(chatId);
   }, [chatId]);
+  const [pastedImage, setPastedImage] = useState<{ dataUrl: string; tempPath?: string } | null>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
-  const abortRef = useRef<AbortController | null>(null);
+  // Tracks the Electron IPC prompt session ID so the stop button can kill it
+  const activePromptSessionRef = useRef<string | null>(null);
   const rafIdRef = useRef<number | null>(null);
   const pendingContentRef = useRef('');
   const scrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -84,11 +87,16 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
       setActiveChatId(chatId);
     }
 
+    const imageContext = pastedImage?.tempPath
+      ? `\n\n[Attached image: ${pastedImage.tempPath}]`
+      : '';
+
     const userMessage: GripMessage = {
       id: crypto.randomUUID(),
       role: 'user',
-      content: input.trim(),
+      content: input.trim() + (pastedImage ? ' [image attached]' : ''),
       timestamp: new Date(),
+      imageDataUrl: pastedImage?.dataUrl,
     };
 
     const assistantMessage: GripMessage = {
@@ -102,6 +110,7 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
     const newMessages = [...messages, userMessage, assistantMessage];
     setMessages(newMessages);
     setInput('');
+    setPastedImage(null);
     setIsStreaming(true);
     spinnerTimerRef.current = setTimeout(() => setShowSpinner(true), 200);
 
@@ -118,8 +127,14 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
     let metrics: GripMetrics | undefined;
     let receivedFirstToken = false;
 
+    const promptText = input.trim() + imageContext;
     try {
-      for await (const event of sendToGrip(input.trim(), sessionId, model)) {
+      for await (const event of sendToGrip(
+        promptText,
+        sessionId,
+        model,
+        (id) => { activePromptSessionRef.current = id; },
+      )) {
         if (event.type === 'text') {
           if (!receivedFirstToken) {
             receivedFirstToken = true;
@@ -175,17 +190,24 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
     if (metrics?.sessionId && chatId) {
       updateSessionId(chatId, metrics.sessionId);
     }
+    activePromptSessionRef.current = null;
     setIsStreaming(false);
     setShowSpinner(false);
     if (spinnerTimerRef.current) {
       clearTimeout(spinnerTimerRef.current);
       spinnerTimerRef.current = null;
     }
-  }, [input, isStreaming, sessionId, model, currentChatId, messages, flushStreamUpdate]);
+  }, [input, isStreaming, sessionId, model, currentChatId, messages, flushStreamUpdate, pastedImage]);
 
   const handleStop = useCallback(() => {
-    abortRef.current?.abort();
+    const id = activePromptSessionRef.current;
+    if (id) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).electronAPI?.grip?.killPrompt?.(id);
+      activePromptSessionRef.current = null;
+    }
     setIsStreaming(false);
+    setShowSpinner(false);
   }, []);
 
   const flushStreamUpdate = useCallback(() => {
@@ -212,6 +234,52 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
     setInput(text);
     inputRef.current?.focus();
   };
+
+  // Shared helper for processing image files (paste or drag-and-drop)
+  const processImageFile = useCallback((file: File) => {
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const dataUrl = ev.target?.result as string;
+      if (!dataUrl) return;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const electronAPI = (window as any).electronAPI;
+      if (electronAPI?.saveTemp) {
+        electronAPI.saveTemp(dataUrl).then((tempPath: string) => {
+          setPastedImage({ dataUrl, tempPath });
+        });
+      } else {
+        setPastedImage({ dataUrl });
+      }
+    };
+    reader.readAsDataURL(file);
+  }, []);
+
+  const handlePaste = useCallback((e: ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = Array.from(e.clipboardData.items);
+    const imageItem = items.find(item => item.type.startsWith('image/'));
+    if (!imageItem) return;
+    e.preventDefault();
+    const file = imageItem.getAsFile();
+    if (file) processImageFile(file);
+  }, [processImageFile]);
+
+  const handleDrop = useCallback((e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragOver(false);
+    const files = Array.from(e.dataTransfer.files);
+    const imageFile = files.find(f => f.type.startsWith('image/'));
+    if (imageFile) processImageFile(imageFile);
+  }, [processImageFile]);
+
+  const handleDragOver = useCallback((e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragOver(false);
+  }, []);
 
   return (
     <div className="flex flex-col h-full">
@@ -274,6 +342,16 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
                       ? 'bg-[var(--primary)] text-[var(--primary-foreground)]'
                       : 'border border-[var(--border)] text-[var(--foreground)]'
                   }`}>
+                    {msg.imageDataUrl && (
+                      <div className="mb-2">
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                          src={msg.imageDataUrl}
+                          alt="Attached"
+                          className="max-h-48 w-auto border border-[var(--border)]"
+                        />
+                      </div>
+                    )}
                     <MarkdownContent content={msg.content} />
                     {msg.streaming && (
                       <span className="inline-block w-2 h-4 bg-[var(--primary)] animate-pulse ml-0.5" />
@@ -319,8 +397,45 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
       </div>
 
       {/* Input area */}
-      <div className="border-t border-[var(--border)] bg-[var(--card)] p-4">
+      <div
+        className="border-t border-[var(--border)] bg-[var(--card)] p-4 relative"
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+      >
+        {/* Drag-and-drop overlay */}
+        {isDragOver && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center border-2 border-dashed border-[var(--primary)] bg-[var(--primary)]/5">
+            <div className="flex items-center gap-2">
+              <ImageIcon className="w-4 h-4 text-[var(--primary)]" />
+              <span className="font-mono text-xs tracking-widest text-[var(--primary)]">
+                DROP IMAGE HERE
+              </span>
+            </div>
+          </div>
+        )}
         <div className="max-w-3xl mx-auto">
+          {/* Image preview strip */}
+          {pastedImage && (
+            <div className="flex items-center gap-3 mb-2 p-2 border border-[var(--border)] bg-[var(--background)]">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={pastedImage.dataUrl}
+                alt="Pasted"
+                className="max-h-16 w-auto border border-[var(--border)]"
+              />
+              <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)]">
+                IMAGE ATTACHED
+              </span>
+              <button
+                onClick={() => setPastedImage(null)}
+                className="ml-auto p-1 hover:bg-[var(--secondary)] transition-colors"
+                title="Remove image"
+              >
+                <X className="w-3 h-3 text-[var(--muted-foreground)]" />
+              </button>
+            </div>
+          )}
           <div className="flex items-end gap-3">
             <div className="flex-1 relative">
               <textarea
@@ -328,6 +443,7 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={handleKeyDown}
+                onPaste={handlePaste}
                 placeholder="Type your message..."
                 rows={1}
                 disabled={isStreaming}

--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useState, useRef, useEffect, useCallback, type ClipboardEvent, type DragEvent } from 'react';
-import { Send, Sparkles, Terminal as TerminalIcon, Square, X, Image as ImageIcon } from 'lucide-react';
+import { Send, Sparkles, Square, X, Image as ImageIcon } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
 import { sendToGrip, type GripMessage, type GripMetrics } from '@/lib/grip-session';
+import TypingIndicator from './TypingIndicator';
 import {
   getChatMessages,
   saveChatMessages,
@@ -286,24 +288,68 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
       {/* Messages area */}
       <div className="flex-1 overflow-y-auto px-4 py-6">
         {messages.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full max-w-xl mx-auto">
-            <div className="w-12 h-12 bg-[var(--primary)] mb-6" />
-            <h1 className="text-3xl font-bold tracking-tighter text-[var(--foreground)] mb-2" style={{ fontFamily: 'var(--font-display)' }}>
+          <div
+            className="flex flex-col items-center justify-center h-full max-w-xl mx-auto relative"
+            style={{
+              background: 'radial-gradient(ellipse at 50% 40%, var(--info-muted) 0%, transparent 60%)',
+            }}
+          >
+            {/* Animated pulse bars as centrepiece */}
+            <motion.div
+              initial={{ opacity: 0, scale: 0.9 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
+              className="flex items-end gap-1 h-12 mb-6"
+            >
+              {[0, 1, 2, 3, 4].map(i => (
+                <motion.div
+                  key={i}
+                  className="w-2 bg-[var(--primary)]"
+                  animate={{ height: ['8px', '48px', '8px'] }}
+                  transition={{
+                    repeat: Infinity,
+                    duration: 1.6,
+                    delay: i * 0.2,
+                    ease: 'easeInOut',
+                  }}
+                />
+              ))}
+            </motion.div>
+            <motion.h1
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.1, duration: 0.3 }}
+              className="text-3xl font-bold tracking-tighter text-[var(--foreground)] mb-2"
+              style={{ fontFamily: 'var(--font-display)' }}
+            >
               GRIP
-            </h1>
-            <p className="font-mono text-xs tracking-widest text-[var(--muted-foreground)] mb-8">
+            </motion.h1>
+            <motion.p
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.15, duration: 0.3 }}
+              className="font-mono text-xs tracking-widest text-[var(--muted-foreground)] mb-8"
+            >
               KNOWLEDGE WORK ENGINE
-            </p>
-            <p className="text-center text-[var(--muted-foreground)] mb-8 max-w-md">
+            </motion.p>
+            <motion.p
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.2, duration: 0.3 }}
+              className="text-center text-[var(--muted-foreground)] mb-8 max-w-md"
+            >
               Your AI thinking partner. Connected to your local GRIP instance
               with all skills, modes, and safety gates active.
-            </p>
+            </motion.p>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 w-full max-w-lg">
-              {SUGGESTED_PROMPTS.map((prompt) => (
-                <button
+              {SUGGESTED_PROMPTS.map((prompt, i) => (
+                <motion.button
                   key={prompt.text}
+                  initial={{ opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.25 + i * 0.05, duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
                   onClick={() => handleSuggestedPrompt(prompt.text)}
-                  className="flex items-start gap-3 p-4 border border-[var(--border)] hover:border-[var(--primary)] transition-colors text-left group"
+                  className="flex items-start gap-3 p-4 border border-[var(--border)] hover:border-[var(--primary)] hover:-translate-y-px transition-all text-left group"
                 >
                   <span className="font-mono text-xs text-[var(--primary)] mt-0.5 shrink-0 w-4">
                     {prompt.icon}
@@ -311,17 +357,29 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
                   <span className="text-sm text-[var(--muted-foreground)] group-hover:text-[var(--foreground)] transition-colors">
                     {prompt.text}
                   </span>
-                </button>
+                </motion.button>
               ))}
             </div>
-            <p className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] mt-8 opacity-60">
+            <motion.p
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 0.6 }}
+              transition={{ delay: 0.5, duration: 0.4 }}
+              className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] mt-8"
+            >
               CMD+K FOR COMMANDS | LOCAL GRIP BACKEND | REAL-TIME STREAMING
-            </p>
+            </motion.p>
           </div>
         ) : (
           <div className="max-w-3xl mx-auto space-y-6">
+            <AnimatePresence initial={false}>
             {messages.map((msg) => (
-              <div key={msg.id} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+              <motion.div
+                key={msg.id}
+                initial={{ opacity: 0, x: msg.role === 'user' ? 12 : -12 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: msg.role === 'user' ? 0.2 : 0.25, ease: [0.16, 1, 0.3, 1] }}
+                className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
+              >
                 <div className="max-w-[85%]">
                   {/* Auto-detection badges */}
                   {msg.detectedMode && !msg.streaming && (
@@ -377,19 +435,11 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
                     )}
                   </div>
                 </div>
-              </div>
+              </motion.div>
             ))}
+            </AnimatePresence>
             {isStreaming && showSpinner && messages[messages.length - 1]?.content === '' && (
-              <div className="flex justify-start">
-                <div className="border border-[var(--border)] p-4">
-                  <div className="flex items-center gap-2">
-                    <TerminalIcon className="w-3 h-3 text-[var(--primary)] animate-pulse" />
-                    <span className="font-mono text-xs text-[var(--muted-foreground)]">
-                      GRIP is processing...
-                    </span>
-                  </div>
-                </div>
-              </div>
+              <TypingIndicator />
             )}
             <div ref={messagesEndRef} />
           </div>

--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -58,9 +58,18 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const rafIdRef = useRef<number | null>(null);
+  const pendingContentRef = useRef('');
+  const scrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    if (scrollTimerRef.current) clearTimeout(scrollTimerRef.current);
+    scrollTimerRef.current = setTimeout(() => {
+      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }, 80);
+    return () => {
+      if (scrollTimerRef.current) clearTimeout(scrollTimerRef.current);
+    };
   }, [messages]);
 
   const handleSend = useCallback(async () => {
@@ -121,14 +130,10 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
             setShowSpinner(false);
           }
           fullText += event.data as string;
-          setMessages(prev => {
-            const updated = [...prev];
-            const lastMsg = updated[updated.length - 1];
-            if (lastMsg.role === 'assistant') {
-              lastMsg.content = fullText;
-            }
-            return [...updated];
-          });
+          pendingContentRef.current = fullText;
+          if (rafIdRef.current === null) {
+            rafIdRef.current = requestAnimationFrame(flushStreamUpdate);
+          }
         } else if (event.type === 'metrics') {
           metrics = event.data as GripMetrics;
           if (metrics.sessionId) {
@@ -136,18 +141,20 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
           }
         } else if (event.type === 'error') {
           fullText += `\n[GRIP Error: ${event.data}]`;
-          setMessages(prev => {
-            const updated = [...prev];
-            const lastMsg = updated[updated.length - 1];
-            if (lastMsg.role === 'assistant') {
-              lastMsg.content = fullText;
-            }
-            return [...updated];
-          });
+          pendingContentRef.current = fullText;
+          if (rafIdRef.current === null) {
+            rafIdRef.current = requestAnimationFrame(flushStreamUpdate);
+          }
         }
       }
     } catch (err) {
       fullText += `\n[Connection error: ${err instanceof Error ? err.message : String(err)}]`;
+    }
+
+    // Flush any pending RAF update before finalising
+    if (rafIdRef.current !== null) {
+      cancelAnimationFrame(rafIdRef.current);
+      rafIdRef.current = null;
     }
 
     // Finalise the message and persist
@@ -174,11 +181,24 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
       clearTimeout(spinnerTimerRef.current);
       spinnerTimerRef.current = null;
     }
-  }, [input, isStreaming, sessionId, model, currentChatId, messages]);
+  }, [input, isStreaming, sessionId, model, currentChatId, messages, flushStreamUpdate]);
 
   const handleStop = useCallback(() => {
     abortRef.current?.abort();
     setIsStreaming(false);
+  }, []);
+
+  const flushStreamUpdate = useCallback(() => {
+    rafIdRef.current = null;
+    const text = pendingContentRef.current;
+    setMessages(prev => {
+      const updated = [...prev];
+      const lastMsg = updated[updated.length - 1];
+      if (lastMsg?.role === 'assistant') {
+        lastMsg.content = text;
+      }
+      return updated;
+    });
   }, []);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/src/components/Engine/MarkdownContent.tsx
+++ b/src/components/Engine/MarkdownContent.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import React, { useMemo, memo } from 'react';
+
 /**
  * Lightweight markdown renderer for GRIP chat messages.
  * No external dependencies — uses regex-based parsing.
@@ -19,116 +21,122 @@ interface MarkdownContentProps {
   content: string;
 }
 
-export default function MarkdownContent({ content }: MarkdownContentProps) {
-  const blocks = content.split('\n');
-  const elements: React.ReactNode[] = [];
-  let inCodeBlock = false;
-  let codeBuffer: string[] = [];
-  let codeLanguage = '';
+function MarkdownContent({ content }: MarkdownContentProps) {
+  const elements = useMemo(() => {
+    const blocks = content.split('\n');
+    const result: React.ReactNode[] = [];
+    let inCodeBlock = false;
+    let codeBuffer: string[] = [];
+    let codeLanguage = '';
 
-  for (let i = 0; i < blocks.length; i++) {
-    const line = blocks[i];
+    for (let i = 0; i < blocks.length; i++) {
+      const line = blocks[i];
 
-    // Code block toggle
-    if (line.startsWith('```')) {
-      if (inCodeBlock) {
-        elements.push(
-          <pre key={`code-${i}`} className="bg-black text-[var(--primary)] p-4 font-mono text-xs overflow-x-auto my-2 border border-[var(--border)]">
-            {codeLanguage && (
-              <span className="font-mono text-[8px] tracking-widest text-[var(--muted-foreground)] block mb-2">
-                {codeLanguage.toUpperCase()}
-              </span>
-            )}
-            <code>{codeBuffer.join('\n')}</code>
-          </pre>
-        );
-        codeBuffer = [];
-        codeLanguage = '';
-        inCodeBlock = false;
-      } else {
-        inCodeBlock = true;
-        codeLanguage = line.slice(3).trim();
+      // Code block toggle
+      if (line.startsWith('```')) {
+        if (inCodeBlock) {
+          result.push(
+            <pre key={`code-${i}`} className="bg-black text-[var(--primary)] p-4 font-mono text-xs overflow-x-auto my-2 border border-[var(--border)]">
+              {codeLanguage && (
+                <span className="font-mono text-[8px] tracking-widest text-[var(--muted-foreground)] block mb-2">
+                  {codeLanguage.toUpperCase()}
+                </span>
+              )}
+              <code>{codeBuffer.join('\n')}</code>
+            </pre>
+          );
+          codeBuffer = [];
+          codeLanguage = '';
+          inCodeBlock = false;
+        } else {
+          inCodeBlock = true;
+          codeLanguage = line.slice(3).trim();
+        }
+        continue;
       }
-      continue;
-    }
 
-    if (inCodeBlock) {
-      codeBuffer.push(line);
-      continue;
-    }
+      if (inCodeBlock) {
+        codeBuffer.push(line);
+        continue;
+      }
 
-    // Empty line
-    if (!line.trim()) {
-      elements.push(<div key={`br-${i}`} className="h-2" />);
-      continue;
-    }
+      // Empty line
+      if (!line.trim()) {
+        result.push(<div key={`br-${i}`} className="h-2" />);
+        continue;
+      }
 
-    // Headings
-    if (line.startsWith('### ')) {
-      elements.push(
-        <h3 key={`h3-${i}`} className="text-sm font-bold tracking-tighter text-[var(--foreground)] mt-3 mb-1">
-          {renderInline(line.slice(4))}
-        </h3>
+      // Headings
+      if (line.startsWith('### ')) {
+        result.push(
+          <h3 key={`h3-${i}`} className="text-sm font-bold tracking-tighter text-[var(--foreground)] mt-3 mb-1">
+            {renderInline(line.slice(4))}
+          </h3>
+        );
+        continue;
+      }
+      if (line.startsWith('## ')) {
+        result.push(
+          <h2 key={`h2-${i}`} className="text-base font-bold tracking-tighter text-[var(--foreground)] mt-3 mb-1">
+            {renderInline(line.slice(3))}
+          </h2>
+        );
+        continue;
+      }
+      if (line.startsWith('# ')) {
+        result.push(
+          <h1 key={`h1-${i}`} className="text-lg font-bold tracking-tighter text-[var(--foreground)] mt-3 mb-1">
+            {renderInline(line.slice(2))}
+          </h1>
+        );
+        continue;
+      }
+
+      // Blockquote
+      if (line.startsWith('> ')) {
+        result.push(
+          <blockquote key={`bq-${i}`} className="border-l-2 border-[var(--primary)] pl-3 text-[var(--muted-foreground)] italic text-sm my-1">
+            {renderInline(line.slice(2))}
+          </blockquote>
+        );
+        continue;
+      }
+
+      // Bullet list
+      if (line.match(/^[-*] /)) {
+        result.push(
+          <div key={`li-${i}`} className="flex items-start gap-2 text-sm">
+            <span className="text-[var(--primary)] font-mono mt-0.5 shrink-0">-</span>
+            <span>{renderInline(line.slice(2))}</span>
+          </div>
+        );
+        continue;
+      }
+
+      // Regular paragraph
+      result.push(
+        <p key={`p-${i}`} className="text-sm leading-relaxed">
+          {renderInline(line)}
+        </p>
       );
-      continue;
-    }
-    if (line.startsWith('## ')) {
-      elements.push(
-        <h2 key={`h2-${i}`} className="text-base font-bold tracking-tighter text-[var(--foreground)] mt-3 mb-1">
-          {renderInline(line.slice(3))}
-        </h2>
-      );
-      continue;
-    }
-    if (line.startsWith('# ')) {
-      elements.push(
-        <h1 key={`h1-${i}`} className="text-lg font-bold tracking-tighter text-[var(--foreground)] mt-3 mb-1">
-          {renderInline(line.slice(2))}
-        </h1>
-      );
-      continue;
     }
 
-    // Blockquote
-    if (line.startsWith('> ')) {
-      elements.push(
-        <blockquote key={`bq-${i}`} className="border-l-2 border-[var(--primary)] pl-3 text-[var(--muted-foreground)] italic text-sm my-1">
-          {renderInline(line.slice(2))}
-        </blockquote>
+    // Handle unclosed code block
+    if (inCodeBlock && codeBuffer.length > 0) {
+      result.push(
+        <pre key="code-unclosed" className="bg-black text-[var(--primary)] p-4 font-mono text-xs overflow-x-auto my-2 border border-[var(--border)]">
+          <code>{codeBuffer.join('\n')}</code>
+        </pre>
       );
-      continue;
     }
 
-    // Bullet list
-    if (line.match(/^[-*] /)) {
-      elements.push(
-        <div key={`li-${i}`} className="flex items-start gap-2 text-sm">
-          <span className="text-[var(--primary)] font-mono mt-0.5 shrink-0">-</span>
-          <span>{renderInline(line.slice(2))}</span>
-        </div>
-      );
-      continue;
-    }
-
-    // Regular paragraph
-    elements.push(
-      <p key={`p-${i}`} className="text-sm leading-relaxed">
-        {renderInline(line)}
-      </p>
-    );
-  }
-
-  // Handle unclosed code block
-  if (inCodeBlock && codeBuffer.length > 0) {
-    elements.push(
-      <pre key="code-unclosed" className="bg-black text-[var(--primary)] p-4 font-mono text-xs overflow-x-auto my-2 border border-[var(--border)]">
-        <code>{codeBuffer.join('\n')}</code>
-      </pre>
-    );
-  }
+    return result;
+  }, [content]);
 
   return <div className="space-y-0.5">{elements}</div>;
 }
+
+export default memo(MarkdownContent);
 
 /**
  * Render inline markdown: bold, italic, code, links.

--- a/src/components/Engine/TypingIndicator.tsx
+++ b/src/components/Engine/TypingIndicator.tsx
@@ -24,7 +24,7 @@ export default function TypingIndicator() {
   useEffect(() => {
     const interval = setInterval(() => {
       setStateIndex(prev => (prev + 1) % PROCESSING_STATES.length);
-    }, 2500);
+    }, 3500);
     return () => clearInterval(interval);
   }, []);
 
@@ -33,17 +33,17 @@ export default function TypingIndicator() {
       <div className="border border-[var(--border)] p-4">
         <div className="flex items-center gap-3">
           {/* Three pulsing bars — sharp, not round */}
-          <div className="flex items-end gap-0.5 h-3">
+          <div className="flex items-end gap-0.5 h-4">
             {[0, 1, 2].map(i => (
               <motion.div
                 key={i}
                 className="w-1 bg-[var(--primary)]"
-                animate={{ height: ['4px', '12px', '4px'] }}
+                animate={{ height: ['3px', '16px', '3px'] }}
                 transition={{
                   repeat: Infinity,
                   duration: 0.8,
                   delay: i * 0.15,
-                  ease: 'easeInOut',
+                  ease: [0.16, 1, 0.3, 1],
                 }}
               />
             ))}
@@ -56,7 +56,7 @@ export default function TypingIndicator() {
               initial={{ opacity: 0, y: 4 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -4 }}
-              transition={{ duration: 0.15 }}
+              transition={{ duration: 0.25 }}
               className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]"
             >
               {PROCESSING_STATES[stateIndex]}

--- a/src/components/Engine/TypingIndicator.tsx
+++ b/src/components/Engine/TypingIndicator.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+const PROCESSING_STATES = [
+  'CONVERGING...',
+  'EVALUATING SAFETY GATES...',
+  'APPLYING GRIP-FIRST RETRIEVAL...',
+  'SEARCHING SKILL GRAPH...',
+  'SYNTHESISING RESPONSE...',
+  'CHECKING CONFIDENCE GATE...',
+  'TRAVERSING CONTEXT...',
+];
+
+/**
+ * Typing indicator with GRIP personality.
+ * Three sharp cyan rectangles pulse in sequence (not dots — Swiss Nihilism).
+ * Status messages rotate every 2.5s, providing ambient GRIP system awareness.
+ */
+export default function TypingIndicator() {
+  const [stateIndex, setStateIndex] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setStateIndex(prev => (prev + 1) % PROCESSING_STATES.length);
+    }, 2500);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="flex justify-start">
+      <div className="border border-[var(--border)] p-4">
+        <div className="flex items-center gap-3">
+          {/* Three pulsing bars — sharp, not round */}
+          <div className="flex items-end gap-0.5 h-3">
+            {[0, 1, 2].map(i => (
+              <motion.div
+                key={i}
+                className="w-1 bg-[var(--primary)]"
+                animate={{ height: ['4px', '12px', '4px'] }}
+                transition={{
+                  repeat: Infinity,
+                  duration: 0.8,
+                  delay: i * 0.15,
+                  ease: 'easeInOut',
+                }}
+              />
+            ))}
+          </div>
+
+          {/* Rotating status message */}
+          <AnimatePresence mode="wait">
+            <motion.span
+              key={stateIndex}
+              initial={{ opacity: 0, y: 4 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -4 }}
+              transition={{ duration: 0.15 }}
+              className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]"
+            >
+              {PROCESSING_STATES[stateIndex]}
+            </motion.span>
+          </AnimatePresence>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/grip-session.ts
+++ b/src/lib/grip-session.ts
@@ -291,14 +291,28 @@ async function* sendToGripElectron(
   }
 
   try {
-    // Use one-shot prompt mode (spawns claude -p with stream-json)
-    const result = await api.prompt({ prompt, model, sessionId });
-    if (!result.success) {
-      yield { type: 'error', data: result.error || 'Failed to start prompt' };
+    // Try persistent stream session first (ultra-fast, no cold start)
+    // Falls back to one-shot if stream session fails
+    let result: { success: boolean; sessionId?: string; error?: string };
+    let usingStreamSession = false;
+
+    if (api.streamMessage && !sessionId) {
+      // Persistent session doesn't support --resume, so only use for non-resumed messages
+      result = await api.streamMessage({ prompt, model });
+      usingStreamSession = result.success;
+    }
+
+    if (!usingStreamSession) {
+      // Fallback: one-shot prompt (spawns claude -p with stream-json)
+      result = await api.prompt({ prompt, model, sessionId });
+    }
+
+    if (!result!.success) {
+      yield { type: 'error', data: result!.error || 'Failed to start prompt' };
       return;
     }
 
-    const promptSessionId = result.sessionId;
+    const promptSessionId = result!.sessionId!;
     onPromptSessionId?.(promptSessionId);
 
     // Collect output via events using a promise-based queue

--- a/src/lib/grip-session.ts
+++ b/src/lib/grip-session.ts
@@ -24,6 +24,7 @@ export interface GripMessage {
   detectedSkills?: string[];
   metrics?: GripMetrics;
   streaming?: boolean;
+  imageDataUrl?: string;
 }
 
 export interface GripMetrics {
@@ -73,13 +74,46 @@ export function stripAnsi(text: string): string {
 }
 
 /**
+ * Detect CLI noise lines that should not be shown in the chat UI.
+ * These are status/progress messages from the claude CLI or stderr.
+ */
+function isCliNoise(line: string): boolean {
+  const noisePatterns = [
+    /^[╭╰│├└─]/,                     // Box-drawing characters (CLI UI frames)
+    /^─+$/,                            // Horizontal rules
+    /^\s*\d+%/,                        // Progress percentages
+    /^(connecting|loading|starting|initializing|resolving)/i,
+    /^session\s+(id|started|resumed)/i,
+    /^(model|using|warning):\s/i,
+    /^\s*$/,                           // Whitespace-only
+  ];
+  return noisePatterns.some(p => p.test(line));
+}
+
+/**
+ * Filter non-JSON lines — only allow through genuine human-readable text.
+ */
+function isAllowedNonJsonLine(line: string): boolean {
+  const cleaned = stripAnsi(line);
+  if (!cleaned) return false;
+  // Skip JSON fragments
+  if (cleaned.startsWith('{') || cleaned.startsWith('[') || cleaned.startsWith('"')) return false;
+  // Skip raw primitives
+  if (/^\s*(true|false|null|\d+)\s*$/.test(cleaned)) return false;
+  // Skip CLI noise
+  if (isCliNoise(cleaned)) return false;
+  return true;
+}
+
+/**
  * Extract text content from a stream-json event.
  * Handles multiple event shapes from Claude CLI output.
  */
 export function extractTextFromEvent(event: StreamEvent): string | null {
   // Skip non-text events entirely — these should NEVER be shown to the user
   const skipTypes = ['system', 'init', 'tool_use', 'tool_result', 'content_block_start',
-    'content_block_stop', 'message_start', 'message_stop', 'ping'];
+    'content_block_stop', 'message_start', 'message_stop', 'ping',
+    'result', 'error', 'input_json'];
   if (skipTypes.includes(event.type)) return null;
   // Also skip if event has subtype 'init' (system init events)
   if ((event as unknown as Record<string, unknown>).subtype === 'init') return null;
@@ -135,15 +169,18 @@ export function isElectronEnv(): boolean {
  * In Electron: uses IPC to grip-engine-handlers (PTY-based, ultra-fast).
  * In Browser: uses /api/grip/chat API route (spawns claude -p).
  * Returns an async iterator of text chunks for streaming display.
+ *
+ * @param onPromptSessionId - Called with the prompt session ID once available (for stop button)
  */
 export async function* sendToGrip(
   prompt: string,
   sessionId?: string,
   model: string = 'sonnet',
+  onPromptSessionId?: (id: string) => void,
 ): AsyncGenerator<{ type: 'text' | 'metrics' | 'error' | 'done'; data: string | GripMetrics }> {
   // Electron path: use IPC for real PTY streaming
   if (isElectronEnv()) {
-    yield* sendToGripElectron(prompt, sessionId, model);
+    yield* sendToGripElectron(prompt, sessionId, model, onPromptSessionId);
     return;
   }
 
@@ -197,25 +234,25 @@ export async function* sendToGrip(
             yield { type: 'metrics', data: metrics };
           }
         } catch {
-          // Non-JSON line — strip ANSI, skip raw JSON fragments
-          const cleaned = stripAnsi(line);
-          if (cleaned && !cleaned.startsWith('{') && !cleaned.startsWith('[')) {
-            yield { type: 'text', data: cleaned };
+          // Non-JSON line — only forward genuine human-readable text
+          if (isAllowedNonJsonLine(line)) {
+            yield { type: 'text', data: stripAnsi(line) };
           }
         }
       }
     }
 
-    // Process remaining buffer — strip raw JSON fragments
+    // Process remaining buffer
     if (buffer.trim()) {
       try {
         const event: StreamEvent = JSON.parse(buffer);
         const text = extractTextFromEvent(event);
         if (text) yield { type: 'text', data: text };
+        const metrics = extractMetrics(event);
+        if (metrics) yield { type: 'metrics', data: metrics };
       } catch {
-        const cleaned = stripAnsi(buffer);
-        if (cleaned && !cleaned.startsWith('{') && !cleaned.startsWith('[')) {
-          yield { type: 'text', data: cleaned };
+        if (isAllowedNonJsonLine(buffer)) {
+          yield { type: 'text', data: stripAnsi(buffer) };
         }
       }
     }
@@ -227,13 +264,15 @@ export async function* sendToGrip(
 }
 
 /**
- * Electron IPC path — uses grip: handlers for PTY-based streaming.
- * Collects output via event listeners, yields as text chunks.
+ * Electron IPC path — uses grip: handlers for one-shot streaming.
+ * Collects output via event listeners, yields as text/metrics chunks.
+ * Line-buffers IPC chunks to prevent partial JSON from leaking through.
  */
 async function* sendToGripElectron(
   prompt: string,
   sessionId?: string,
   model: string = 'sonnet',
+  onPromptSessionId?: (id: string) => void,
 ): AsyncGenerator<{ type: 'text' | 'metrics' | 'error' | 'done'; data: string | GripMetrics }> {
   // Wait up to 2s for preload bridge to initialise (app:// protocol timing)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -260,43 +299,60 @@ async function* sendToGripElectron(
     }
 
     const promptSessionId = result.sessionId;
+    onPromptSessionId?.(promptSessionId);
 
     // Collect output via events using a promise-based queue
-    const chunks: Array<{ type: 'text' | 'done'; data: string }> = [];
+    type ChunkType = 'text' | 'metrics' | 'done';
+    const chunks: Array<{ type: ChunkType; data: string | GripMetrics }> = [];
     let resolve: (() => void) | null = null;
     let done = false;
+    // Line buffer: accumulate partial IPC chunks until we get complete lines
+    let lineBuffer = '';
+
+    const pushChunk = (type: ChunkType, data: string | GripMetrics) => {
+      chunks.push({ type, data });
+      if (resolve) { resolve(); resolve = null; }
+    };
+
+    const processLine = (line: string) => {
+      if (!line.trim()) return;
+      try {
+        const parsed: StreamEvent = JSON.parse(line);
+        const text = extractTextFromEvent(parsed);
+        if (text) pushChunk('text', text);
+        const metrics = extractMetrics(parsed);
+        if (metrics) pushChunk('metrics', metrics);
+      } catch {
+        // Non-JSON line — only forward genuine human-readable text
+        if (isAllowedNonJsonLine(line)) {
+          pushChunk('text', stripAnsi(line));
+        }
+      }
+    };
 
     const unsubOutput = api.onPromptOutput((event: { sessionId: string; data: string }) => {
       if (event.sessionId !== promptSessionId) return;
 
-      // Parse stream-json lines
-      const lines = event.data.split('\n');
+      // Accumulate into line buffer and process complete lines
+      lineBuffer += event.data;
+      const lines = lineBuffer.split('\n');
+      // Keep the last (potentially incomplete) segment in the buffer
+      lineBuffer = lines.pop() || '';
+
       for (const line of lines) {
-        if (!line.trim()) continue;
-        try {
-          const parsed: StreamEvent = JSON.parse(line);
-          const text = extractTextFromEvent(parsed);
-          if (text) {
-            chunks.push({ type: 'text', data: text });
-            if (resolve) { resolve(); resolve = null; }
-          }
-        } catch {
-          // Non-JSON line — strip ANSI and only forward if it has real content
-          const cleaned = stripAnsi(line);
-          // Skip raw JSON objects that failed to parse (init events, etc.)
-          if (cleaned && !cleaned.startsWith('{') && !cleaned.startsWith('[')) {
-            chunks.push({ type: 'text', data: cleaned });
-            if (resolve) { resolve(); resolve = null; }
-          }
-        }
+        processLine(line);
       }
     });
 
     const unsubDone = api.onPromptDone((event: { sessionId: string; exitCode: number }) => {
       if (event.sessionId !== promptSessionId) return;
+      // Process any remaining buffered content
+      if (lineBuffer.trim()) {
+        processLine(lineBuffer);
+        lineBuffer = '';
+      }
       done = true;
-      chunks.push({ type: 'done', data: '' });
-      if (resolve) { resolve(); resolve = null; }
+      pushChunk('done', '');
     });
 
     // Yield chunks as they arrive
@@ -305,7 +361,7 @@ async function* sendToGripElectron(
         if (chunks.length > 0) {
           const chunk = chunks.shift()!;
           if (chunk.type === 'done') break;
-          yield { type: 'text', data: chunk.data };
+          yield { type: chunk.type as 'text' | 'metrics', data: chunk.data };
         } else {
           // Wait for next chunk
           await new Promise<void>(r => { resolve = r; });


### PR DESCRIPTION
## Summary

7-wave performance and UX sprint for GRIP Commander:

- **V8 JIT recovery**: Replace unconditional `--jitless` with conditional. Development gets full JIT, production uses `--no-v8-untrusted-code-mitigations`. Estimated 10-100x JS performance improvement.
- **Persistent streaming session**: `claude -p --input-format stream-json --output-format stream-json` keeps context alive between messages. Eliminates 2-3s cold start per turn. Pre-warms on app launch.
- **Session dump filtering**: `isCliNoise()` filter, tightened `extractTextFromEvent`, line buffering for partial IPC chunks. No more raw JSON or CLI noise before real output.
- **Image paste + drag-and-drop**: Clipboard image paste, drag-and-drop, preview strip, temp file save via IPC, images in messages.
- **Stop button**: `grip:killPrompt` IPC tracks and terminates active child processes.
- **Navigation guards**: Whitelist localhost/app:// only, external URLs open in system browser, validate `app:openExternal`.
- **IPC batching**: 16ms stdout buffer reduces IPC call count by ~50-80%.
- **Deferred service init**: Telegram, Slack, MCP orchestrator defer 3s after window.
- **UX delight**: Framer-motion message animations, typing indicator with GRIP personality, atmospheric welcome screen, live status bar.
- **Code splitting**: `optimizePackageImports` for framer-motion and lucide-react.

## Hypothesis

**H-GRIP-FAST-001**: Persistent streaming session reduces follow-up TTFT from ~2500ms to <500ms.

## Test plan

- [ ] `npm run dev` — Next.js dev server works
- [ ] `npm run electron:dev` — Electron app launches
- [ ] Click external link in chat response — opens in system browser
- [ ] Stop button kills running prompt (Electron only)
- [ ] Send message — no JSON fragments before response text
- [ ] Paste/drag image — preview shows, sends with prompt
- [ ] Send follow-up message — response in <500ms (Electron with persistent session)
- [ ] Welcome screen — animated pulse bars, staggered reveal
- [ ] Typing indicator — three pulsing bars, rotating status messages
- [ ] Status bar — shows real skill count from GRIP health API