### PR TITLE
fix: flushStreamUpdate TDZ error in Engine chat

### DIFF
--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -78,6 +78,19 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
     };
   }, [messages]);
 
+  const flushStreamUpdate = useCallback(() => {
+    rafIdRef.current = null;
+    const text = pendingContentRef.current;
+    setMessages(prev => {
+      const updated = [...prev];
+      const lastMsg = updated[updated.length - 1];
+      if (lastMsg?.role === 'assistant') {
+        lastMsg.content = text;
+      }
+      return updated;
+    });
+  }, []);
+
   const handleSend = useCallback(async () => {
     if (!input.trim() || isStreaming) return;
 
@@ -211,19 +224,6 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
     }
     setIsStreaming(false);
     setShowSpinner(false);
-  }, []);
-
-  const flushStreamUpdate = useCallback(() => {
-    rafIdRef.current = null;
-    const text = pendingContentRef.current;
-    setMessages(prev => {
-      const updated = [...prev];
-      const lastMsg = updated[updated.length - 1];
-      if (lastMsg?.role === 'assistant') {
-        lastMsg.content = text;
-      }
-      return updated;
-    });
   }, []);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {


### PR DESCRIPTION
## Summary

- Move `flushStreamUpdate` definition above `handleSend` to fix `ReferenceError: Cannot access 'flushStreamUpdate' before initialization`
- `const` declarations are not hoisted — temporal dead zone (TDZ) causes runtime crash when referenced before definition in `useCallback` dependency array

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] `npm run dev` — no 500 errors on page load
- [ ] Send a message — streaming works with RAF-batched updates