### PR TITLE
feat: agent card entrance, skill grid stagger, cinematic focus mode

### DIFF
--- a/src/components/AgentList/AgentCard.tsx
+++ b/src/components/AgentList/AgentCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { motion, useReducedMotion } from 'framer-motion';
 import { Loader2, AlertTriangle, GitBranch, Pencil, Crown } from 'lucide-react';
 import type { AgentStatus } from '@/types/electron';
 import { STATUS_COLORS, CHARACTER_FACES, getProjectColor, isSuperAgentCheck } from '@/app/agents/constants';
@@ -14,17 +15,23 @@ interface AgentCardProps {
   isSelected: boolean;
   onSelect: () => void;
   onEdit: () => void;
+  index?: number;
 }
 
-export function AgentCard({ agent, isSelected, onSelect, onEdit }: AgentCardProps) {
+export function AgentCard({ agent, isSelected, onSelect, onEdit, index = 0 }: AgentCardProps) {
   const statusConfig = STATUS_COLORS[agent.status];
   const StatusIcon = statusConfig.icon;
   const projectName = agent.projectPath.split('/').pop() || 'Unknown';
   const projectColor = getProjectColor(projectName);
   const isSuper = isSuperAgentCheck(agent);
+  const reduceMotion = useReducedMotion();
 
   return (
-    <div
+    <motion.div
+      initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, delay: reduceMotion ? 0 : index * 0.05, ease: 'easeOut' }}
+      whileHover={reduceMotion ? undefined : { x: 2 }}
       onClick={onSelect}
       className={`
         p-4 cursor-pointer transition-all relative
@@ -150,6 +157,6 @@ export function AgentCard({ agent, isSelected, onSelect, onEdit }: AgentCardProp
           )}
         </div>
       </div>
-    </div>
+    </motion.div>
   );
 }

--- a/src/components/Engine/FocusMode.tsx
+++ b/src/components/Engine/FocusMode.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { Minimize2, Maximize2 } from 'lucide-react';
 
 interface FocusModeProps {
@@ -21,6 +22,7 @@ interface FocusModeProps {
  */
 export default function FocusMode({ children, onToggle }: FocusModeProps) {
   const [focused, setFocused] = useState(false);
+  const reduceMotion = useReducedMotion();
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -41,11 +43,11 @@ export default function FocusMode({ children, onToggle }: FocusModeProps) {
     return () => window.removeEventListener('keydown', handler);
   }, [focused, onToggle]);
 
-  if (!focused) {
-    return (
-      <div className="relative">
-        {children}
-        {/* Focus mode trigger */}
+  return (
+    <div className="relative">
+      {children}
+      {/* Focus mode trigger */}
+      {!focused && (
         <button
           onClick={() => { setFocused(true); onToggle?.(true); }}
           className="absolute top-3 right-3 p-2 text-[var(--muted-foreground)] hover:text-[var(--primary)] transition-colors opacity-0 hover:opacity-100"
@@ -53,32 +55,49 @@ export default function FocusMode({ children, onToggle }: FocusModeProps) {
         >
           <Maximize2 className="w-4 h-4" strokeWidth={1.5} />
         </button>
-      </div>
-    );
-  }
+      )}
 
-  return (
-    <div className="fixed inset-0 z-[100] bg-[var(--background)] animate-fade-in">
-      {/* Exit button */}
-      <button
-        onClick={() => { setFocused(false); onToggle?.(false); }}
-        className="fixed top-4 right-4 z-[101] p-2 text-[var(--muted-foreground)] hover:text-[var(--primary)] transition-colors border border-[var(--border)] bg-[var(--card)]"
-        title="Exit Focus Mode (Esc)"
-      >
-        <Minimize2 className="w-4 h-4" strokeWidth={1.5} />
-      </button>
+      {/* Cinematic focus overlay */}
+      <AnimatePresence>
+        {focused && (
+          <motion.div
+            className="fixed inset-0 z-[100] bg-[var(--background)]"
+            initial={reduceMotion ? { opacity: 1 } : { opacity: 0, scale: 1.02 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.98 }}
+            transition={{ duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
+          >
+            {/* Exit button */}
+            <motion.button
+              onClick={() => { setFocused(false); onToggle?.(false); }}
+              className="fixed top-4 right-4 z-[101] p-2 text-[var(--muted-foreground)] hover:text-[var(--primary)] transition-colors border border-[var(--border)] bg-[var(--card)]"
+              title="Exit Focus Mode (Esc)"
+              initial={reduceMotion ? false : { opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ delay: 0.3 }}
+            >
+              <Minimize2 className="w-4 h-4" strokeWidth={1.5} />
+            </motion.button>
 
-      {/* Mode indicator */}
-      <div className="fixed top-4 left-4 z-[101]">
-        <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)] opacity-40">
-          FOCUS MODE
-        </span>
-      </div>
+            {/* Mode indicator */}
+            <motion.div
+              className="fixed top-4 left-4 z-[101]"
+              initial={reduceMotion ? false : { opacity: 0, x: -8 }}
+              animate={{ opacity: 0.4, x: 0 }}
+              transition={{ delay: 0.2, duration: 0.3 }}
+            >
+              <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)]">
+                FOCUS MODE
+              </span>
+            </motion.div>
 
-      {/* Full-width chat */}
-      <div className="h-full max-w-4xl mx-auto">
-        {children}
-      </div>
+            {/* Full-width chat */}
+            <div className="h-full max-w-4xl mx-auto">
+              {children}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/src/components/SkillBrowser.tsx
+++ b/src/components/SkillBrowser.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
 import { Search, Sparkles, Shield } from 'lucide-react';
 import { GRIP_SKILLS, SKILL_CATEGORIES, type SkillCategory, searchSkills, getParamountSkills } from '@/lib/grip-skills';
 import SkillPill from '@/components/Engine/SkillPill';
@@ -15,6 +16,7 @@ import SkillPill from '@/components/Engine/SkillPill';
 export default function SkillBrowser() {
   const [query, setQuery] = useState('');
   const [activeCategory, setActiveCategory] = useState<SkillCategory | 'all'>('all');
+  const reduceMotion = useReducedMotion();
 
   const filteredSkills = useMemo(() => {
     let skills = query ? searchSkills(query) : GRIP_SKILLS;
@@ -99,9 +101,13 @@ export default function SkillBrowser() {
 
       {/* Skill grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-        {filteredSkills.map((skill) => (
-          <div
+        {filteredSkills.map((skill, index) => (
+          <motion.div
             key={skill.id}
+            initial={reduceMotion ? false : { opacity: 0, scale: 0.97 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.2, delay: reduceMotion ? 0 : Math.min(index * 0.015, 0.3) }}
+            whileHover={reduceMotion ? undefined : { y: -1, borderColor: 'var(--primary)' }}
             className={`p-4 border transition-colors ${
               skill.paramount
                 ? 'border-[var(--primary)]/30 bg-[var(--primary)]/5'
@@ -122,7 +128,7 @@ export default function SkillBrowser() {
             <span className="font-mono text-[8px] tracking-widest text-[var(--muted-foreground)] opacity-60">
               {SKILL_CATEGORIES[skill.category]?.label || skill.category.toUpperCase()}
             </span>
-          </div>
+          </motion.div>
         ))}
       </div>
 


### PR DESCRIPTION
## Summary
- AgentCard: staggered slide-up entrance (50ms/card), subtle hover shift
- SkillBrowser: 149 skill cards scale in with 15ms stagger (capped at 300ms)
- FocusMode: cinematic zoom transition (scale 1.02->1 enter, 1->0.98 exit)
- FocusMode: delayed exit button + mode indicator reveal with AnimatePresence
- All animations respect useReducedMotion

## Test plan
- [x] `npm test` — 773/773 pass
- [x] TypeScript clean
- [ ] Verify agent cards animate on /agents page load
- [ ] Verify 149 skill cards stagger smoothly without jank
- [ ] Verify Cmd+Shift+F triggers cinematic focus mode transition
- [ ] Verify Escape exits with reverse zoom animation