### PR TITLE
feat: live session metrics and recently-used commands

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -14,6 +14,21 @@ interface CommandItem {
   action: () => void;
 }
 
+const RECENT_KEY = 'grip-command-palette-recent';
+const MAX_RECENT = 5;
+
+function getRecentCommands(): string[] {
+  try {
+    return JSON.parse(localStorage.getItem(RECENT_KEY) || '[]');
+  } catch { return []; }
+}
+
+function saveRecentCommand(id: string): void {
+  const recent = getRecentCommands().filter(r => r !== id);
+  recent.unshift(id);
+  localStorage.setItem(RECENT_KEY, JSON.stringify(recent.slice(0, MAX_RECENT)));
+}
+
 export default function CommandPalette() {
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState('');
@@ -61,14 +76,24 @@ export default function CommandPalette() {
     { id: 'easter-vortex', label: 'Vortex', description: 'Enter the knowledge double helix', category: 'HIDDEN', action: () => router.push('/vortex') },
   ];
 
+  // Recently used commands (shown when no query)
+  const recentIds = getRecentCommands();
+  const recentCommands = recentIds
+    .map(id => commands.find(c => c.id === id))
+    .filter((c): c is CommandItem => c != null)
+    .map(c => ({ ...c, category: 'RECENT' }));
+
   // Filter commands
   const filtered = query
     ? commands.filter(cmd =>
         cmd.label.toLowerCase().includes(query.toLowerCase()) ||
         cmd.description.toLowerCase().includes(query.toLowerCase())
       )
-    : commands.filter(cmd => cmd.category === 'NAVIGATE' || cmd.category === 'ACTIONS')
-        .filter(cmd => cmd.category !== 'HIDDEN');
+    : [
+        ...recentCommands,
+        ...commands.filter(cmd => cmd.category === 'NAVIGATE' || cmd.category === 'ACTIONS')
+          .filter(cmd => cmd.category !== 'HIDDEN'),
+      ];
 
   // Group by category
   const grouped = filtered.reduce<Record<string, CommandItem[]>>((acc, cmd) => {
@@ -112,6 +137,7 @@ export default function CommandPalette() {
     } else if (e.key === 'Enter') {
       e.preventDefault();
       if (filtered[selectedIndex]) {
+        saveRecentCommand(filtered[selectedIndex].id);
         filtered[selectedIndex].action();
         setIsOpen(false);
       }
@@ -148,6 +174,9 @@ export default function CommandPalette() {
           <span className="font-mono text-[10px] text-[var(--muted-foreground)] border border-[var(--border)] px-1.5 py-0.5">
             ESC
           </span>
+          <span className="font-mono text-[10px] text-[var(--muted-foreground)] opacity-50">
+            ⌘K
+          </span>
         </div>
 
         {/* Results */}
@@ -164,7 +193,7 @@ export default function CommandPalette() {
                 return (
                   <button
                     key={item.id}
-                    onClick={() => { item.action(); setIsOpen(false); }}
+                    onClick={() => { saveRecentCommand(item.id); item.action(); setIsOpen(false); }}
                     className={`w-full flex items-center justify-between px-4 py-2.5 text-left transition-colors ${
                       currentIndex === selectedIndex
                         ? 'bg-[var(--primary)]/10 text-[var(--foreground)]'

--- a/src/components/Engine/GripStatusBar.tsx
+++ b/src/components/Engine/GripStatusBar.tsx
@@ -1,18 +1,21 @@
 'use client';
 
-import { Activity, Layers, Sparkles, Shield } from 'lucide-react';
+import { Activity, Layers, Sparkles, Shield, Clock, Cpu, Zap } from 'lucide-react';
 import GripPulse from './GripPulse';
+import type { GripMetrics } from '@/lib/grip-session';
 
 interface GripStatusBarProps {
   activeMode?: string;
   skillCount?: number;
   contextPercent?: number;
   safetyActive?: boolean;
+  metrics?: GripMetrics | null;
+  isStreaming?: boolean;
 }
 
 /**
  * A minimal status bar at the bottom of the Engine page.
- * Shows active mode, skill count, context usage, and safety gate status.
+ * Shows active mode, skill count, context usage, safety gate status, and live session metrics.
  * Swiss Nihilism: monospace, tracking-widest, paper-thin, no height waste.
  */
 export default function GripStatusBar({
@@ -20,6 +23,8 @@ export default function GripStatusBar({
   skillCount = 5,
   contextPercent = 23,
   safetyActive = true,
+  metrics,
+  isStreaming = false,
 }: GripStatusBarProps) {
   return (
     <div className="fixed bottom-0 left-0 right-0 z-20 h-6 border-t border-[var(--border)] bg-[var(--card)] flex items-center px-4 gap-6 shrink-0">
@@ -52,6 +57,40 @@ export default function GripStatusBar({
           />
         </div>
       </div>
+
+      {/* Live session metrics */}
+      {isStreaming && (
+        <div className="flex items-center gap-1.5">
+          <Zap className="w-3 h-3 text-[var(--primary)] animate-pulse" strokeWidth={1.5} />
+          <span className="font-mono text-[9px] tracking-widest text-[var(--primary)]">
+            STREAMING
+          </span>
+        </div>
+      )}
+
+      {metrics?.model && (
+        <div className="flex items-center gap-1.5">
+          <Cpu className="w-3 h-3 text-[var(--muted-foreground)]" strokeWidth={1.5} />
+          <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)]">
+            {metrics.model.toUpperCase()}
+          </span>
+        </div>
+      )}
+
+      {metrics?.totalDurationMs && !isStreaming && (
+        <div className="flex items-center gap-1.5">
+          <Clock className="w-3 h-3 text-[var(--muted-foreground)]" strokeWidth={1.5} />
+          <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)]">
+            {(metrics.totalDurationMs / 1000).toFixed(1)}s
+          </span>
+        </div>
+      )}
+
+      {metrics?.numTurns && (
+        <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)]">
+          {metrics.numTurns} TURNS
+        </span>
+      )}
 
       {/* Spacer */}
       <div className="flex-1" />


### PR DESCRIPTION
## Summary
- GripStatusBar: live streaming indicator, model name, response duration, turn count
- CommandPalette: recently-used commands shown at top (persisted in localStorage)
- CommandPalette: cmd-K hint badge added

## Test plan
- [x] `npm test` — 773/773 pass
- [x] TypeScript clean (no errors in changed files)
- [ ] Verify status bar shows model and duration after response
- [ ] Verify streaming indicator pulses during active stream
- [ ] Verify recently-used commands appear after first use
- [ ] Verify cmd-K opens palette