### PR TITLE
fix: add delay between paste and submit (#38)

### DIFF
--- a/electron/core/pty-manager.ts
+++ b/electron/core/pty-manager.ts
@@ -46,7 +46,9 @@ export function killAllPty(): void {
  */
 export function writeProgrammaticInput(ptyProcess: pty.IPty, data: string): void {
   ptyProcess.write(data);
-  ptyProcess.write('\r');
+  // Delay CR so Claude Code finishes processing the paste event before receiving submit.
+  // Without this, CC v2.1.81+ absorbs the \r into the paste buffer (see #38).
+  setTimeout(() => ptyProcess.write('\r'), 50);
 }
 
 export function writeToPty(ptyId: string, data: string, isQuick = false): boolean {


### PR DESCRIPTION
## Summary
- Fixes #38 — messages from Telegram/Slack stuck as pasted text
- Adds 50ms delay between write(data) and write(\r) in writeProgrammaticInput
- Claude Code v2.1.81+ treats back-to-back write+CR as paste event; delay lets paste processing complete before submit

## Test plan
- [ ] Send message via Telegram to idle Super Agent
- [ ] Verify message submits automatically (no manual Enter needed)
- [ ] Verify Slack messages also submit correctly