### PR TITLE
feat: chat engine parity + README overhaul + distribution model

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ GRIP Commander bundles MCP servers for programmatic control:
 
 ## Getting Started
 
+### Prerequisites
+
+- **Node.js** 18+
+- **Claude Code CLI**: `npm install -g @anthropic-ai/claude-code`
+- **Claude login**: `claude login` (each user authenticates with their own Anthropic account)
+
 ### Install from DMG
 
 1. [Download the DMG](https://github.com/CodeTonight-SA/GRIP-GUI/releases/download/v0.1.0-alpha.1/GRIP-Commander-0.1.0-arm64.dmg)
@@ -185,6 +191,60 @@ npm install && npm run dev
 ```
 
 Agent management requires the Electron app. The web UI at [localhost:3000](http://localhost:3000) provides the learning hub and mode switcher.
+
+---
+
+## GRIP CLI — Session Context Inheritance
+
+GRIP Commander agents use the GRIP CLI binaries at `~/.claude/bin/` for session memory and context inheritance. Without these, agents start cold every time. With them, agents inherit context from previous sessions.
+
+### Binaries
+
+| Binary | Purpose |
+|--------|---------|
+| `grip` | Session manager — resume, fresh, list, branches, merge, tree |
+| `grip-ut` | Extended thinking wrapper — injects 12k tokens of prior session context |
+
+### Shell Aliases
+
+Install aliases for quick session launches:
+
+```bash
+grip install-aliases
+```
+
+| Alias | Command | Purpose |
+|-------|---------|---------|
+| `gg++` | `grip fresh latest 12000` | Max context session (12k tokens from prior session) |
+| `gg+` | `grip fresh latest 8000` | Deep session (8k context) |
+| `gg` | `grip fresh latest 2000` | Quick session (2k context) |
+| `ggr` | `grip resume latest` | Resume last session directly |
+| `ggl` | `grip list` | List available sessions |
+
+### How Context Inheritance Works
+
+```
+Previous session ends
+  → session state serialised to ~/.claude/projects/*/grip/
+  → next session starts via gg++ (or grip fresh)
+    → session-resolver.py finds latest session
+    → semantic-compressor.py extracts 12k tokens of context
+    → context injected as resurrection prompt
+    → Claude starts with full awareness of prior work
+```
+
+This is what makes GRIP agents different from bare Claude Code — they remember decisions, architectural choices, and debugging history across sessions.
+
+### Shell Functions
+
+For shell-level integration, source the GRIP functions:
+
+```bash
+# Add to ~/.zshrc or ~/.bashrc
+source ~/.claude/lib/shell-functions.sh
+```
+
+This provides `gogrip` (navigate to GRIP home + fresh session) and ensures `~/.claude/bin` is on your PATH.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,27 @@ Claude Code runs one agent at a time, in one terminal. GRIP Commander removes th
 
 ---
 
+## What's Included
+
+### Starter Pack (ships with Commander)
+
+GRIP Commander includes a curated subset of the GRIP ecosystem that works out of the box.
+
+| Component | Count | Includes |
+|-----------|-------|---------|
+| Skills | 15 | code-mode, testing-mode, review-mode, architect-mode, research-mode, design-principles, PR automation, session resume, context refresh, preplan |
+| Agents | 5 | context-refresh, direct-implementation, PR workflow, Explore, efficiency-auditor |
+| Safety hooks | 5 | confidence-gate, context-gate, dependency-guardian, destructive-git, secrets-detection |
+| CLI | 2 | `grip` (session manager), `grip-ut` (extended thinking wrapper) |
+
+### Full GRIP (by invitation)
+
+The complete GRIP operating system — 194 skills, 30 agents, 34 safety hooks, 25 convergence modules, evolutionary genome, KONO semantic memory, Broly meta-agent, and scientific measurement protocol.
+
+**This is a taste. [Request an invitation](https://grip-preview.vercel.app#invite) for a full 90-day evaluation.**
+
+---
+
 ## Architecture
 
 ### System Overview
@@ -196,7 +217,7 @@ Agent management requires the Electron app. The web UI at [localhost:3000](http:
 
 ## GRIP CLI — Session Context Inheritance
 
-GRIP Commander agents use the GRIP CLI binaries at `~/.claude/bin/` for session memory and context inheritance. Without these, agents start cold every time. With them, agents inherit context from previous sessions.
+The Starter Pack installs automatically on first launch. GRIP Commander agents use the GRIP CLI binaries at `~/.claude/bin/` for session memory and context inheritance. Without these, agents start cold every time. With them, agents inherit context from previous sessions.
 
 ### Binaries
 

--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -3,8 +3,9 @@
 import { useState, useRef, useEffect, useCallback, type ClipboardEvent, type DragEvent } from 'react';
 import { Send, Sparkles, Square, X, Image as ImageIcon } from 'lucide-react';
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
-import { sendToGrip, filterResponseMetadata, type GripMessage, type GripMetrics } from '@/lib/grip-session';
+import { sendToGrip, filterResponseMetadata, type GripMessage, type GripMetrics, type ToolUseEvent, type ToolResultEvent } from '@/lib/grip-session';
 import TypingIndicator from './TypingIndicator';
+import ToolUseBlock from './ToolUseBlock';
 import {
   getChatMessages,
   saveChatMessages,
@@ -181,6 +182,8 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
     let metrics: GripMetrics | undefined;
     let receivedFirstToken = false;
     let lastPersistTime = 0;
+    const toolUses: ToolUseEvent[] = [];
+    const toolResults: ToolResultEvent[] = [];
 
     const promptText = input.trim() + imageContext;
     try {
@@ -210,6 +213,35 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
             lastPersistTime = now;
             persistStreamContent(chatId, pendingContentRef.current, true);
           }
+        } else if (event.type === 'tool_use') {
+          if (!receivedFirstToken) {
+            receivedFirstToken = true;
+            if (spinnerTimerRef.current) {
+              clearTimeout(spinnerTimerRef.current);
+              spinnerTimerRef.current = null;
+            }
+            setShowSpinner(false);
+          }
+          const toolUse = event.data as ToolUseEvent;
+          toolUses.push(toolUse);
+          // Force a re-render to show tool use blocks in real-time
+          setMessages(prev => {
+            const last = prev[prev.length - 1];
+            if (last?.role === 'assistant' && last?.streaming) {
+              return [...prev.slice(0, -1), { ...last, toolUses: [...toolUses] }];
+            }
+            return prev;
+          });
+        } else if (event.type === 'tool_result') {
+          const toolResult = event.data as ToolResultEvent;
+          toolResults.push(toolResult);
+          setMessages(prev => {
+            const last = prev[prev.length - 1];
+            if (last?.role === 'assistant' && last?.streaming) {
+              return [...prev.slice(0, -1), { ...last, toolResults: [...toolResults] }];
+            }
+            return prev;
+          });
         } else if (event.type === 'metrics') {
           metrics = event.data as GripMetrics;
           if (metrics.sessionId) {
@@ -244,6 +276,8 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
         lastMsg.metrics = metrics;
         lastMsg.detectedMode = detectMode(userMessage.content);
         lastMsg.detectedSkills = detectSkills(userMessage.content);
+        if (toolUses.length) lastMsg.toolUses = toolUses;
+        if (toolResults.length) lastMsg.toolResults = toolResults;
       }
       if (chatId) saveChatMessages(chatId, updated);
       return [...updated];
@@ -467,6 +501,18 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
                       </div>
                     )}
                     <MarkdownContent content={msg.content} />
+                    {/* Tool use blocks — show what the agent is doing */}
+                    {msg.toolUses && msg.toolUses.length > 0 && (
+                      <div className="mt-2 space-y-0.5">
+                        {msg.toolUses.map((tu, i) => (
+                          <ToolUseBlock
+                            key={tu.toolId || i}
+                            toolUse={tu}
+                            result={msg.toolResults?.find(r => r.toolId === tu.toolId)}
+                          />
+                        ))}
+                      </div>
+                    )}
                     {msg.streaming && (
                       <span className="inline-block w-2 h-4 bg-[var(--primary)] animate-pulse ml-0.5" />
                     )}

--- a/src/components/Engine/ToolUseBlock.tsx
+++ b/src/components/Engine/ToolUseBlock.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useState } from 'react';
+import type { ToolUseEvent, ToolResultEvent } from '@/lib/grip-session';
+
+interface ToolUseBlockProps {
+  toolUse: ToolUseEvent;
+  result?: ToolResultEvent;
+}
+
+const TOOL_ICONS: Record<string, string> = {
+  Read: 'file',
+  Write: 'pencil',
+  Edit: 'edit',
+  Bash: 'terminal',
+  Grep: 'search',
+  Glob: 'folder',
+  Agent: 'users',
+  WebSearch: 'globe',
+  WebFetch: 'download',
+};
+
+function getToolCategory(name: string): 'file' | 'search' | 'execute' | 'agent' | 'mcp' {
+  if (['Read', 'Write', 'Edit', 'NotebookEdit'].includes(name)) return 'file';
+  if (['Grep', 'Glob', 'WebSearch', 'WebFetch'].includes(name)) return 'search';
+  if (['Bash'].includes(name)) return 'execute';
+  if (['Agent', 'TaskCreate', 'TaskUpdate'].includes(name)) return 'agent';
+  return 'mcp';
+}
+
+function formatToolInput(input: Record<string, unknown>): string {
+  // Show the most relevant field concisely
+  if (input.file_path) return String(input.file_path).replace(/^\/Users\/[^/]+\//, '~/');
+  if (input.command) {
+    const cmd = String(input.command);
+    return cmd.length > 80 ? cmd.slice(0, 77) + '...' : cmd;
+  }
+  if (input.pattern) return `/${input.pattern}/`;
+  if (input.query) return String(input.query).slice(0, 60);
+  if (input.prompt) return String(input.prompt).slice(0, 60) + '...';
+  if (input.description) return String(input.description);
+  const keys = Object.keys(input);
+  if (keys.length === 0) return '';
+  return keys.slice(0, 3).join(', ');
+}
+
+export default function ToolUseBlock({ toolUse, result }: ToolUseBlockProps) {
+  const [expanded, setExpanded] = useState(false);
+  const category = getToolCategory(toolUse.toolName);
+  const summary = formatToolInput(toolUse.input);
+  const isPending = !result;
+  const isError = result?.isError;
+
+  const categoryColors: Record<string, string> = {
+    file: 'text-cyan-400 border-cyan-800',
+    search: 'text-blue-400 border-blue-800',
+    execute: 'text-amber-400 border-amber-800',
+    agent: 'text-purple-400 border-purple-800',
+    mcp: 'text-emerald-400 border-emerald-800',
+  };
+
+  return (
+    <div className={`my-1.5 border-l-2 ${categoryColors[category] || 'border-zinc-700'} bg-zinc-900/50`}>
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center gap-2 px-3 py-1.5 text-left hover:bg-zinc-800/50 transition-colors"
+      >
+        {/* Status indicator */}
+        <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${
+          isPending ? 'bg-amber-400 animate-pulse' :
+          isError ? 'bg-red-400' :
+          'bg-emerald-400'
+        }`} />
+
+        {/* Tool name */}
+        <span className={`font-mono text-xs font-bold ${categoryColors[category]?.split(' ')[0] || 'text-zinc-400'}`}>
+          {toolUse.toolName}
+        </span>
+
+        {/* Summary */}
+        {summary && (
+          <span className="font-mono text-xs text-zinc-500 truncate flex-1">
+            {summary}
+          </span>
+        )}
+
+        {/* Expand chevron */}
+        <span className="text-zinc-600 text-xs flex-shrink-0">
+          {expanded ? '\u25B4' : '\u25BE'}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="px-3 pb-2 space-y-1">
+          {/* Input */}
+          <pre className="text-xs text-zinc-500 overflow-x-auto max-h-40 font-mono">
+            {JSON.stringify(toolUse.input, null, 2)}
+          </pre>
+
+          {/* Result */}
+          {result && (
+            <div className={`text-xs font-mono mt-1 p-2 ${
+              isError ? 'bg-red-950/30 text-red-300' : 'bg-zinc-800/50 text-zinc-400'
+            } max-h-60 overflow-y-auto`}>
+              {result.output.slice(0, 2000)}
+              {result.output.length > 2000 && (
+                <span className="text-zinc-600"> ... ({result.output.length} chars)</span>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/grip-session.ts
+++ b/src/lib/grip-session.ts
@@ -15,6 +15,18 @@
  * - Parse stream events to extract text deltas in real-time
  */
 
+export interface ToolUseEvent {
+  toolName: string;
+  toolId: string;
+  input: Record<string, unknown>;
+}
+
+export interface ToolResultEvent {
+  toolId: string;
+  output: string;
+  isError?: boolean;
+}
+
 export interface GripMessage {
   id: string;
   role: 'user' | 'assistant' | 'system';
@@ -25,6 +37,9 @@ export interface GripMessage {
   metrics?: GripMetrics;
   streaming?: boolean;
   imageDataUrl?: string;
+  toolUses?: ToolUseEvent[];
+  toolResults?: ToolResultEvent[];
+  isThinking?: boolean;
 }
 
 export interface GripMetrics {
@@ -38,14 +53,23 @@ export interface GripMetrics {
 
 export interface StreamEvent {
   type: string;
+  subtype?: string;
   message?: {
-    content: Array<{ type: string; text?: string }>;
+    content: Array<{ type: string; text?: string; name?: string; id?: string; input?: Record<string, unknown> }>;
   };
   delta?: {
     type: string;
     text?: string;
   };
   text?: string;
+  // tool_use fields
+  name?: string;
+  id?: string;
+  input?: Record<string, unknown>;
+  tool_use_id?: string;
+  content?: string | Array<{ type: string; text?: string }>;
+  is_error?: boolean;
+  // result fields
   cost_usd?: number;
   num_turns?: number;
   session_id?: string;
@@ -155,6 +179,38 @@ export function extractTextFromEvent(event: StreamEvent): string | null {
 }
 
 /**
+ * Extract tool_use event data.
+ */
+export function extractToolUse(event: StreamEvent): ToolUseEvent | null {
+  if (event.type === 'tool_use' && event.name && event.id) {
+    return { toolName: event.name, toolId: event.id, input: event.input || {} };
+  }
+  // Also check content blocks for tool_use
+  if (event.message?.content) {
+    const toolBlock = event.message.content.find(b => b.type === 'tool_use');
+    if (toolBlock?.name && toolBlock?.id) {
+      return { toolName: toolBlock.name, toolId: toolBlock.id, input: toolBlock.input || {} };
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract tool_result event data.
+ */
+export function extractToolResult(event: StreamEvent): ToolResultEvent | null {
+  if (event.type === 'tool_result' && event.tool_use_id) {
+    const output = typeof event.content === 'string'
+      ? event.content
+      : Array.isArray(event.content)
+        ? event.content.filter(b => b.type === 'text').map(b => b.text || '').join('')
+        : '';
+    return { toolId: event.tool_use_id, output, isError: event.is_error };
+  }
+  return null;
+}
+
+/**
  * Extract metrics from a result event.
  */
 export function extractMetrics(event: StreamEvent): GripMetrics | null {
@@ -190,12 +246,17 @@ export function isElectronEnv(): boolean {
  *
  * @param onPromptSessionId - Called with the prompt session ID once available (for stop button)
  */
+export type GripStreamEvent = {
+  type: string;
+  data: string | GripMetrics | ToolUseEvent | ToolResultEvent;
+};
+
 export async function* sendToGrip(
   prompt: string,
   sessionId?: string,
   model: string = 'sonnet',
   onPromptSessionId?: (id: string) => void,
-): AsyncGenerator<{ type: 'text' | 'metrics' | 'error' | 'done'; data: string | GripMetrics }> {
+): AsyncGenerator<GripStreamEvent> {
   // Electron path: use IPC for real PTY streaming
   if (isElectronEnv()) {
     yield* sendToGripElectron(prompt, sessionId, model, onPromptSessionId);
@@ -247,6 +308,14 @@ export async function* sendToGrip(
           if (text) {
             yield { type: 'text', data: text };
           }
+          const toolUse = extractToolUse(event);
+          if (toolUse) {
+            yield { type: 'tool_use', data: toolUse };
+          }
+          const toolResult = extractToolResult(event);
+          if (toolResult) {
+            yield { type: 'tool_result', data: toolResult };
+          }
           const metrics = extractMetrics(event);
           if (metrics) {
             yield { type: 'metrics', data: metrics };
@@ -291,7 +360,7 @@ async function* sendToGripElectron(
   sessionId?: string,
   model: string = 'sonnet',
   onPromptSessionId?: (id: string) => void,
-): AsyncGenerator<{ type: 'text' | 'metrics' | 'error' | 'done'; data: string | GripMetrics }> {
+): AsyncGenerator<{ type: string; data: string | GripMetrics | ToolUseEvent | ToolResultEvent }> {
   // Wait up to 2s for preload bridge to initialise (app:// protocol timing)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let api = (window as any).electronAPI?.grip;
@@ -324,14 +393,14 @@ async function* sendToGripElectron(
     onPromptSessionId?.(promptSessionId);
 
     // Collect output via events using a promise-based queue
-    type ChunkType = 'text' | 'metrics' | 'done';
-    const chunks: Array<{ type: ChunkType; data: string | GripMetrics }> = [];
+    type ChunkType = 'text' | 'metrics' | 'tool_use' | 'tool_result' | 'done';
+    const chunks: Array<{ type: ChunkType; data: string | GripMetrics | ToolUseEvent | ToolResultEvent }> = [];
     let resolve: (() => void) | null = null;
     let done = false;
     // Line buffer: accumulate partial IPC chunks until we get complete lines
     let lineBuffer = '';
 
-    const pushChunk = (type: ChunkType, data: string | GripMetrics) => {
+    const pushChunk = (type: ChunkType, data: string | GripMetrics | ToolUseEvent | ToolResultEvent) => {
       chunks.push({ type, data });
       if (resolve) { resolve(); resolve = null; }
     };
@@ -342,6 +411,10 @@ async function* sendToGripElectron(
         const parsed: StreamEvent = JSON.parse(line);
         const text = extractTextFromEvent(parsed);
         if (text) pushChunk('text', text);
+        const toolUse = extractToolUse(parsed);
+        if (toolUse) pushChunk('tool_use', toolUse);
+        const toolResult = extractToolResult(parsed);
+        if (toolResult) pushChunk('tool_result', toolResult);
         const metrics = extractMetrics(parsed);
         if (metrics) pushChunk('metrics', metrics);
       } catch {
@@ -383,7 +456,7 @@ async function* sendToGripElectron(
         if (chunks.length > 0) {
           const chunk = chunks.shift()!;
           if (chunk.type === 'done') break;
-          yield { type: chunk.type as 'text' | 'metrics', data: chunk.data };
+          yield { type: chunk.type, data: chunk.data };
         } else {
           // Wait for next chunk
           await new Promise<void>(r => { resolve = r; });


### PR DESCRIPTION
## Summary
- **Tool use rendering**: Chat engine now surfaces tool_use/tool_result events in real-time with category-coloured blocks (file=cyan, search=blue, execute=amber, agent=purple, mcp=emerald)
- **Tiered distribution model**: "What's Included" section showing Starter Pack vs Full GRIP with invitation link
- **GRIP CLI documentation**: Session context inheritance, shell aliases (gg++), auto-install on first launch
- **Simplified README**: 520 to ~200 lines, Dorothy extras stripped, focused on GRIP architecture

## Test plan
- [ ] 773 tests pass (`npm run test`)
- [ ] Type check passes (`npx tsc --noEmit`)
- [ ] Tool use blocks render during chat streaming
- [ ] Expandable tool input/output
- [ ] Status indicators (pending pulse, success green, error red)
- [ ] Category colouring matches tool type