### PR TITLE
fix: disable broken persistent stream session, use proven one-shot path

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -564,11 +564,9 @@ app.whenReady().then(async () => {
     saveAgents,
   });
 
-  // Pre-warm a GRIP Engine session for instant first response (2s delay to not block window)
-  setTimeout(() => {
-    const { preWarmSession } = require('./handlers/grip-engine-handlers');
-    preWarmSession('sonnet');
-  }, 2000);
+  // NOTE: Pre-warm disabled — stream-json input protocol needs investigation.
+  // One-shot grip:prompt with --resume is used for now.
+  // TODO: Re-enable when stream-json input format is confirmed.
 
   // Defer non-essential services to speed up window appearance
   setTimeout(async () => {

--- a/src/lib/grip-session.ts
+++ b/src/lib/grip-session.ts
@@ -297,12 +297,12 @@ async function* sendToGripElectron(
     // correct JSON schema. One-shot with --resume is reliable.
     const result = await api.prompt({ prompt, model, sessionId });
 
-    if (!result!.success) {
-      yield { type: 'error', data: result!.error || 'Failed to start prompt' };
+    if (!result.success) {
+      yield { type: 'error', data: result.error || 'Failed to start prompt' };
       return;
     }
 
-    const promptSessionId = result!.sessionId!;
+    const promptSessionId = result.sessionId!;
     onPromptSessionId?.(promptSessionId);
 
     // Collect output via events using a promise-based queue

--- a/src/lib/grip-session.ts
+++ b/src/lib/grip-session.ts
@@ -291,21 +291,11 @@ async function* sendToGripElectron(
   }
 
   try {
-    // Try persistent stream session first (ultra-fast, no cold start)
-    // Falls back to one-shot if stream session fails
-    let result: { success: boolean; sessionId?: string; error?: string };
-    let usingStreamSession = false;
-
-    if (api.streamMessage && !sessionId) {
-      // Persistent session doesn't support --resume, so only use for non-resumed messages
-      result = await api.streamMessage({ prompt, model });
-      usingStreamSession = result.success;
-    }
-
-    if (!usingStreamSession) {
-      // Fallback: one-shot prompt (spawns claude -p with stream-json)
-      result = await api.prompt({ prompt, model, sessionId });
-    }
+    // Use one-shot prompt mode (spawns claude -p with stream-json)
+    // NOTE: Persistent stream session (streamMessage) disabled — the
+    // --input-format stream-json protocol needs investigation for the
+    // correct JSON schema. One-shot with --resume is reliable.
+    const result = await api.prompt({ prompt, model, sessionId });
 
     if (!result!.success) {
       yield { type: 'error', data: result!.error || 'Failed to start prompt' };


### PR DESCRIPTION
## Summary

- Disable `grip:streamMessage` persistent session path — `--input-format stream-json` doesn't respond to our input JSON schema, causing chat to hang indefinitely on typing indicator
- Disable session pre-warm in main.ts (was spawning unused process)
- Falls back to proven one-shot `grip:prompt` with `--resume` for session continuity
- Infrastructure remains in place for re-enabling when protocol is confirmed

## Root cause

The persistent `claude -p --input-format stream-json` process accepts stdin writes without error but never produces stdout output. The correct JSON input schema for stream-json mode needs investigation.

## Test plan

- [ ] Send "hello" in GRIP Commander — response streams back
- [ ] Follow-up messages work (--resume path)
- [ ] Stop button works
- [ ] No hanging typing indicator