### PR TITLE
feat: add subtle entrance animations for delight

### DIFF
--- a/src/app/modes/page.tsx
+++ b/src/app/modes/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
 import { GRIP_MODES, MODE_CATEGORIES, type ModeCategory } from '@/lib/grip-modes';
 import { Check, Loader2 } from 'lucide-react';
 
@@ -9,6 +10,7 @@ export default function ModesPage() {
   const [activeCategory, setActiveCategory] = useState<ModeCategory | 'all'>('all');
   const [saving, setSaving] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const reduceMotion = useReducedMotion();
 
   // Load active modes from real ~/.claude/.active-modes
   useEffect(() => {
@@ -116,13 +118,17 @@ export default function ModesPage() {
 
       {/* Mode Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {filteredModes.map((mode) => {
+        {filteredModes.map((mode, index) => {
           const isActive = activeModes.includes(mode.id);
           return (
-            <button
+            <motion.button
               key={mode.id}
+              initial={reduceMotion ? false : { opacity: 0, scale: 0.96 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ duration: 0.25, delay: reduceMotion ? 0 : index * 0.03, ease: 'easeOut' }}
+              whileHover={reduceMotion ? undefined : { y: -2, boxShadow: '0 0 12px rgba(8,145,178,0.3)' }}
               onClick={() => toggleMode(mode.id)}
-              className={`text-left p-5 border transition-all min-h-[44px] ${
+              className={`text-left p-5 border transition-colors min-h-[44px] ${
                 isActive
                   ? 'border-[var(--primary)] bg-[var(--primary)]/5'
                   : 'border-[var(--border)] hover:border-[var(--primary)]/50'
@@ -159,7 +165,7 @@ export default function ModesPage() {
                   ))}
                 </div>
               )}
-            </button>
+            </motion.button>
           );
         })}
       </div>

--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -4,10 +4,10 @@ import { useStore } from '@/store';
 import Sidebar from './Sidebar';
 import CommandPalette from './CommandPalette';
 import KeyboardShortcutsHelp from './KeyboardShortcutsHelp';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { Menu, X, Download, ExternalLink, RotateCw, Loader2 } from 'lucide-react';
 import { useEffect, useState, useCallback, useRef } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 
 function useIsMobile() {
   const [isMobile, setIsMobile] = useState(false);
@@ -170,6 +170,10 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
 
   const mainMarginLeft = isMobile ? 0 : (sidebarCollapsed ? 72 : 240);
 
+  // Page transitions
+  const pathname = usePathname();
+  const reduceMotion = useReducedMotion();
+
   // Konami code easter egg
   const router = useRouter();
   const konamiRef = useRef(0);
@@ -235,7 +239,17 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
         transition={{ duration: 0.2, ease: 'easeInOut' }}
         className="min-h-screen pt-16 lg:pt-0 p-4 lg:p-6 pb-6"
       >
-        {children}
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={pathname}
+            initial={reduceMotion ? false : { opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={reduceMotion ? undefined : { opacity: 0 }}
+            transition={{ duration: 0.15, ease: 'easeOut' }}
+          >
+            {children}
+          </motion.div>
+        </AnimatePresence>
       </motion.main>
 
       {/* Update Available Dialog */}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import {
   Terminal,
   FolderKanban,
@@ -45,10 +45,21 @@ interface SidebarProps {
   isMobile?: boolean;
 }
 
+const navContainerVariants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.05 } },
+};
+
+const navItemVariants = {
+  hidden: { opacity: 0, x: -10 },
+  visible: { opacity: 1, x: 0, transition: { duration: 0.2, ease: 'easeOut' as const } },
+};
+
 export default function Sidebar({ isMobile = false }: SidebarProps) {
   const pathname = usePathname();
   const router = useRouter();
   const { sidebarCollapsed, toggleSidebar, mobileMenuOpen, setMobileMenuOpen, darkMode, toggleDarkMode, vaultUnreadCount } = useStore();
+  const reduceMotion = useReducedMotion();
 
   const sidebarWidth = isMobile ? 240 : (sidebarCollapsed ? 64 : 240);
   const showLabels = isMobile || !sidebarCollapsed;
@@ -131,11 +142,23 @@ export default function Sidebar({ isMobile = false }: SidebarProps) {
       </div>
 
       {/* Navigation */}
-      <nav className="flex-1 py-3 px-1 space-y-0.5 overflow-y-auto">
+      <motion.nav
+        className="flex-1 py-3 px-1 space-y-0.5 overflow-y-auto"
+        variants={reduceMotion ? undefined : navContainerVariants}
+        initial="hidden"
+        animate="visible"
+      >
         {navItems.map((item) => (
-          <NavLink key={item.href} item={item} onClick={isMobile ? handleNavClick : undefined} />
+          <motion.div
+            key={item.href}
+            variants={reduceMotion ? undefined : navItemVariants}
+            whileHover={reduceMotion ? undefined : { scale: 1.02 }}
+            transition={{ duration: 0.15 }}
+          >
+            <NavLink item={item} onClick={isMobile ? handleNavClick : undefined} />
+          </motion.div>
         ))}
-      </nav>
+      </motion.nav>
 
       {/* Bottom section */}
       <div className="border-t border-[var(--border)]">


### PR DESCRIPTION
## Summary
- Staggered sidebar nav entrance with hover micro-interactions (scale 1.02)
- Mode cards scale in (0.96->1) with 30ms stagger and cyan glow on hover
- Page transitions with 150ms opacity fade keyed on pathname
- All animations respect useReducedMotion for accessibility

## Test plan
- [x] `npm test` — 773/773 pass
- [x] TypeScript clean (no errors in changed files)
- [ ] Verify sidebar items animate on page load
- [ ] Verify mode cards animate on /modes page
- [ ] Verify page transitions are smooth between routes
- [ ] Verify no animation with prefers-reduced-motion