### PR TITLE
feat: chat history stagger animations and context panel transitions

### DIFF
--- a/src/components/Engine/ChatHistory.tsx
+++ b/src/components/Engine/ChatHistory.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { Plus, Trash2, MessageSquare } from 'lucide-react';
 import {
   getChatSessions,
@@ -25,6 +26,7 @@ interface ChatHistoryProps {
 export default function ChatHistory({ onSessionChange, onNewChat, currentModel }: ChatHistoryProps) {
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
+  const reduceMotion = useReducedMotion();
 
   useEffect(() => {
     setSessions(getChatSessions());
@@ -89,9 +91,14 @@ export default function ChatHistory({ onSessionChange, onNewChat, currentModel }
             </span>
           </div>
         ) : (
-          sessions.map(session => (
-            <div
+          <AnimatePresence initial={!reduceMotion}>
+          {sessions.map((session, index) => (
+            <motion.div
               key={session.id}
+              initial={reduceMotion ? false : { opacity: 0, x: -8 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={reduceMotion ? undefined : { opacity: 0, height: 0, marginBottom: 0 }}
+              transition={{ duration: 0.2, delay: reduceMotion ? 0 : index * 0.03 }}
               role="button"
               tabIndex={0}
               onClick={() => handleSelectChat(session.id)}
@@ -124,8 +131,9 @@ export default function ChatHistory({ onSessionChange, onNewChat, currentModel }
                   {session.model.toUpperCase()}
                 </span>
               </div>
-            </div>
-          ))
+            </motion.div>
+          ))}
+          </AnimatePresence>
         )}
       </div>
     </div>

--- a/src/components/Engine/ContextPanel.tsx
+++ b/src/components/Engine/ContextPanel.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { motion, useReducedMotion } from 'framer-motion';
 import { Layers, Sparkles, Activity, Plus } from 'lucide-react';
 import RetrievalTierIndicator from './RetrievalTierIndicator';
 import ConvergenceIndicator from './ConvergenceIndicator';
@@ -18,6 +19,8 @@ export default function ContextPanel({
   contextUsage = 23,
   tokenCount = 45200,
 }: ContextPanelProps) {
+  const reduceMotion = useReducedMotion();
+  const ctxColour = contextUsage > 80 ? 'var(--danger)' : contextUsage > 60 ? 'var(--warning)' : 'var(--primary)';
   return (
     <div className="h-full flex flex-col bg-[var(--card)]">
       {/* Mode — Quick Switch */}
@@ -30,13 +33,19 @@ export default function ContextPanel({
       <div className="p-4 border-b border-[var(--border)]">
         <span className="grip-label block mb-2">SKILLS</span>
         <div className="space-y-1.5">
-          {activeSkills.map((skill) => (
-            <div key={skill} className="flex items-center gap-2">
+          {activeSkills.map((skill, i) => (
+            <motion.div
+              key={skill}
+              className="flex items-center gap-2"
+              initial={reduceMotion ? false : { opacity: 0, x: -6 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ duration: 0.2, delay: reduceMotion ? 0 : i * 0.05 }}
+            >
               <Sparkles className="w-3 h-3 text-[var(--primary)]" strokeWidth={1.5} />
               <span className="font-mono text-[11px] tracking-wider text-[var(--foreground)]">
                 {skill}
               </span>
-            </div>
+            </motion.div>
           ))}
           <button className="flex items-center gap-2 mt-2 text-[var(--muted-foreground)] hover:text-[var(--primary)] transition-colors">
             <Plus className="w-3 h-3" strokeWidth={1.5} />
@@ -54,10 +63,13 @@ export default function ContextPanel({
               <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">CTX</span>
               <span className="font-mono text-[10px] tracking-wider text-[var(--foreground)]">{contextUsage}%</span>
             </div>
-            <div className="w-full h-1 bg-[var(--border)]">
-              <div
-                className="h-full bg-[var(--primary)] transition-all"
-                style={{ width: `${contextUsage}%` }}
+            <div className="w-full h-1.5 bg-[var(--border)] overflow-hidden">
+              <motion.div
+                className="h-full"
+                initial={reduceMotion ? { width: `${contextUsage}%` } : { width: '0%' }}
+                animate={{ width: `${contextUsage}%` }}
+                transition={{ duration: 0.8, ease: [0.16, 1, 0.3, 1] }}
+                style={{ backgroundColor: ctxColour }}
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- ChatHistory: staggered slide-in (30ms per session), delete animation with collapse
- ContextPanel: animated context bar fill (800ms spring), colour transitions by usage level
- ContextPanel: skills list entrance with 50ms stagger
- All animations respect useReducedMotion

## Test plan
- [x] `npm test` — 773/773 pass
- [x] TypeScript clean
- [ ] Verify chat sessions animate in on sidebar open
- [ ] Verify deleting a chat shows exit animation
- [ ] Verify context bar fills smoothly on panel mount
- [ ] Verify context bar colour changes at 60%/80% thresholds