### PR TITLE
feat: animated dropdowns, keyboard shortcuts stagger, focus mode shortcut

### DIFF
--- a/src/components/Engine/ModelSelector.tsx
+++ b/src/components/Engine/ModelSelector.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 import { ChevronDown } from 'lucide-react';
 
 interface ModelSelectorProps {
@@ -22,10 +23,23 @@ const MODELS = [
 export default function ModelSelector({ value, onChange, compact = false }: ModelSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
   const current = MODELS.find(m => m.id === value) || MODELS[0];
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close on click outside
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [isOpen]);
 
   if (compact) {
     return (
-      <div className="relative">
+      <div className="relative" ref={containerRef}>
         <button
           onClick={() => setIsOpen(!isOpen)}
           className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)] hover:text-[var(--primary)] transition-colors flex items-center gap-1"
@@ -33,30 +47,38 @@ export default function ModelSelector({ value, onChange, compact = false }: Mode
           {current.label}
           <ChevronDown className={`w-2.5 h-2.5 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
         </button>
-        {isOpen && (
-          <div className="absolute bottom-full left-0 mb-1 border border-[var(--border)] bg-[var(--card)] z-50 min-w-[140px] animate-fade-in">
-            {MODELS.map(model => (
-              <button
-                key={model.id}
-                onClick={() => { onChange(model.id); setIsOpen(false); }}
-                className={`w-full text-left px-3 py-2 flex items-center justify-between transition-colors ${
-                  model.id === value
-                    ? 'text-[var(--primary)]'
-                    : 'text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--secondary)]'
-                }`}
-              >
-                <span className="font-mono text-[9px] tracking-widest">{model.label}</span>
-                <span className="font-mono text-[7px] tracking-wider opacity-50">{model.badge}</span>
-              </button>
-            ))}
-          </div>
-        )}
+        <AnimatePresence>
+          {isOpen && (
+            <motion.div
+              initial={{ opacity: 0, y: 4 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 4 }}
+              transition={{ duration: 0.15, ease: 'easeOut' }}
+              className="absolute bottom-full left-0 mb-1 border border-[var(--border)] bg-[var(--card)] z-50 min-w-[140px]"
+            >
+              {MODELS.map(model => (
+                <button
+                  key={model.id}
+                  onClick={() => { onChange(model.id); setIsOpen(false); }}
+                  className={`w-full text-left px-3 py-2 flex items-center justify-between transition-colors ${
+                    model.id === value
+                      ? 'text-[var(--primary)]'
+                      : 'text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--secondary)]'
+                  }`}
+                >
+                  <span className="font-mono text-[9px] tracking-widest">{model.label}</span>
+                  <span className="font-mono text-[7px] tracking-wider opacity-50">{model.badge}</span>
+                </button>
+              ))}
+            </motion.div>
+          )}
+        </AnimatePresence>
       </div>
     );
   }
 
   return (
-    <div className="relative">
+    <div className="relative" ref={containerRef}>
       <button
         onClick={() => setIsOpen(!isOpen)}
         className="flex items-center gap-2 px-2 py-1 border border-[var(--border)] hover:border-[var(--primary)]/50 transition-colors"
@@ -67,27 +89,35 @@ export default function ModelSelector({ value, onChange, compact = false }: Mode
         <ChevronDown className={`w-3 h-3 text-[var(--muted-foreground)] transition-transform ${isOpen ? 'rotate-180' : ''}`} />
       </button>
 
-      {isOpen && (
-        <div className="absolute bottom-full left-0 mb-1 border border-[var(--border)] bg-[var(--card)] z-50 min-w-[180px] animate-fade-in">
-          {MODELS.map(model => (
-            <button
-              key={model.id}
-              onClick={() => { onChange(model.id); setIsOpen(false); }}
-              className={`w-full text-left px-3 py-2.5 transition-colors ${
-                model.id === value
-                  ? 'text-[var(--primary)] bg-[var(--primary)]/5'
-                  : 'text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--secondary)]'
-              }`}
-            >
-              <div className="flex items-center justify-between">
-                <span className="font-mono text-[10px] tracking-widest">{model.label}</span>
-                <span className="font-mono text-[8px] tracking-wider opacity-50">{model.badge}</span>
-              </div>
-              <span className="text-[9px] opacity-60 block mt-0.5">{model.description}</span>
-            </button>
-          ))}
-        </div>
-      )}
+      <AnimatePresence>
+        {isOpen && (
+          <motion.div
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 4 }}
+            transition={{ duration: 0.15, ease: 'easeOut' }}
+            className="absolute bottom-full left-0 mb-1 border border-[var(--border)] bg-[var(--card)] z-50 min-w-[180px]"
+          >
+            {MODELS.map(model => (
+              <button
+                key={model.id}
+                onClick={() => { onChange(model.id); setIsOpen(false); }}
+                className={`w-full text-left px-3 py-2.5 transition-colors ${
+                  model.id === value
+                    ? 'text-[var(--primary)] bg-[var(--primary)]/5'
+                    : 'text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--secondary)]'
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-mono text-[10px] tracking-widest">{model.label}</span>
+                  <span className="font-mono text-[8px] tracking-wider opacity-50">{model.badge}</span>
+                </div>
+                <span className="text-[9px] opacity-60 block mt-0.5">{model.description}</span>
+              </button>
+            ))}
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/src/components/KeyboardShortcutsHelp.tsx
+++ b/src/components/KeyboardShortcutsHelp.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 
 const SHORTCUTS = [
   { category: 'NAVIGATION', items: [
@@ -13,6 +14,7 @@ const SHORTCUTS = [
   ]},
   { category: 'COMMANDS', items: [
     { keys: ['Cmd', 'K'], description: 'Command Palette' },
+    { keys: ['Cmd', 'Shift', 'F'], description: 'Focus Mode' },
     { keys: ['D'], description: 'Toggle Dark Mode' },
     { keys: ['?'], description: 'This Help' },
   ]},
@@ -30,6 +32,7 @@ const SHORTCUTS = [
  */
 export default function KeyboardShortcutsHelp() {
   const [isOpen, setIsOpen] = useState(false);
+  const reduceMotion = useReducedMotion();
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -49,15 +52,27 @@ export default function KeyboardShortcutsHelp() {
     return () => window.removeEventListener('keydown', handler);
   }, [isOpen]);
 
-  if (!isOpen) return null;
-
   return (
-    <div className="fixed inset-0 z-[300]">
+    <AnimatePresence>
+      {isOpen && (
+    <motion.div
+      className="fixed inset-0 z-[300]"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.15 }}
+    >
       <div
         className="absolute inset-0 bg-black/80"
         onClick={() => setIsOpen(false)}
       />
-      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-lg animate-fade-in">
+      <motion.div
+        className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-lg"
+        initial={reduceMotion ? false : { opacity: 0, scale: 0.96 }}
+        animate={{ opacity: 1, scale: 1 }}
+        exit={reduceMotion ? undefined : { opacity: 0, scale: 0.96 }}
+        transition={{ duration: 0.2, ease: 'easeOut' }}
+      >
         <div className="border border-[var(--border)] bg-[var(--card)]">
           {/* Header */}
           <div className="px-6 py-4 border-b border-[var(--border)] flex items-center justify-between">
@@ -74,8 +89,13 @@ export default function KeyboardShortcutsHelp() {
 
           {/* Shortcuts */}
           <div className="p-6 space-y-6">
-            {SHORTCUTS.map((group) => (
-              <div key={group.category}>
+            {SHORTCUTS.map((group, groupIndex) => (
+              <motion.div
+                key={group.category}
+                initial={reduceMotion ? false : { opacity: 0, y: 6 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.2, delay: reduceMotion ? 0 : groupIndex * 0.1 }}
+              >
                 <span className="font-mono text-[10px] tracking-widest text-[var(--primary)] block mb-2">
                   {group.category}
                 </span>
@@ -100,7 +120,7 @@ export default function KeyboardShortcutsHelp() {
                     </div>
                   ))}
                 </div>
-              </div>
+              </motion.div>
             ))}
           </div>
 
@@ -111,7 +131,9 @@ export default function KeyboardShortcutsHelp() {
             </span>
           </div>
         </div>
-      </div>
-    </div>
+      </motion.div>
+    </motion.div>
+      )}
+    </AnimatePresence>
   );
 }


### PR DESCRIPTION
## Summary
- ModelSelector: AnimatePresence dropdown with slide-up animation + click-outside-to-close
- KeyboardShortcutsHelp: overlay scale+fade entrance, shortcut groups stagger (100ms)
- Added Cmd+Shift+F (Focus Mode) to keyboard shortcuts list

## Test plan
- [x] `npm test` — 773/773 pass
- [x] TypeScript clean
- [ ] Verify model selector dropdown animates open/close
- [ ] Verify clicking outside model selector closes it
- [ ] Verify keyboard shortcuts overlay animates in with stagger
- [ ] Verify Focus Mode shortcut listed in shortcuts overlay