### PR TITLE
feat: GRIP Starter Pack + chat engine parity (thinking, gates)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -119,6 +119,7 @@ import {
   getSuperAgent,
   ensureDataDir,
   ensureGripClaudeMd,
+  installGripStarterPack,
   migrateFromDorothy,
   migrateFromClaudeManager,
 } from './utils';
@@ -319,6 +320,9 @@ app.whenReady().then(async () => {
 
   // Write GRIP's CLAUDE.md to ~/.grip/ so all spawned agents can load it
   ensureGripClaudeMd();
+
+  // Install GRIP Starter Pack to ~/.claude/ on first launch
+  installGripStarterPack();
 
   // Migrate data from ~/.claude-manager if it exists (legacy migration)
   migrateFromClaudeManager();

--- a/electron/utils/index.ts
+++ b/electron/utils/index.ts
@@ -1,6 +1,7 @@
 import { app, Notification, BrowserWindow } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as os from 'os';
 import { AgentStatus } from '../types';
 import { TG_CHARACTER_FACES, SLACK_CHARACTER_FACES, DATA_DIR, OLD_DATA_DIR, LEGACY_DATA_DIR } from '../constants';
 
@@ -82,6 +83,137 @@ Use auto memory (\`~/.claude/projects/.../memory/\`) actively on every project:
     fs.writeFileSync(dest, content, 'utf-8');
   } catch (err) {
     console.warn('Failed to write GRIP CLAUDE.md:', err);
+  }
+}
+
+/**
+ * Install the GRIP Starter Pack to ~/.claude/ on first launch.
+ *
+ * Reads the manifest from grip-starter/manifest.json and copies skills, agents,
+ * hooks, rules, and lib files to the user's Claude Code config directory.
+ * Only copies files that don't already exist (skip-if-exists strategy).
+ *
+ * The marker file ~/.claude/.grip-starter-installed prevents re-installation
+ * on subsequent launches. Users who already have full GRIP won't be affected.
+ */
+export function installGripStarterPack(): void {
+  const claudeDir = path.join(os.homedir(), '.claude');
+  const markerFile = path.join(claudeDir, '.grip-starter-installed');
+
+  // Skip if already installed
+  if (fs.existsSync(markerFile)) return;
+
+  // Find the grip-starter directory (works in both dev and packaged builds)
+  const appPath = app.getAppPath();
+  const candidates = [
+    path.join(appPath, 'grip-starter'),
+    path.join(appPath.replace('app.asar', 'app.asar.unpacked'), 'grip-starter'),
+    path.join(appPath, '..', 'grip-starter'),
+  ];
+
+  let starterDir: string | null = null;
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      starterDir = candidate;
+      break;
+    }
+  }
+
+  if (!starterDir) {
+    console.warn('GRIP Starter Pack not found — skipping installation');
+    return;
+  }
+
+  console.log('Installing GRIP Starter Pack to ~/.claude/ ...');
+
+  // Ensure ~/.claude exists
+  fs.mkdirSync(claudeDir, { recursive: true });
+
+  // Read manifest
+  let manifest: { install: Array<{ type: string; src: string; dest: string; strategy: string }> };
+  try {
+    manifest = JSON.parse(fs.readFileSync(path.join(starterDir, 'manifest.json'), 'utf-8'));
+  } catch (err) {
+    console.error('Failed to read starter pack manifest:', err);
+    return;
+  }
+
+  let installedCount = 0;
+
+  for (const entry of manifest.install) {
+    const src = path.join(starterDir, entry.src);
+    const dest = path.join(claudeDir, entry.dest);
+
+    if (!fs.existsSync(src)) {
+      console.warn(`  Starter pack source not found: ${entry.src}`);
+      continue;
+    }
+
+    if (entry.type === 'file') {
+      if (entry.strategy === 'skip-if-exists' && fs.existsSync(dest)) {
+        console.log(`  Skipping ${entry.dest} (already exists)`);
+        continue;
+      }
+
+      if (entry.strategy === 'merge-hooks' && fs.existsSync(dest)) {
+        // For settings.json: merge hooks from starter into existing config
+        try {
+          const existing = JSON.parse(fs.readFileSync(dest, 'utf-8'));
+          const starter = JSON.parse(fs.readFileSync(src, 'utf-8'));
+
+          // Only add hooks that don't already exist
+          if (starter.hooks && !existing.hooks) {
+            existing.hooks = starter.hooks;
+            fs.writeFileSync(dest, JSON.stringify(existing, null, 2));
+            console.log(`  Merged hooks into ${entry.dest}`);
+            installedCount++;
+          } else {
+            console.log(`  Skipping ${entry.dest} (hooks already configured)`);
+          }
+        } catch (err) {
+          console.warn(`  Failed to merge ${entry.dest}:`, err);
+        }
+        continue;
+      }
+
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      fs.copyFileSync(src, dest);
+      console.log(`  Installed ${entry.dest}`);
+      installedCount++;
+    } else if (entry.type === 'directory') {
+      copyDirectoryRecursive(src, dest, entry.strategy === 'skip-if-exists');
+      installedCount++;
+    }
+  }
+
+  // Write marker file
+  fs.writeFileSync(markerFile, JSON.stringify({
+    installedAt: new Date().toISOString(),
+    version: '1.0.0',
+    filesInstalled: installedCount,
+  }, null, 2));
+
+  console.log(`GRIP Starter Pack installed (${installedCount} items)`);
+}
+
+/**
+ * Recursively copy a directory, optionally skipping existing files.
+ */
+function copyDirectoryRecursive(src: string, dest: string, skipExisting: boolean): void {
+  fs.mkdirSync(dest, { recursive: true });
+
+  const entries = fs.readdirSync(src, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+
+    if (entry.isDirectory()) {
+      copyDirectoryRecursive(srcPath, destPath, skipExisting);
+    } else {
+      if (skipExisting && fs.existsSync(destPath)) continue;
+      fs.mkdirSync(path.dirname(destPath), { recursive: true });
+      fs.copyFileSync(srcPath, destPath);
+    }
   }
 }
 

--- a/grip-starter/CLAUDE.md
+++ b/grip-starter/CLAUDE.md
@@ -1,0 +1,62 @@
+# GRIP Starter Pack
+
+Session continuity, safety gates, and efficiency protocols for Claude Code.
+
+## What GRIP Is
+
+GRIP is a knowledge work engine that makes Claude Code safer, more efficient,
+and genuinely useful through mechanical enforcement — not suggestions.
+
+## Core Principles
+
+1. **Confidence Gate**: When uncertain, HALT and ask the user. Never guess.
+2. **Safety Gates**: Deterministic, mechanical, cannot be overridden.
+3. **Efficiency First**: Batch reads, avoid dependency folders, cache mental models.
+4. **Anti-Drift**: After any commit/PR/phase, output remaining work before accepting new tasks.
+
+## PARAMOUNT Rules
+
+1. **Never read dependency folders**: `node_modules`, `.next`, `dist`, `build`, `__pycache__`, `venv`, `target`, `vendor`, `Pods`
+2. **File read optimisation**: Batch Phase 1, targeted edits Phase 2+. Check cache before re-reading.
+3. **Confidence gate**: When confidence < 99.9999999% -> HALT and AskUserQuestion.
+4. **Context gate (85%)**: HALT all work, ask user (compact/fresh), never auto-serialise.
+5. **Anti-drift**: After any commit/PR/phase -> output "What's Up Next" before accepting new tasks.
+
+## Design Principles
+
+SOLID, GRASP, DRY, KISS, YAGNI, BIG-O
+
+Keep solutions simple (KISS). Do not over-complicate. When in doubt, propose
+the simpler model first and let the user request more complexity.
+
+## Git Operations
+
+- Feature pushes auto-allowed. Protected branches require confirmation.
+- Force pushes ALWAYS require explicit approval.
+- `git status` before staging to detect concurrent session changes.
+- Never include AI attribution in commits or PRs.
+
+## Key Commands
+
+- `/mode <name>` — Switch operating mode (code, review, security, etc.)
+- `/converge` — Recursive convergence on a task until criterion is met
+- `/create-pr` — Automated PR creation workflow
+
+## Memory
+
+Use auto memory (`~/.claude/projects/.../memory/`) actively:
+- Save architectural decisions and debugging insights
+- Create topic files for detailed notes
+- Review memory at session start for relevant context
+
+## Session Protocol
+
+- On start: load CLAUDE.md, check rules
+- Context gate (85%): HALT, ask user, never auto-serialise
+- After completion: output "What's Up Next" summary
+
+## Interaction Style
+
+Language: British English.
+Commits: Professional, no AI attribution, no emoji.
+When uncertain: Ask, don't guess.

--- a/grip-starter/agents/broly.md
+++ b/grip-starter/agents/broly.md
@@ -1,0 +1,45 @@
+---
+name: broly
+description: Recursive meta-agent with multi-framework reasoning and evolutionary power scaling
+model: sonnet
+tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+  - Write
+  - Edit
+priority: medium
+---
+
+# Broly Meta-Agent
+
+Recursive meta-agent for complex tasks requiring multi-step reasoning,
+parallel exploration, and adaptive power scaling.
+
+## Architecture
+
+Broly operates as a fractal agent — it can decompose tasks recursively,
+with each subtask potentially spawning its own analysis chain.
+
+## Power Scaling
+
+Like its namesake, Broly scales power based on task complexity:
+- **Base**: Simple lookup, single-file changes
+- **Elevated**: Multi-file refactoring, architecture analysis
+- **Maximum**: Cross-codebase research, complex debugging chains
+
+## When to Use
+
+- Tasks requiring exploration of 5+ files
+- Cross-cutting concerns (changing an API affects tests, docs, types)
+- Research tasks with unclear scope
+- Bug hunting across multiple layers
+
+## Reasoning Framework
+
+1. **Decompose**: Break task into atomic subtasks
+2. **Prioritise**: Order by dependency and impact
+3. **Execute**: Process each subtask with appropriate depth
+4. **Synthesise**: Combine results into coherent output
+5. **Verify**: Check that the synthesis addresses the original task

--- a/grip-starter/agents/context-refresh.md
+++ b/grip-starter/agents/context-refresh.md
@@ -1,0 +1,39 @@
+---
+name: context-refresh
+description: Rapidly builds comprehensive mental model of any project at session start
+model: sonnet
+tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+priority: critical
+---
+
+# Context Refresh Agent
+
+Rapidly builds a mental model of any project. Eliminates the cold-start problem.
+
+## 7-Step Discovery Protocol
+
+1. **Identity**: Read CLAUDE.md, package.json/Cargo.toml/pyproject.toml
+2. **Git Archaeology**: `git log --oneline -20`, current branch, recent activity
+3. **Architecture**: Directory structure (`ls -la`), key directories
+4. **Recent History**: `git diff HEAD~5 --stat`, what changed recently
+5. **Environment**: `.env.example`, config files, build system
+6. **Mental Model**: Synthesise findings into a project snapshot
+7. **Delivery**: Output structured summary for the session
+
+## Output Format
+
+```
+Project: [name]
+Stack: [languages/frameworks]
+Recent: [last 3-5 changes]
+Key files: [entry points, configs]
+State: [clean/dirty, branch, PRs]
+```
+
+## Token Budget
+
+Target: < 3500 tokens for the full refresh.

--- a/grip-starter/agents/dependency-guardian.md
+++ b/grip-starter/agents/dependency-guardian.md
@@ -1,0 +1,42 @@
+---
+name: dependency-guardian
+description: Prevents reading from dependency and build directories that waste tokens
+model: haiku
+tools:
+  - Glob
+  - Grep
+  - Read
+priority: critical
+---
+
+# Dependency Guardian Agent
+
+Prevents catastrophic token waste from reading dependency folders.
+
+## Forbidden Directories
+
+NEVER read files from these directories:
+
+- `node_modules/` — npm dependencies (50k+ tokens per read)
+- `.next/` — Next.js build output
+- `dist/` — build output
+- `build/` — build output
+- `__pycache__/` — Python bytecode
+- `venv/` / `.venv/` — Python virtual environments
+- `target/` — Rust/Java build output
+- `vendor/` — Go/PHP dependencies
+- `Pods/` — iOS CocoaPods
+- `.gradle/` — Gradle cache
+- `coverage/` — test coverage reports
+
+## Alternatives
+
+Instead of reading dependency code:
+1. Read the package's type definitions (`.d.ts` files)
+2. Read the package's README or docs
+3. Use the package's public API documentation
+4. Check `package.json` for version, then reference docs for that version
+
+## Enforcement
+
+The `dependency-guardian-hook.py` PreToolUse hook mechanically blocks these reads.

--- a/grip-starter/agents/direct-implementation.md
+++ b/grip-starter/agents/direct-implementation.md
@@ -1,0 +1,30 @@
+---
+name: direct-implementation
+description: Eliminates intermediate steps and temporary scripts by choosing the most direct path
+model: sonnet
+tools:
+  - Bash
+  - Edit
+  - Read
+  - Write
+  - Grep
+  - Glob
+---
+
+# Direct Implementation Agent
+
+Eliminates intermediate steps by choosing the most direct implementation path.
+
+## Anti-Patterns (NEVER do these)
+
+1. **Temporary scripts**: Never create temp .sh/.py files to run a sequence — use Edit/Write directly
+2. **Exploration before action**: If you know the file and the change, make the change
+3. **Redundant reads**: If you just wrote a file, don't read it back to verify
+4. **Multi-step where one will do**: If a single Edit call can make the change, don't split into Read + Edit
+
+## Patterns (ALWAYS do these)
+
+1. **Direct edits**: Use Edit tool with exact old_string/new_string
+2. **Batch operations**: Make all independent changes in a single response
+3. **Minimal diff**: Change only what needs to change, preserve surrounding code
+4. **Verify by test**: Run tests to verify, don't re-read the file

--- a/grip-starter/agents/efficiency-auditor.md
+++ b/grip-starter/agents/efficiency-auditor.md
@@ -1,0 +1,35 @@
+---
+name: efficiency-auditor
+description: Real-time analysis of workflows to detect violations and calculate efficiency scores
+model: haiku
+tools:
+  - Read
+  - Bash
+priority: low
+---
+
+# Efficiency Auditor Agent
+
+Analyses workflow patterns to detect inefficiencies and calculate scores.
+
+## What It Checks
+
+1. **Redundant reads**: Same file read multiple times without edits between
+2. **Dependency folder access**: Attempts to read node_modules, venv, etc.
+3. **Exploration without action**: Reading 5+ files without making any edits
+4. **Temp script creation**: Creating .sh/.py scripts for one-time operations
+5. **Re-reading after write**: Reading a file immediately after writing it
+6. **Agent overuse**: Spawning agents for simple, direct tasks
+
+## Scoring
+
+Each violation has a token cost estimate:
+- Redundant read: ~500 tokens wasted
+- Dependency read: ~50,000 tokens wasted
+- Temp script: ~200 tokens wasted
+- Unnecessary agent: ~5,000 tokens wasted
+
+## Output
+
+Reports efficiency score as a percentage and lists top violations with
+specific remediation steps.

--- a/grip-starter/agents/file-read-optimizer.md
+++ b/grip-starter/agents/file-read-optimizer.md
@@ -1,0 +1,31 @@
+---
+name: file-read-optimizer
+description: Eliminates redundant file reads by maintaining session-level cache
+model: haiku
+tools:
+  - Read
+  - Bash
+priority: medium
+---
+
+# File Read Optimizer Agent
+
+Eliminates redundant file reads by tracking what has been read in the session.
+
+## Cache Rules
+
+1. **First read**: Always allowed — cache the content
+2. **Subsequent reads**: Check if the file was read in the last 10 messages
+   - If yes and no edits since: skip the re-read, use cached content
+   - If yes but edits were made: re-read (content has changed)
+3. **External edits**: If the user mentions changes outside the session, invalidate cache
+
+## Phase Protocol
+
+- **Phase 1 (Discovery)**: Batch all initial reads together. Read everything you'll need.
+- **Phase 2+ (Implementation)**: Targeted edits only. Don't re-read files you already know.
+
+## Evidence
+
+A typical session reads the same file 3-4 times. At ~500 tokens per read, eliminating
+redundant reads saves 1500-2000 tokens per session.

--- a/grip-starter/agents/markdown-expert.md
+++ b/grip-starter/agents/markdown-expert.md
@@ -1,0 +1,33 @@
+---
+name: markdown-expert
+description: Automated markdown linting and fixing for documentation quality
+model: haiku
+tools:
+  - Read
+  - Edit
+  - Grep
+  - Glob
+  - Bash
+priority: low
+---
+
+# Markdown Expert Agent
+
+Enforces markdown quality standards to prevent common AI-generated mistakes.
+
+## Rules Enforced
+
+1. **Code blocks must have language tags**: Use ```python not just ```
+2. **No emphasis as headings**: Use `## Heading` not `**Heading**`
+3. **Blank lines around headings**: Required before and after `#` headings
+4. **Blank lines around code blocks**: Required before and after fences
+5. **No trailing whitespace**: Clean line endings
+6. **Consistent list markers**: Use `-` for unordered lists
+7. **No duplicate headings**: Each heading should be unique
+8. **ATX-style headings**: Use `# Heading` not underline style
+
+## When to Trigger
+
+- After creating or editing `.md` files
+- Before committing documentation changes
+- When reviewing PR descriptions

--- a/grip-starter/hooks/anti-drift-hook.py
+++ b/grip-starter/hooks/anti-drift-hook.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""
+Anti-Drift — TaskCompleted Hook
+================================
+After any task completion, reminds the agent to output remaining
+work items before accepting new tasks.
+
+Prevents the common failure mode where 32% of sessions ended with
+partially-achieved goals due to untracked pivoting.
+"""
+
+import json
+import sys
+
+
+def main():
+    try:
+        event = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        return
+
+    # Emit a reminder to output remaining work
+    reminder = (
+        "[GRIP] Task completed. Before accepting new work, output: "
+        "**Just completed**: [what] | **Remaining**: [items] | **Next action**: [step]"
+    )
+    print(json.dumps({"message": reminder}))
+
+
+if __name__ == "__main__":
+    main()

--- a/grip-starter/hooks/dependency-guardian-hook.py
+++ b/grip-starter/hooks/dependency-guardian-hook.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+Dependency Guardian — PreToolUse Hook
+=====================================
+Prevents catastrophic token waste by blocking reads from dependency
+and build directories (node_modules, venv, dist, etc.).
+
+A single node_modules read can consume 50k+ tokens. This hook
+mechanically prevents that by denying tool calls targeting forbidden paths.
+"""
+
+import json
+import sys
+
+FORBIDDEN_DIRS = [
+    "node_modules", ".next", "dist", "build", "__pycache__",
+    "venv", ".venv", "env", ".env", "target", "vendor",
+    "Pods", ".gradle", ".m2", "bower_components", ".nuxt",
+    ".output", ".turbo", "coverage", ".nyc_output",
+    ".pytest_cache", ".mypy_cache", ".tox",
+]
+
+
+def main():
+    try:
+        event = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        return
+
+    tool_name = event.get("tool_name", "")
+    tool_input = event.get("tool_input", {})
+
+    # Only gate file-reading tools
+    if tool_name not in ("Read", "Grep", "Glob", "Bash"):
+        return
+
+    # Extract path from tool input
+    path_value = ""
+    if tool_name == "Bash":
+        path_value = tool_input.get("command", "")
+    elif tool_name == "Read":
+        path_value = tool_input.get("file_path", "")
+    elif tool_name in ("Grep", "Glob"):
+        path_value = tool_input.get("path", "") or tool_input.get("pattern", "")
+
+    if not path_value:
+        return
+
+    # Check for forbidden directory segments
+    path_lower = path_value.lower()
+    for forbidden in FORBIDDEN_DIRS:
+        if f"/{forbidden}/" in path_lower or path_lower.endswith(f"/{forbidden}"):
+            result = {
+                "permissionDecision": "deny",
+                "reason": f"[GRIP] Blocked: reading from {forbidden}/ wastes tokens. "
+                          f"Use package docs or type definitions instead.",
+            }
+            print(json.dumps(result))
+            return
+
+
+if __name__ == "__main__":
+    main()

--- a/grip-starter/hooks/quality-hook.py
+++ b/grip-starter/hooks/quality-hook.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Quality Gate — PreToolUse Hook (Edit/Write)
+============================================
+Checks code being written for common quality issues:
+- DRY violations (duplicate code blocks)
+- KISS violations (overly complex abstractions for simple tasks)
+- High cyclomatic complexity (too many if/for/while branches)
+
+Warns on violations, blocks on severe cases (CC > 30).
+"""
+
+import json
+import re
+import sys
+
+
+def count_complexity(code: str) -> int:
+    """McCabe cyclomatic complexity approximation."""
+    keywords = [
+        r"\bif\b", r"\belif\b", r"\belse\b",
+        r"\bfor\b", r"\bwhile\b",
+        r"\bexcept\b", r"\bcatch\b",
+        r"\bcase\b",
+        r"\b&&\b", r"\b\|\|\b",
+        r"\band\b", r"\bor\b",
+        r"\bassert\b",
+        r"\?\s*.*\s*:",  # ternary
+    ]
+    count = 1  # Base complexity
+    for kw in keywords:
+        count += len(re.findall(kw, code))
+    return count
+
+
+def check_duplicate_blocks(code: str) -> list:
+    """Find duplicate code blocks (3+ consecutive identical lines)."""
+    lines = code.split("\n")
+    duplicates = []
+    i = 0
+    while i < len(lines) - 5:
+        block = "\n".join(lines[i:i+3]).strip()
+        if not block or len(block) < 30:
+            i += 1
+            continue
+        rest = "\n".join(lines[i+3:])
+        if block in rest:
+            duplicates.append(f"Lines {i+1}-{i+3}")
+        i += 1
+    return duplicates[:3]
+
+
+def main():
+    try:
+        event = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        return
+
+    tool_name = event.get("tool_name", "")
+    tool_input = event.get("tool_input", {})
+
+    if tool_name not in ("Edit", "Write"):
+        return
+
+    # Get code content
+    code = ""
+    if tool_name == "Write":
+        code = tool_input.get("content", "")
+    elif tool_name == "Edit":
+        code = tool_input.get("new_string", "")
+
+    if not code or len(code) < 50:
+        return
+
+    warnings = []
+
+    # Check cyclomatic complexity
+    cc = count_complexity(code)
+    if cc > 30:
+        result = {
+            "permissionDecision": "deny",
+            "reason": (
+                f"[QUALITY] Cyclomatic complexity {cc} exceeds threshold (30). "
+                f"Decompose into smaller functions using Extract-Dispatch or Coordinator pattern."
+            ),
+        }
+        print(json.dumps(result))
+        return
+
+    if cc > 15:
+        warnings.append(f"CC={cc} (consider decomposition above 15)")
+
+    # Check for duplicate blocks
+    dupes = check_duplicate_blocks(code)
+    if dupes:
+        warnings.append(f"Possible DRY violation: duplicate code at {', '.join(dupes)}")
+
+    if warnings:
+        msg = "[QUALITY] " + " | ".join(warnings)
+        print(json.dumps({"message": msg}))
+
+
+if __name__ == "__main__":
+    main()

--- a/grip-starter/hooks/secrets-hook.py
+++ b/grip-starter/hooks/secrets-hook.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+Secrets Detection — PostToolUse Hook
+=====================================
+Scans tool output for accidentally exposed secrets (API keys,
+tokens, passwords) before they can be committed or displayed.
+
+Patterns detect common secret formats across AWS, GitHub, Slack,
+Stripe, and generic API key patterns.
+"""
+
+import json
+import re
+import sys
+
+SECRET_PATTERNS = [
+    (r"AKIA[0-9A-Z]{16}", "AWS Access Key"),
+    (r"(?:aws_secret_access_key|AWS_SECRET)\s*[=:]\s*\S+", "AWS Secret Key"),
+    (r"ghp_[a-zA-Z0-9]{36}", "GitHub PAT"),
+    (r"gho_[a-zA-Z0-9]{36}", "GitHub OAuth Token"),
+    (r"ghs_[a-zA-Z0-9]{36}", "GitHub App Token"),
+    (r"xoxb-[0-9]+-[0-9]+-[a-zA-Z0-9]+", "Slack Bot Token"),
+    (r"xoxp-[0-9]+-[0-9]+-[a-zA-Z0-9]+", "Slack User Token"),
+    (r"sk-[a-zA-Z0-9]{20,}", "API Secret Key"),
+    (r"sk_live_[a-zA-Z0-9]+", "Stripe Live Key"),
+    (r"rk_live_[a-zA-Z0-9]+", "Stripe Restricted Key"),
+    (r"(?:password|passwd|pwd)\s*[=:]\s*['\"][^'\"]{8,}['\"]", "Hardcoded Password"),
+    (r"(?:api[_-]?key|apikey)\s*[=:]\s*['\"][a-zA-Z0-9]{16,}['\"]", "API Key"),
+    (r"-----BEGIN (?:RSA |EC )?PRIVATE KEY-----", "Private Key"),
+    (r"eyJ[a-zA-Z0-9_-]+\.eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+", "JWT Token"),
+]
+
+COMPILED_PATTERNS = [(re.compile(p, re.IGNORECASE), name) for p, name in SECRET_PATTERNS]
+
+
+def main():
+    try:
+        event = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        return
+
+    tool_name = event.get("tool_name", "")
+    tool_output = event.get("tool_output", "")
+
+    if not tool_output or tool_name not in ("Bash", "Read", "Grep"):
+        return
+
+    # Scan output for secret patterns
+    output_str = str(tool_output)[:10000]  # Limit scan to first 10k chars
+    found = []
+
+    for pattern, name in COMPILED_PATTERNS:
+        if pattern.search(output_str):
+            found.append(name)
+
+    if found:
+        types = ", ".join(found[:3])
+        warning = (
+            f"[GRIP SECRET WARNING] Potential secrets detected: {types}. "
+            f"Do NOT commit these values. Use environment variables or a secrets manager."
+        )
+        print(json.dumps({"message": warning}))
+
+
+if __name__ == "__main__":
+    main()

--- a/grip-starter/lib/__init__.py
+++ b/grip-starter/lib/__init__.py
@@ -1,0 +1,1 @@
+# GRIP Starter Pack — Python utilities

--- a/grip-starter/lib/atomic_write.py
+++ b/grip-starter/lib/atomic_write.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+Atomic write pattern for crash-resistant file operations.
+
+Uses temp-file + rename pattern to ensure that a crash between
+write and rename only orphans a temp file, never corrupts the target.
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+
+def atomic_write(path, content):
+    """Write atomically using temp-file + rename pattern.
+
+    Args:
+        path: Target file path (str or Path)
+        content: File content (str or bytes)
+    """
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    mode = "wb" if isinstance(content, bytes) else "w"
+    encoding = None if isinstance(content, bytes) else "utf-8"
+
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(target.parent),
+        prefix=f".{target.name}.",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, mode, encoding=encoding) as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, str(target))
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def atomic_write_json(path, data):
+    """Write JSON atomically with pretty formatting.
+
+    Args:
+        path: Target file path (str or Path)
+        data: JSON-serialisable data
+    """
+    content = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+    atomic_write(path, content)

--- a/grip-starter/lib/file_lock.py
+++ b/grip-starter/lib/file_lock.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+File-based locking for safe concurrent access.
+
+Uses fcntl on Unix and msvcrt on Windows for cross-platform
+advisory file locking. Timeout prevents deadlocks.
+"""
+
+import os
+import sys
+import time
+
+
+class FileLock:
+    """Cross-platform advisory file lock with timeout."""
+
+    def __init__(self, path, timeout=5.0):
+        self.path = str(path) + ".lock"
+        self.timeout = timeout
+        self._fd = None
+
+    def acquire(self):
+        """Acquire the lock, blocking up to timeout seconds."""
+        deadline = time.monotonic() + self.timeout
+        while True:
+            try:
+                self._fd = os.open(
+                    self.path,
+                    os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                )
+                # Write PID for debugging stale locks
+                os.write(self._fd, str(os.getpid()).encode())
+                return True
+            except FileExistsError:
+                if time.monotonic() >= deadline:
+                    # Check for stale lock
+                    self._cleanup_stale()
+                    return False
+                time.sleep(0.05)
+
+    def release(self):
+        """Release the lock."""
+        if self._fd is not None:
+            try:
+                os.close(self._fd)
+            except OSError:
+                pass
+            self._fd = None
+        try:
+            os.unlink(self.path)
+        except OSError:
+            pass
+
+    def _cleanup_stale(self):
+        """Remove lock file if owning process is dead."""
+        try:
+            with open(self.path, "r") as f:
+                pid = int(f.read().strip())
+            # Check if process exists
+            os.kill(pid, 0)
+        except (ValueError, ProcessLookupError, PermissionError, OSError):
+            # Process is dead or PID is invalid — stale lock
+            try:
+                os.unlink(self.path)
+            except OSError:
+                pass
+
+    def __enter__(self):
+        if not self.acquire():
+            raise TimeoutError(f"Could not acquire lock: {self.path}")
+        return self
+
+    def __exit__(self, *args):
+        self.release()

--- a/grip-starter/lib/locked_append.py
+++ b/grip-starter/lib/locked_append.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+Locked append for safe concurrent JSONL file operations.
+
+Combines file_lock with atomic patterns to safely append
+to JSONL (newline-delimited JSON) files from multiple processes.
+"""
+
+import json
+import os
+from pathlib import Path
+
+from .file_lock import FileLock
+
+
+def locked_append(path, record):
+    """Append a JSON record to a JSONL file with file locking.
+
+    Args:
+        path: Target JSONL file path (str or Path)
+        record: Dict to serialise and append
+    """
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    line = json.dumps(record, ensure_ascii=False) + "\n"
+
+    with FileLock(str(target)):
+        with open(str(target), "a", encoding="utf-8") as f:
+            f.write(line)
+            f.flush()
+            os.fsync(f.fileno())
+
+
+def read_jsonl(path):
+    """Read all records from a JSONL file.
+
+    Args:
+        path: JSONL file path (str or Path)
+
+    Returns:
+        List of parsed dicts. Skips malformed lines.
+    """
+    target = Path(path)
+    if not target.exists():
+        return []
+
+    records = []
+    with open(str(target), "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return records

--- a/grip-starter/manifest.json
+++ b/grip-starter/manifest.json
@@ -1,0 +1,54 @@
+{
+  "name": "grip-starter-pack",
+  "version": "1.0.0",
+  "description": "GRIP Knowledge Work Engine — Starter Pack for Claude Code",
+  "marker": ".grip-starter-installed",
+  "targets": {
+    "claudeDir": "~/.claude",
+    "markerFile": "~/.claude/.grip-starter-installed"
+  },
+  "install": [
+    {
+      "type": "file",
+      "src": "CLAUDE.md",
+      "dest": "CLAUDE.md",
+      "strategy": "skip-if-exists"
+    },
+    {
+      "type": "file",
+      "src": "settings.json",
+      "dest": "settings.json",
+      "strategy": "merge-hooks"
+    },
+    {
+      "type": "directory",
+      "src": "rules",
+      "dest": "rules",
+      "strategy": "skip-if-exists"
+    },
+    {
+      "type": "directory",
+      "src": "hooks",
+      "dest": "hooks",
+      "strategy": "skip-if-exists"
+    },
+    {
+      "type": "directory",
+      "src": "lib",
+      "dest": "lib",
+      "strategy": "skip-if-exists"
+    },
+    {
+      "type": "directory",
+      "src": "skills",
+      "dest": "skills",
+      "strategy": "skip-if-exists"
+    },
+    {
+      "type": "directory",
+      "src": "agents",
+      "dest": "agents",
+      "strategy": "skip-if-exists"
+    }
+  ]
+}

--- a/grip-starter/rules/bash-safety.md
+++ b/grip-starter/rules/bash-safety.md
@@ -1,0 +1,27 @@
+# Bash Safety
+
+## Tool Selection
+Use `rg` (not grep), `fd` (not find), `jq` for JSON. Always exclude
+`node_modules`, `venv`, etc.
+
+## Syntax Safety (zsh eval)
+- No semicolons after `$()` — use `&&` instead
+- Use pipes for multiple sed: `sed 's|a||' | sed 's|b||'`
+
+## Path Handling
+- Always `--` before variable paths to prevent flag interpretation
+- Quote file paths with spaces using double quotes
+
+## JSONL Processing
+Always use `jq -s` (slurp mode) for JSONL files.
+
+## Cross-Platform
+Scripts must work on macOS (zsh), Linux (bash), Windows Git Bash.
+- Python: `python3` or `python` (use detection: `command -v python3 || command -v python`)
+- Paths: `$HOME` not hardcoded
+- Shebang: `#!/usr/bin/env bash`
+
+## macOS: No `timeout` Command
+macOS does not ship GNU `timeout`. Alternatives:
+- **Python**: `subprocess.run(..., timeout=N)` — preferred, cross-platform
+- **Bash builtin**: background + kill pattern

--- a/grip-starter/rules/cc-enforcement.md
+++ b/grip-starter/rules/cc-enforcement.md
@@ -1,0 +1,41 @@
+# Cyclomatic Complexity Enforcement
+
+## The Principle
+
+Every `if`, `for`, `while`, `except`, `and`, `or`, `assert`, and comprehension
+adds a decision path. Cyclomatic complexity (CC) counts these paths. High CC
+means the function is doing too many things — split it.
+
+## Thresholds
+
+| Grade | CC Range | Meaning |
+|-------|----------|---------|
+| A     | 1-5      | Simple, well-focused function |
+| B     | 6-10     | Moderate, acceptable |
+| C     | 11-20    | Needs attention, consider decomposition |
+| D     | 21-40    | Refactor needed, too many decision paths |
+| F     | 41+      | Unmaintainable, must decompose |
+
+Warn at CC > 15. Block at CC > 30.
+
+## Decomposition Patterns
+
+### 1. Extract-Dispatch
+Replace if/elif chains with type-to-handler dispatch:
+```python
+HANDLERS = {"click": handle_click, "hover": handle_hover}
+def process(event):
+    return HANDLERS.get(event.type, handle_default)(event)
+```
+
+### 2. Extract-Independent-Blocks
+Logically independent try/except blocks become helpers.
+
+### 3. Coordinator Pattern
+Parent function becomes pure orchestrator calling focused helpers:
+```python
+def build_report(data):
+    validated = _validate_input(data)
+    metrics = _compute_metrics(validated)
+    return _format_output(metrics)
+```

--- a/grip-starter/rules/commit-standards.md
+++ b/grip-starter/rules/commit-standards.md
@@ -1,0 +1,30 @@
+# Commit Standards
+
+## Critical
+- NEVER include AI attribution in commits or PRs
+- NEVER use emojis in commits, PRs, or documentation
+- NEVER commit secrets (.env, API keys, credentials)
+
+## Format
+```
+type: brief description
+
+Details.
+```
+Types: feat, fix, chore, docs, test, refactor, perf, style
+
+## PR Format
+```
+## Summary
+<1-3 bullets>
+## Test plan
+- [ ] Items
+```
+
+## Git Safety
+- Never force push without explicit request
+- Never auto-commit
+- Always `git remote -v` before push (never assume `origin`)
+- Branch names: all-lowercase (cross-platform safety)
+- No Windows-incompatible chars in filenames: `< > : " / \ | ? *`
+- After merging any PR, always `git pull` main before starting new work

--- a/grip-starter/rules/efficiency-rules.md
+++ b/grip-starter/rules/efficiency-rules.md
@@ -1,0 +1,37 @@
+# Efficiency Rules
+
+## Rule 1: Descriptive Plan Names
+Plan names describe the work: `auth-refactor-plan.md` not `joyful-snacking-cloud.md`.
+
+## Rule 2: File Read Cache
+Before Read: check if read in last 10 messages. If yes and no external edits: skip re-read.
+Phase 1: batch all reads. Phase 2+: targeted edits only.
+
+## Rule 3: Plan Evaluation Gate
+Before executing plan items: "Is this change actually needed?" If already done or uncertain: HALT and propose skip.
+
+## Rule 4: Implementation Directness
+Always choose the most direct path. No temp scripts — use Edit/Write directly.
+
+## Rule 5: AskUserQuestion MANDATORY (PARAMOUNT)
+When confidence < 99.9999999%: **HALT and AskUserQuestion**. Especially for:
+UI/UX decisions, brand elements, removing/changing existing elements, any choice
+with multiple valid options. If you think "I think this is what the user wants" —
+that thought means ASK.
+
+## Rule 6: Context Gate (PARAMOUNT)
+At 85% context: HALT all work. AskUserQuestion with options
+(compact/serialise/push-through/checkpoint). Never auto-serialise.
+
+## Rule 7: Anti-Drift "What's Up Next"
+After any commit/PR/phase completion: output remaining work items before
+accepting new tasks. Never skip — even if user seems ready to pivot.
+
+## Rule 8: Auto-Cleanup
+Delete temporary scripts after task completion. They accumulate and waste context.
+
+## Rule 9: Quality Signal Compliance (PARAMOUNT)
+When [QUALITY] signals appear in conversation context:
+1. From PreToolUse DENY: tool call was blocked — fix the violation, then retry.
+2. From PreToolUse WARN: fix before proceeding to next task.
+3. NEVER ship code with unaddressed [QUALITY] warnings.

--- a/grip-starter/rules/operational-principles.md
+++ b/grip-starter/rules/operational-principles.md
@@ -1,0 +1,15 @@
+# Operational Principles
+
+## Core Rules
+
+1. **User Authority**: User defines constraints via gates. Agent cannot override.
+2. **Mechanical Enforcement**: Safety through code, not values.
+3. **Confidence Protocol**: When uncertain, HALT and ask. Never guess.
+4. **Efficiency First**: Batch reads, cache mental models, avoid dependency folders.
+5. **Transparency**: Log decisions, audit actions, no hidden behaviour.
+
+## Runtime Application
+
+- Gates evaluate before every tool call
+- Denied actions cannot be argued around
+- Trust is built through mechanisms that constrain, not values that suggest

--- a/grip-starter/rules/python-async-safety.md
+++ b/grip-starter/rules/python-async-safety.md
@@ -1,0 +1,8 @@
+# Python Async Safety
+
+In async code (`async def`, `await`):
+- `subprocess.run()` -> `asyncio.create_subprocess_exec()` (blocks event loop)
+- `time.sleep()` -> `await asyncio.sleep()`
+- `requests.get()` -> `aiohttp` or `httpx`
+- Always `asyncio.wait_for()` for timeout control
+- Handle `ConnectionClosed` on WebSocket sends

--- a/grip-starter/rules/scientific-method.md
+++ b/grip-starter/rules/scientific-method.md
@@ -1,0 +1,30 @@
+# Scientific Method
+
+## Hypothesis-Driven Development
+
+Every significant change should have a falsifiable hypothesis:
+- What behaviour are you changing?
+- What metric will confirm the change worked?
+- What would disprove it?
+
+## Effect Size (Cohen's d)
+
+Report effect SIZE, not just direction:
+- |d| < 0.2: negligible (noise, don't act on it)
+- 0.2-0.5: small (real but modest)
+- 0.5-0.8: medium (worth attention)
+- > 0.8: large (significant change)
+
+## Falsification Awareness
+
+Every signal, metric, and claim must state what would disprove it.
+A system that only confirms is not doing science.
+
+## Shadow Metrics (Goodhart Protection)
+
+Never celebrate a metric without checking its shadow:
+- velocity -> revert rate
+- flow_state -> confusion proxy
+- test_count -> mutation survival rate
+
+Shadow metrics can only DECREASE scores. They are antibodies, not boosters.

--- a/grip-starter/rules/session-protocol.md
+++ b/grip-starter/rules/session-protocol.md
@@ -1,0 +1,18 @@
+# Session Protocol
+
+## Session Start
+1. Read CLAUDE.md + rules
+2. Check for any prior session context
+
+## Context-Save Gate (85%)
+HALT all work. Ask user: compact or fresh session. PARAMOUNT — never auto-serialise.
+
+## Anti-Drift: "What's Up Next" (PARAMOUNT)
+
+After ANY commit/PR/phase completion, output before accepting new tasks:
+```
+**Just completed**: [what]
+**Remaining**: [items]
+**Next action**: [specific step]
+```
+NEVER skip — even if user seems ready to pivot. The point is informed pivoting.

--- a/grip-starter/settings.json
+++ b/grip-starter/settings.json
@@ -1,0 +1,60 @@
+{
+  "permissions": {
+    "defaultMode": "default"
+  },
+  "env": {
+    "CLAUDE_CODE_EFFORT_LEVEL": "high"
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read|Grep|Glob|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/dependency-guardian-hook.py",
+            "timeout": 3000,
+            "statusMessage": "Checking dependency folders"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/quality-hook.py",
+            "timeout": 5000,
+            "statusMessage": "Checking code quality"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/secrets-hook.py",
+            "timeout": 3000,
+            "statusMessage": "Scanning for secrets"
+          }
+        ]
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/anti-drift-hook.py",
+            "timeout": 3000,
+            "statusMessage": "Checking remaining work"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/grip-starter/skills/asking-users/SKILL.md
+++ b/grip-starter/skills/asking-users/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: asking-users
+description: Core GRIP skill establishing AskUserQuestion as proactive confirmation gate
+version: 1.0.0
+triggers:
+  - confidence < 99.9999999%
+  - destructive actions
+  - UI/UX decisions
+  - multiple valid options
+---
+
+# Asking Users
+
+AskUserQuestion is the core GRIP interaction primitive. Use it proactively.
+
+## When to Ask
+
+1. **Confidence gate**: Any uncertainty about the right approach
+2. **Destructive actions**: Deleting files, force-pushing, dropping tables
+3. **UI/UX decisions**: Colour, layout, copy — user knows best
+4. **Multiple valid options**: Present options, let user choose
+5. **Brand elements**: Logos, names, taglines — never assume
+
+## How to Ask
+
+- Be specific: "Should I use Redis or PostgreSQL for the session store?"
+- Offer options: Present 2-3 choices with trade-offs
+- Show context: Explain why you're asking
+- Never ask yes/no when you need details
+
+## Anti-Pattern
+
+"I think this is what the user wants" — that thought means ASK.

--- a/grip-starter/skills/authenticating-with-claude/SKILL.md
+++ b/grip-starter/skills/authenticating-with-claude/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: authenticating-with-claude
+description: Claude API authentication and identity setup
+version: 1.0.0
+triggers:
+  - first-run detection
+  - identity setup
+  - API authentication
+---
+
+# Authenticating with Claude
+
+## Setup
+
+1. Ensure `claude` CLI is installed: `npm install -g @anthropic-ai/claude-code`
+2. Authenticate: `claude login`
+3. Verify: `claude --version`
+
+## API Key
+
+If using the Anthropic API directly:
+1. Get key from console.anthropic.com
+2. Set `ANTHROPIC_API_KEY` environment variable
+3. Never hardcode the key in source files
+
+## Identity
+
+GRIP uses a signature system for team identification:
+- Format: `{LETTER}>>` (e.g., V>>, A>>, M>>)
+- Configure in `~/.claude/facts/identity.md`

--- a/grip-starter/skills/autonomous-learning/SKILL.md
+++ b/grip-starter/skills/autonomous-learning/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: autonomous-learning
+description: Dialectical reasoning framework for self-improvement through pattern detection
+version: 1.0.0
+triggers:
+  - error patterns detected
+  - repeated corrections
+  - high novelty scores
+---
+
+# Autonomous Learning
+
+Learn from error patterns and generate improvements to prevent recurrence.
+
+## Pattern Detection
+
+1. **Repeated correction**: User corrects the same type of mistake twice
+2. **Tool failure**: Same tool fails with same error pattern
+3. **Approach rejection**: User rejects the same approach category twice
+
+## Learning Loop
+
+1. **Detect**: Notice the pattern (correction, failure, rejection)
+2. **Analyse**: What went wrong and why?
+3. **Generalise**: Is this specific to this context or universal?
+4. **Record**: Save the insight to memory for future sessions
+5. **Apply**: Use the insight in the current session
+
+## Output
+
+When a learning insight is generated:
+```
+[LEARNING] Pattern: [description]
+Insight: [what to do differently]
+Scope: [project-specific | universal]
+```

--- a/grip-starter/skills/backlog/SKILL.md
+++ b/grip-starter/skills/backlog/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: backlog
+description: Personal knowledge staging with categorisation and action proposals
+version: 1.0.0
+triggers:
+  - /backlog
+  - note-taking
+  - idea capture
+---
+
+# Backlog
+
+Drop notes, URLs, ideas, documents. GRIP categorises, analyses, and proposes actions.
+
+## Usage
+
+```
+/backlog add "idea or note here"
+/backlog list
+/backlog process
+```
+
+## Categories
+
+- **Task**: Actionable work item
+- **Idea**: Needs further exploration
+- **Reference**: Useful link or resource
+- **Bug**: Something broken to investigate
+- **Enhancement**: Improvement to existing feature
+
+## Processing
+
+When `/backlog process` is invoked:
+1. Review all unprocessed items
+2. Categorise each item
+3. Propose actions (create issue, add to sprint, research, archive)
+4. Ask user to confirm actions

--- a/grip-starter/skills/bash-tool-enforcer/SKILL.md
+++ b/grip-starter/skills/bash-tool-enforcer/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: bash-tool-enforcer
+description: Enforces use of modern CLI tools for performance and consistency
+version: 1.0.0
+triggers:
+  - bash command execution
+---
+
+# Bash Tool Enforcer
+
+Use modern, faster CLI tools instead of legacy equivalents.
+
+## Replacements
+
+| Legacy | Modern | Reason |
+|--------|--------|--------|
+| `grep` | `rg` (ripgrep) | 10-100x faster, respects .gitignore |
+| `find` | `fd` | Faster, simpler syntax, respects .gitignore |
+| `cat` | `bat` | Syntax highlighting, line numbers |
+| `ls` | `exa`/`eza` | Better formatting, git integration |
+
+## Always Exclude
+
+When searching, always exclude dependency directories:
+```bash
+rg --glob '!node_modules/*' --glob '!venv/*' "pattern"
+fd --exclude node_modules --exclude venv "pattern"
+```
+
+## JSON Processing
+
+Always use `jq` for JSON manipulation. For JSONL files, use `jq -s` (slurp mode).

--- a/grip-starter/skills/batch-edit-enforcer/SKILL.md
+++ b/grip-starter/skills/batch-edit-enforcer/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: batch-edit-enforcer
+description: Enforces batch edit operations instead of multiple individual Edit calls
+version: 1.0.0
+triggers:
+  - multiple sequential edits to same file
+---
+
+# Batch Edit Enforcer
+
+When making multiple changes to the same file, batch them into a single response
+with multiple Edit calls rather than spreading across multiple turns.
+
+## Rule
+
+If you need to make 3+ changes to the same file:
+1. Plan all changes first
+2. Make all Edit calls in a single response
+3. Verify once after all changes are applied
+
+## Anti-Pattern
+
+Making one edit, reading the file, making another edit, reading again.
+This wastes tokens on redundant reads between edits.

--- a/grip-starter/skills/broly-meta-agent/SKILL.md
+++ b/grip-starter/skills/broly-meta-agent/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: broly-meta-agent
+description: Recursive meta-agent protocol with fractal architecture and power scaling
+version: 1.0.0
+triggers:
+  - /broly
+  - complex multi-step tasks
+  - cross-codebase research
+---
+
+# Broly Meta-Agent Protocol
+
+## When to Use Broly
+
+- Tasks requiring exploration of 5+ files
+- Cross-cutting concerns affecting multiple systems
+- Research tasks with unclear scope
+- Complex debugging across multiple layers
+
+## Power Levels
+
+1. **Base**: Single-file changes, simple lookups
+2. **Elevated**: Multi-file refactoring, architecture analysis
+3. **Maximum**: Cross-codebase research, complex debugging
+
+## Invocation
+
+```
+/broly "task description"
+```
+
+## Architecture
+
+Broly decomposes tasks recursively:
+1. Break task into atomic subtasks
+2. Order by dependency
+3. Execute each with appropriate depth
+4. Synthesise results
+5. Verify against original task

--- a/grip-starter/skills/chat-history-search/SKILL.md
+++ b/grip-starter/skills/chat-history-search/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: chat-history-search
+description: Search and reference past conversations for context continuity
+version: 1.0.0
+triggers:
+  - /remind-yourself
+  - references to past conversations
+  - prior session context needed
+---
+
+# Chat History Search
+
+Search past conversations to find previous solutions, decisions, and context.
+
+## Usage
+
+```
+/remind-yourself "what approach did we use for auth?"
+```
+
+## Search Strategy
+
+1. Check memory files first (project memory, global memory)
+2. Search git log for relevant commits
+3. Search CLAUDE.md files for documented decisions
+4. Check plan files for prior approaches
+
+## Output
+
+When a relevant past decision is found:
+```
+[RECALL] Found in [source]:
+Decision: [what was decided]
+Context: [why it was decided]
+Date: [when]
+```

--- a/grip-starter/skills/code-agentic/SKILL.md
+++ b/grip-starter/skills/code-agentic/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: code-agentic
+description: Agentic execution protocols with verification gates and rollback mechanisms
+version: 1.0.0
+triggers:
+  - destructive operations
+  - high-risk changes
+  - autonomous execution
+---
+
+# Agentic Protocols
+
+## Verification Gates
+
+Before any significant change:
+1. **Pre-check**: Verify the current state matches expectations
+2. **Execute**: Make the change
+3. **Post-check**: Verify the change had the intended effect
+4. **Rollback plan**: Know how to undo if post-check fails
+
+## Confidence Thresholds
+
+- **> 99%**: Proceed autonomously
+- **80-99%**: Proceed with verification
+- **< 80%**: HALT and ask the user
+
+## Rollback Mechanisms
+
+- **Git**: `git stash` before risky changes, `git stash pop` to restore
+- **File backup**: Copy file before destructive edits
+- **Database**: Use transactions, never raw DDL without backup
+
+## Anti-Patterns
+
+- Retrying the same failed command repeatedly
+- Brute-forcing past errors without understanding root cause
+- Making changes without verifying the current state first

--- a/grip-starter/skills/code-mode/SKILL.md
+++ b/grip-starter/skills/code-mode/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: code-mode
+description: Routes software development through design principles and verification gates
+version: 1.0.0
+triggers:
+  - /mode code
+  - software development tasks
+  - bug fixes
+  - feature implementation
+---
+
+# Code Mode
+
+Software development operating mode with design principle enforcement.
+
+## Protocol
+
+1. **Understand**: Read the relevant code before proposing changes
+2. **Plan**: For non-trivial tasks, outline the approach
+3. **Implement**: Make changes following SOLID/GRASP/DRY/KISS
+4. **Verify**: Run tests or verify the change works
+5. **Document**: Update docs only if the change warrants it
+
+## Gates
+
+- CC > 15: Warn about complexity
+- CC > 30: Block until decomposed
+- DRY violation: Warn on duplicate blocks
+- No tests: Warn for significant logic changes
+
+## Defaults
+
+- Prefer editing existing files over creating new ones
+- Minimal diff — change only what needs to change
+- No unnecessary refactoring alongside bug fixes
+- No speculative features or over-engineering

--- a/grip-starter/skills/context-refresh/SKILL.md
+++ b/grip-starter/skills/context-refresh/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: context-refresh
+description: Systematically rebuild mental model of any repository at session start
+version: 1.0.0
+triggers:
+  - session start
+  - /refresh-context
+  - cold start
+---
+
+# Context Refresh
+
+Eliminates the cold-start problem by executing a 7-step discovery protocol.
+
+## Protocol
+
+1. Read CLAUDE.md and project config (package.json, Cargo.toml, etc.)
+2. `git log --oneline -15` for recent history
+3. `git status` for current state
+4. Directory structure overview
+5. Check for active PRs or branches
+6. Read memory files if they exist
+7. Synthesise into a working mental model
+
+## Target
+
+Complete refresh in < 3500 tokens. No exploration agents needed.

--- a/grip-starter/skills/converge/SKILL.md
+++ b/grip-starter/skills/converge/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: converge
+description: Recursive convergence on a task until criterion is met
+version: 1.0.0
+triggers:
+  - /converge
+  - complex multi-step tasks
+  - iterative improvement
+---
+
+# Converge
+
+Recursive convergence loop: keep improving until the criterion is satisfied.
+
+## Pattern
+
+```
+converge(
+    task="description of what to achieve",
+    criterion="measurable exit condition",
+    max_depth=3
+)
+```
+
+## How It Works
+
+1. **Assess**: Check current state against criterion
+2. **Improve**: Make one improvement step
+3. **Re-assess**: Check if criterion is now met
+4. **Recurse**: If not met, go to step 2 (up to max_depth)
+5. **Exit**: Report final state and whether criterion was met
+
+## Examples
+
+```
+converge(task="fix all lint errors", criterion="lint passes with 0 errors")
+converge(task="reduce bundle size", criterion="bundle < 500KB", max_depth=5)
+```
+
+## Guard Rails
+
+- Maximum depth prevents infinite loops
+- Each iteration must make measurable progress
+- If stuck (no progress for 2 iterations): HALT and ask user

--- a/grip-starter/skills/decision-lifecycle/SKILL.md
+++ b/grip-starter/skills/decision-lifecycle/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: decision-lifecycle
+description: Record, track, resolve, and audit decisions across their full lifecycle
+version: 1.0.0
+triggers:
+  - recording decisions
+  - checking outcomes
+  - decision reviews
+---
+
+# Decision Lifecycle
+
+Track decisions from proposal through resolution to retrospective review.
+
+## States
+
+1. **Proposed**: Decision identified, options listed
+2. **Evaluated**: Trade-offs analysed, recommendation made
+3. **Decided**: User has chosen an option
+4. **Implemented**: Decision has been executed
+5. **Reviewed**: Outcome checked against expectations
+
+## Recording
+
+When a significant decision is made, record:
+- **What**: The decision and chosen option
+- **Why**: The reasoning and trade-offs
+- **When**: Date of decision
+- **Alternatives**: What was rejected and why
+- **Review date**: When to check if the decision was correct

--- a/grip-starter/skills/dependency-guardian/SKILL.md
+++ b/grip-starter/skills/dependency-guardian/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: dependency-guardian
+description: Prevents reading from dependency directories that waste tokens
+version: 1.0.0
+triggers:
+  - file read operations
+  - search operations
+---
+
+# Dependency Guardian
+
+Mechanically prevents reading from dependency and build directories.
+
+## Forbidden Directories
+
+`node_modules`, `.next`, `dist`, `build`, `__pycache__`, `venv`, `.venv`,
+`target`, `vendor`, `Pods`, `.gradle`, `coverage`
+
+## Enforcement
+
+The `dependency-guardian-hook.py` PreToolUse hook blocks Read/Grep/Glob/Bash
+calls targeting forbidden directories.
+
+## Alternatives
+
+- Read `.d.ts` type definitions
+- Check package README/docs
+- Use public API documentation
+- Reference `package.json` for versions

--- a/grip-starter/skills/design-principles/SKILL.md
+++ b/grip-starter/skills/design-principles/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: design-principles
+description: Unified software design principles — SOLID, GRASP, DRY, KISS, YAGNI, BIG-O
+version: 1.0.0
+triggers:
+  - designing architecture
+  - reviewing code
+  - refactoring
+---
+
+# Design Principles
+
+## SOLID
+- **S**ingle Responsibility: One reason to change per class/module
+- **O**pen/Closed: Open for extension, closed for modification
+- **L**iskov Substitution: Subtypes must be substitutable for base types
+- **I**nterface Segregation: Many specific interfaces over one general
+- **D**ependency Inversion: Depend on abstractions, not concretions
+
+## GRASP
+- Information Expert: Assign responsibility to the class with the information
+- Creator: Assign creation to the class that has the initialising data
+- Controller: Assign system events to a non-UI class
+- Low Coupling / High Cohesion: Minimise dependencies, maximise focus
+
+## DRY (Don't Repeat Yourself)
+Every piece of knowledge has a single, authoritative representation.
+Three similar lines of code is NOT a DRY violation — premature abstraction is worse.
+
+## KISS (Keep It Simple)
+The right amount of complexity is the minimum needed for the current task.
+
+## YAGNI (You Aren't Gonna Need It)
+Don't build for hypothetical future requirements.
+
+## BIG-O
+Be aware of algorithmic complexity. Flag O(n^2)+ patterns.

--- a/grip-starter/skills/dry-kiss-enforcer/SKILL.md
+++ b/grip-starter/skills/dry-kiss-enforcer/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: dry-kiss-enforcer
+description: Enforces DRY and KISS principles to eliminate duplication and over-engineering
+version: 1.0.0
+triggers:
+  - code review
+  - writing new code
+  - refactoring
+---
+
+# DRY/KISS Enforcer
+
+## DRY (Don't Repeat Yourself)
+
+Every piece of knowledge should have a single, authoritative representation.
+
+**Important nuance**: Three similar lines of code is NOT automatically a DRY violation.
+Premature abstraction is worse than mild duplication. Extract only when:
+- The same logic appears 3+ times
+- The duplicated code changes together
+- The abstraction has a clear, meaningful name
+
+## KISS (Keep It Simple)
+
+The right amount of complexity is the minimum needed for the current task.
+
+**Signs of KISS violation**:
+- Helper functions called from exactly one place
+- Abstractions with only one implementation
+- Configuration for things that never change
+- Generic solutions for specific problems
+
+## Enforcement
+
+The `quality-hook.py` PreToolUse hook detects duplicate code blocks and warns.

--- a/grip-starter/skills/grip-first-retrieval/SKILL.md
+++ b/grip-starter/skills/grip-first-retrieval/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: grip-first-retrieval
+description: Check what you already know before searching externally
+version: 1.0.0
+triggers:
+  - information retrieval
+  - uncertainty about facts
+  - knowledge lookup
+---
+
+# GRIP-First Retrieval
+
+When unsure or retrieving information, check what you already know first.
+
+## Retrieval Tiers (escalate only when prior tier fails)
+
+| Tier | Method | Cost | When |
+|------|--------|------|------|
+| 0 | Session context / mental model | ~0 tokens | "Do I already know this?" |
+| 1 | Memory files (project + global) | ~200 tokens | Saved knowledge |
+| 2 | Structured lookup (Read known paths) | ~500 tokens | Known file locations |
+| 3 | Filesystem search (Grep/Glob) | ~1000 tokens | Unknown file locations |
+| 4 | Explore agent | ~88k tokens | ONLY after tiers 0-3 exhausted |
+
+Each escalation requires a documented reason. Return at the FIRST tier that resolves.
+
+## When to Skip
+
+- Direct execution commands ("fix this bug")
+- Pure creation tasks ("write a new component")
+- User-requested web searches
+- Conversational exchanges

--- a/grip-starter/skills/secrets-detection/SKILL.md
+++ b/grip-starter/skills/secrets-detection/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: secrets-detection
+description: Detect and prevent accidental exposure of secrets in code and output
+version: 1.0.0
+triggers:
+  - file writes
+  - git commits
+  - tool output scanning
+---
+
+# Secrets Detection
+
+Prevents accidental exposure of API keys, tokens, passwords, and other secrets.
+
+## Detected Patterns
+
+- AWS access keys (`AKIA...`)
+- GitHub PATs (`ghp_...`, `gho_...`, `ghs_...`)
+- Slack tokens (`xoxb-...`, `xoxp-...`)
+- API secret keys (`sk-...`)
+- Stripe keys (`sk_live_...`, `rk_live_...`)
+- Private keys (`-----BEGIN PRIVATE KEY-----`)
+- JWT tokens (`eyJ...`)
+- Hardcoded passwords
+
+## Enforcement
+
+The `secrets-hook.py` PostToolUse hook scans tool output for secret patterns
+and warns before they can be committed.
+
+## Prevention
+
+- Use environment variables, not hardcoded values
+- Use `.env` files (never commit them)
+- Use secrets managers for production
+- Add `.env` to `.gitignore`

--- a/grip-starter/skills/session-context-preservation/SKILL.md
+++ b/grip-starter/skills/session-context-preservation/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: session-context-preservation
+description: Auto-update session state for seamless cross-session continuity
+version: 1.0.0
+triggers:
+  - milestone completion
+  - session end
+  - context gate (85%)
+---
+
+# Session Context Preservation
+
+Automatically save session state so the next session can pick up seamlessly.
+
+## What to Save
+
+- Completed work items
+- Remaining tasks
+- Key decisions made
+- Files modified
+- Current approach/strategy
+- Blockers encountered
+
+## Where to Save
+
+Project memory directory: `~/.claude/projects/<project>/memory/session_context.md`
+
+## When to Save
+
+1. After each major milestone (PR created, feature complete, etc.)
+2. When context reaches 85% (before compaction)
+3. When user invokes `/save`
+4. Before session ends

--- a/grip-starter/skills/worktree-isolation/SKILL.md
+++ b/grip-starter/skills/worktree-isolation/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: worktree-isolation
+description: Git worktree isolation for concurrent sessions and safe branch work
+version: 1.0.0
+triggers:
+  - concurrent sessions detected
+  - branch switching needed
+  - isolation required
+---
+
+# Worktree Isolation
+
+Use git worktrees to isolate concurrent work and prevent branch conflicts.
+
+## When to Use
+
+- Multiple Claude Code sessions running simultaneously
+- Feature work that shouldn't affect the main working directory
+- Experimental changes that need easy cleanup
+
+## Pattern
+
+```bash
+git worktree add /tmp/feature-name feat/feature-name
+cd /tmp/feature-name
+# ... do work, commit, push ...
+git worktree remove /tmp/feature-name
+```
+
+## Benefits
+
+- Main session stays on `main` branch
+- No risk of concurrent branch switching
+- Easy cleanup — just remove the worktree
+- Full git history available in the worktree

--- a/package.json
+++ b/package.json
@@ -40,11 +40,13 @@
       "!node_modules/@next/env",
       "!node_modules/@next/eslint-plugin-next",
       "skills/**/*",
-      "hooks/**/*"
+      "hooks/**/*",
+      "grip-starter/**/*"
     ],
     "asarUnpack": [
       "out/**/*",
       "hooks/**/*",
+      "grip-starter/**/*",
       "electron/resources/**/*",
       "node_modules/better-sqlite3/**/*",
       "node_modules/node-pty/**/*"

--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -3,9 +3,11 @@
 import { useState, useRef, useEffect, useCallback, type ClipboardEvent, type DragEvent } from 'react';
 import { Send, Sparkles, Square, X, Image as ImageIcon } from 'lucide-react';
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
-import { sendToGrip, filterResponseMetadata, type GripMessage, type GripMetrics, type ToolUseEvent, type ToolResultEvent } from '@/lib/grip-session';
+import { sendToGrip, filterResponseMetadata, detectGateInText, type GripMessage, type GripMetrics, type ToolUseEvent, type ToolResultEvent, type GateEvent } from '@/lib/grip-session';
 import TypingIndicator from './TypingIndicator';
+import ThinkingIndicator from './ThinkingIndicator';
 import ToolUseBlock from './ToolUseBlock';
+import GateIndicator from './GateIndicator';
 import {
   getChatMessages,
   saveChatMessages,
@@ -60,6 +62,7 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
   const [input, setInput] = useState('');
   const [isStreaming, setIsStreaming] = useState(false);
   const [showSpinner, setShowSpinner] = useState(false);
+  const [isThinking, setIsThinking] = useState(false);
   const [sessionId, setSessionId] = useState<string | undefined>();
   const [model, setModel] = useState('sonnet');
   const spinnerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -184,6 +187,7 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
     let lastPersistTime = 0;
     const toolUses: ToolUseEvent[] = [];
     const toolResults: ToolResultEvent[] = [];
+    const gates: GateEvent[] = [];
 
     const promptText = input.trim() + imageContext;
     try {
@@ -193,7 +197,17 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
         model,
         (id) => { activePromptSessionRef.current = id; if (chatId) activeStreams.set(chatId, id); },
       )) {
-        if (event.type === 'text') {
+        if (event.type === 'thinking') {
+          // Show thinking indicator — extended reasoning in progress
+          setIsThinking(true);
+          if (spinnerTimerRef.current) {
+            clearTimeout(spinnerTimerRef.current);
+            spinnerTimerRef.current = null;
+          }
+          setShowSpinner(false);
+        } else if (event.type === 'text') {
+          // Text arrived — thinking phase is over
+          setIsThinking(false);
           if (!receivedFirstToken) {
             receivedFirstToken = true;
             if (spinnerTimerRef.current) {
@@ -202,10 +216,23 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
             }
             setShowSpinner(false);
           }
-          fullText += event.data as string;
+          const textChunk = event.data as string;
+          fullText += textChunk;
           pendingContentRef.current = filterResponseMetadata(fullText);
           if (rafIdRef.current === null) {
             rafIdRef.current = requestAnimationFrame(flushStreamUpdate);
+          }
+          // Detect GRIP gate patterns in text chunks
+          const gate = detectGateInText(textChunk);
+          if (gate) {
+            gates.push(gate);
+            setMessages(prev => {
+              const last = prev[prev.length - 1];
+              if (last?.role === 'assistant' && last?.streaming) {
+                return [...prev.slice(0, -1), { ...last, gates: [...gates] }];
+              }
+              return prev;
+            });
           }
           // Periodic persist for tab-switch resilience
           const now = Date.now();
@@ -278,6 +305,7 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
         lastMsg.detectedSkills = detectSkills(userMessage.content);
         if (toolUses.length) lastMsg.toolUses = toolUses;
         if (toolResults.length) lastMsg.toolResults = toolResults;
+        if (gates.length) lastMsg.gates = gates;
       }
       if (chatId) saveChatMessages(chatId, updated);
       return [...updated];
@@ -293,6 +321,7 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
     }
     activePromptSessionRef.current = null;
     setIsStreaming(false);
+    setIsThinking(false);
     setShowSpinner(false);
     if (spinnerTimerRef.current) {
       clearTimeout(spinnerTimerRef.current);
@@ -501,6 +530,10 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
                       </div>
                     )}
                     <MarkdownContent content={msg.content} />
+                    {/* Gate indicators — show when GRIP safety gates fire */}
+                    {msg.gates && msg.gates.length > 0 && (
+                      <GateIndicator gates={msg.gates} />
+                    )}
                     {/* Tool use blocks — show what the agent is doing */}
                     {msg.toolUses && msg.toolUses.length > 0 && (
                       <div className="mt-2 space-y-0.5">
@@ -540,7 +573,10 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
               </motion.div>
             ))}
             </AnimatePresence>
-            {isStreaming && showSpinner && messages[messages.length - 1]?.content === '' && (
+            {isStreaming && isThinking && (
+              <ThinkingIndicator />
+            )}
+            {isStreaming && showSpinner && !isThinking && messages[messages.length - 1]?.content === '' && (
               <TypingIndicator />
             )}
             <div ref={messagesEndRef} />

--- a/src/components/Engine/GateIndicator.tsx
+++ b/src/components/Engine/GateIndicator.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Shield, ChevronDown, ChevronUp } from 'lucide-react';
+
+export interface GateEvent {
+  id: string;
+  type: 'deny' | 'warn' | 'info';
+  gate: string;
+  message: string;
+  timestamp: Date;
+}
+
+interface GateIndicatorProps {
+  gates: GateEvent[];
+}
+
+const TYPE_STYLES = {
+  deny: {
+    border: 'border-red-800/60',
+    bg: 'bg-red-950/30',
+    icon: 'text-red-400',
+    label: 'BLOCKED',
+    labelColor: 'text-red-400',
+  },
+  warn: {
+    border: 'border-amber-800/60',
+    bg: 'bg-amber-950/20',
+    icon: 'text-amber-400',
+    label: 'WARNING',
+    labelColor: 'text-amber-400',
+  },
+  info: {
+    border: 'border-blue-800/60',
+    bg: 'bg-blue-950/20',
+    icon: 'text-blue-400',
+    label: 'GATE',
+    labelColor: 'text-blue-400',
+  },
+};
+
+/**
+ * Gate indicator — shows when GRIP safety gates fire during a response.
+ * Displays denied actions (red), warnings (amber), and info (blue).
+ * Expandable to show the full gate message.
+ */
+export default function GateIndicator({ gates }: GateIndicatorProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (gates.length === 0) return null;
+
+  const latest = gates[gates.length - 1];
+  const style = TYPE_STYLES[latest.type];
+
+  return (
+    <div className="my-2">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className={`w-full flex items-center gap-2 px-3 py-2 border ${style.border} ${style.bg} text-left transition-colors hover:opacity-90`}
+      >
+        <Shield className={`w-3.5 h-3.5 ${style.icon} flex-shrink-0`} />
+        <span className={`font-mono text-[10px] tracking-widest ${style.labelColor} flex-shrink-0`}>
+          {style.label}
+        </span>
+        <span className="font-mono text-xs text-[var(--muted-foreground)] truncate flex-1">
+          {latest.gate}
+        </span>
+        <span className="font-mono text-[9px] text-[var(--muted-foreground)] opacity-50 flex-shrink-0">
+          {gates.length > 1 ? `${gates.length} gates` : ''}
+        </span>
+        {expanded ? (
+          <ChevronUp className="w-3 h-3 text-[var(--muted-foreground)] flex-shrink-0" />
+        ) : (
+          <ChevronDown className="w-3 h-3 text-[var(--muted-foreground)] flex-shrink-0" />
+        )}
+      </button>
+
+      <AnimatePresence>
+        {expanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            className="overflow-hidden"
+          >
+            <div className={`border border-t-0 ${style.border} ${style.bg} px-3 py-2 space-y-1.5`}>
+              {gates.map((gate) => {
+                const gStyle = TYPE_STYLES[gate.type];
+                return (
+                  <div key={gate.id} className="flex items-start gap-2">
+                    <span className={`font-mono text-[9px] tracking-widest ${gStyle.labelColor} mt-0.5 flex-shrink-0`}>
+                      {gStyle.label}
+                    </span>
+                    <span className="font-mono text-xs text-[var(--muted-foreground)]">
+                      {gate.message}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/Engine/ThinkingIndicator.tsx
+++ b/src/components/Engine/ThinkingIndicator.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+/**
+ * Thinking indicator — shown when Claude is in extended thinking mode.
+ * Distinct from TypingIndicator: slower pulse, different colour (amber),
+ * and a brain-like visual to communicate deep reasoning vs. text generation.
+ */
+export default function ThinkingIndicator() {
+  return (
+    <div className="flex justify-start">
+      <div className="border border-amber-800/40 bg-amber-950/20 p-3 flex items-center gap-3">
+        {/* Pulsing concentric rings — represents deep thought */}
+        <div className="relative w-5 h-5 flex items-center justify-center">
+          <motion.div
+            className="absolute w-5 h-5 border border-amber-500/40"
+            animate={{ scale: [1, 1.5, 1], opacity: [0.4, 0, 0.4] }}
+            transition={{ repeat: Infinity, duration: 2, ease: 'easeInOut' }}
+          />
+          <motion.div
+            className="absolute w-3 h-3 border border-amber-500/60"
+            animate={{ scale: [1, 1.3, 1], opacity: [0.6, 0.2, 0.6] }}
+            transition={{ repeat: Infinity, duration: 2, delay: 0.3, ease: 'easeInOut' }}
+          />
+          <div className="w-1.5 h-1.5 bg-amber-400" />
+        </div>
+
+        <span className="font-mono text-[10px] tracking-widest text-amber-400/80">
+          EXTENDED THINKING...
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/grip-session.ts
+++ b/src/lib/grip-session.ts
@@ -27,6 +27,14 @@ export interface ToolResultEvent {
   isError?: boolean;
 }
 
+export interface GateEvent {
+  id: string;
+  type: 'deny' | 'warn' | 'info';
+  gate: string;
+  message: string;
+  timestamp: Date;
+}
+
 export interface GripMessage {
   id: string;
   role: 'user' | 'assistant' | 'system';
@@ -39,6 +47,7 @@ export interface GripMessage {
   imageDataUrl?: string;
   toolUses?: ToolUseEvent[];
   toolResults?: ToolResultEvent[];
+  gates?: GateEvent[];
   isThinking?: boolean;
 }
 
@@ -155,7 +164,7 @@ export function extractTextFromEvent(event: StreamEvent): string | null {
   // Skip non-text events entirely — these should NEVER be shown to the user
   const skipTypes = ['system', 'init', 'tool_use', 'tool_result', 'content_block_start',
     'content_block_stop', 'message_start', 'message_stop', 'ping',
-    'result', 'error', 'input_json'];
+    'result', 'error', 'input_json', 'thinking'];
   if (skipTypes.includes(event.type)) return null;
   // Also skip if event has subtype 'init' (system init events)
   if ((event as unknown as Record<string, unknown>).subtype === 'init') return null;
@@ -207,6 +216,86 @@ export function extractToolResult(event: StreamEvent): ToolResultEvent | null {
         : '';
     return { toolId: event.tool_use_id, output, isError: event.is_error };
   }
+  return null;
+}
+
+/**
+ * Extract thinking event data.
+ * Claude CLI emits thinking events during extended thinking (stream-json).
+ * Returns the thinking text content, or null if not a thinking event.
+ */
+export function extractThinking(event: StreamEvent): string | null {
+  if (event.type === 'thinking' && typeof event.text === 'string') {
+    return event.text;
+  }
+  // Content block with thinking type
+  if (event.type === 'content_block_start' && event.delta?.type === 'thinking') {
+    return '';
+  }
+  if (event.delta?.type === 'thinking_delta' && event.delta.text) {
+    return event.delta.text;
+  }
+  return null;
+}
+
+/**
+ * Detect GRIP gate patterns in text.
+ * Returns a GateEvent if a gate pattern is found, null otherwise.
+ * Gate patterns: [GRIP], [QUALITY], [GRIP SECRET WARNING], [LEARNING]
+ */
+export function detectGateInText(text: string): GateEvent | null {
+  if (!text) return null;
+
+  // Blocked actions
+  const denyMatch = text.match(/\[GRIP\]\s*Blocked:\s*(.+)/i);
+  if (denyMatch) {
+    return {
+      id: crypto.randomUUID(),
+      type: 'deny',
+      gate: 'Dependency Guardian',
+      message: denyMatch[1].trim(),
+      timestamp: new Date(),
+    };
+  }
+
+  // Quality warnings
+  const qualityMatch = text.match(/\[QUALITY\]\s*(.+)/i);
+  if (qualityMatch) {
+    const msg = qualityMatch[1].trim();
+    const isDeny = msg.toLowerCase().includes('exceeds threshold');
+    return {
+      id: crypto.randomUUID(),
+      type: isDeny ? 'deny' : 'warn',
+      gate: 'Quality Gate',
+      message: msg,
+      timestamp: new Date(),
+    };
+  }
+
+  // Secret warnings
+  const secretMatch = text.match(/\[GRIP SECRET WARNING\]\s*(.+)/i);
+  if (secretMatch) {
+    return {
+      id: crypto.randomUUID(),
+      type: 'warn',
+      gate: 'Secrets Detection',
+      message: secretMatch[1].trim(),
+      timestamp: new Date(),
+    };
+  }
+
+  // Anti-drift reminders
+  const driftMatch = text.match(/\[GRIP\]\s*Task completed\.\s*(.+)/i);
+  if (driftMatch) {
+    return {
+      id: crypto.randomUUID(),
+      type: 'info',
+      gate: 'Anti-Drift',
+      message: driftMatch[1].trim(),
+      timestamp: new Date(),
+    };
+  }
+
   return null;
 }
 
@@ -304,6 +393,10 @@ export async function* sendToGrip(
 
         try {
           const event: StreamEvent = JSON.parse(line);
+          const thinking = extractThinking(event);
+          if (thinking !== null) {
+            yield { type: 'thinking', data: thinking };
+          }
           const text = extractTextFromEvent(event);
           if (text) {
             yield { type: 'text', data: text };
@@ -393,7 +486,7 @@ async function* sendToGripElectron(
     onPromptSessionId?.(promptSessionId);
 
     // Collect output via events using a promise-based queue
-    type ChunkType = 'text' | 'metrics' | 'tool_use' | 'tool_result' | 'done';
+    type ChunkType = 'text' | 'metrics' | 'tool_use' | 'tool_result' | 'thinking' | 'done';
     const chunks: Array<{ type: ChunkType; data: string | GripMetrics | ToolUseEvent | ToolResultEvent }> = [];
     let resolve: (() => void) | null = null;
     let done = false;
@@ -409,6 +502,8 @@ async function* sendToGripElectron(
       if (!line.trim()) return;
       try {
         const parsed: StreamEvent = JSON.parse(line);
+        const thinking = extractThinking(parsed);
+        if (thinking !== null) pushChunk('thinking', thinking);
         const text = extractTextFromEvent(parsed);
         if (text) pushChunk('text', text);
         const toolUse = extractToolUse(parsed);


### PR DESCRIPTION
## Summary

- **GRIP Starter Pack**: 46 files in `grip-starter/` — 20 skills, 7 agents, 4 hooks, 8 rules, 3 lib utilities. Bundled in DMG via `asarUnpack`. First-launch installer copies to `~/.claude/` with skip-if-exists strategy.
- **Thinking indicator**: Detects extended thinking events from stream-json, renders amber concentric pulse indicator distinct from typing indicator.
- **Gate visibility**: Detects GRIP safety gate patterns (`[GRIP]`, `[QUALITY]`, `[GRIP SECRET WARNING]`) in stream text, renders expandable gate indicator with deny/warn/info severity levels.

## Test plan

- [ ] Install DMG on clean machine (no existing ~/.claude/) — verify starter pack installs
- [ ] Install DMG on machine with existing GRIP — verify skip-if-exists preserves customisations
- [ ] Send a prompt that triggers extended thinking — verify amber indicator appears
- [ ] Trigger a dependency guardian block — verify red gate indicator appears
- [ ] Verify DMG build includes grip-starter/ in app.asar.unpacked