### PR TITLE
feat: walkthrough step transitions, progress bar, and chat input focus glow

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -487,6 +487,14 @@ input:focus, textarea:focus, select:focus {
   box-shadow: 0 0 0 2px rgba(34, 211, 238, 0.2);
 }
 
+/* Chat input focus glow — subtle cyan ambient glow on the primary input */
+.chat-input-glow:focus {
+  box-shadow: 0 0 0 1px var(--primary), 0 0 12px rgba(8, 145, 178, 0.15);
+}
+.dark .chat-input-glow:focus {
+  box-shadow: 0 0 0 1px var(--primary), 0 0 16px rgba(34, 211, 238, 0.2);
+}
+
 input::placeholder, textarea::placeholder {
   color: var(--muted-foreground);
 }

--- a/src/app/learn/walkthrough/page.tsx
+++ b/src/app/learn/walkthrough/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { ArrowRight, ArrowLeft, Check } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
@@ -25,9 +26,11 @@ const EXPERIENCE_LEVELS = [
 
 export default function WalkthroughPage() {
   const [step, setStep] = useState(0);
+  const [direction, setDirection] = useState(1); // 1 = forward, -1 = backward
   const [selectedRole, setSelectedRole] = useState<string | null>(null);
   const [selectedExperience, setSelectedExperience] = useState<string | null>(null);
   const router = useRouter();
+  const reduceMotion = useReducedMotion();
 
   const handleComplete = () => {
     // Store user preferences
@@ -180,28 +183,40 @@ export default function WalkthroughPage() {
   return (
     <div className="min-h-screen flex items-center justify-center px-4">
       <div className="w-full max-w-xl">
-        {/* Progress */}
+        {/* Progress — animated fill */}
         <div className="flex gap-1 mb-8">
           {steps.map((_, i) => (
-            <div
-              key={i}
-              className={`h-0.5 flex-1 transition-colors ${
-                i <= step ? 'bg-[var(--primary)]' : 'bg-[var(--border)]'
-              }`}
-            />
+            <div key={i} className="h-0.5 flex-1 bg-[var(--border)] overflow-hidden">
+              <motion.div
+                className="h-full bg-[var(--primary)]"
+                initial={false}
+                animate={{ width: i <= step ? '100%' : '0%' }}
+                transition={{ duration: 0.3, ease: 'easeOut' }}
+              />
+            </div>
           ))}
         </div>
 
         {/* Content */}
-        <div className="border border-[var(--border)] bg-[var(--card)]">
-          <div className="p-8">
-            {currentStep.content}
-          </div>
+        <div className="border border-[var(--border)] bg-[var(--card)] overflow-hidden">
+          <AnimatePresence mode="wait" custom={direction}>
+            <motion.div
+              key={step}
+              custom={direction}
+              initial={reduceMotion ? false : { opacity: 0, x: direction * 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={reduceMotion ? undefined : { opacity: 0, x: direction * -20 }}
+              transition={{ duration: 0.25, ease: 'easeOut' }}
+              className="p-8"
+            >
+              {currentStep.content}
+            </motion.div>
+          </AnimatePresence>
 
           {/* Navigation */}
           <div className="flex items-center justify-between px-8 py-4 border-t border-[var(--border)]">
             <button
-              onClick={() => setStep(Math.max(0, step - 1))}
+              onClick={() => { setDirection(-1); setStep(Math.max(0, step - 1)); }}
               disabled={step === 0}
               className="flex items-center gap-2 font-mono text-xs tracking-widest text-[var(--muted-foreground)] hover:text-[var(--foreground)] disabled:opacity-30 transition-colors min-h-[48px]"
             >
@@ -217,7 +232,7 @@ export default function WalkthroughPage() {
               </button>
             ) : (
               <button
-                onClick={() => setStep(Math.min(steps.length - 1, step + 1))}
+                onClick={() => { setDirection(1); setStep(Math.min(steps.length - 1, step + 1)); }}
                 disabled={!canProceed}
                 className="flex items-center gap-2 bg-[var(--foreground)] text-[var(--background)] px-6 py-3 font-mono text-xs tracking-widest hover:opacity-90 disabled:opacity-30 transition-opacity min-h-[48px]"
               >

--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -670,7 +670,7 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
                 placeholder="Type your message..."
                 rows={1}
                 disabled={isStreaming}
-                className="w-full resize-none bg-[var(--background)] border border-[var(--border)] px-4 py-3 text-sm text-[var(--foreground)] focus:border-[var(--primary)] focus:outline-none placeholder:text-[var(--muted-foreground)] min-h-[48px] max-h-[200px] disabled:opacity-50"
+                className="w-full resize-none bg-[var(--background)] border border-[var(--border)] px-4 py-3 text-sm text-[var(--foreground)] focus:border-[var(--primary)] focus:outline-none placeholder:text-[var(--muted-foreground)] min-h-[48px] max-h-[200px] disabled:opacity-50 chat-input-glow"
                 style={{ height: 'auto' }}
                 onInput={(e) => {
                   const target = e.target as HTMLTextAreaElement;


### PR DESCRIPTION
## Summary
- Walkthrough: directional slide transitions between steps (AnimatePresence)
- Progress bar: segments animate fill independently (300ms each)
- Chat input: subtle cyan ambient glow on focus (.chat-input-glow)
- Light/dark mode aware glow intensity

## Test plan
- [x] `npm test` — 773/773 pass
- [x] TypeScript clean
- [ ] Navigate walkthrough forward/backward — verify slide direction
- [ ] Verify progress bar segments fill smoothly
- [ ] Click in chat input — verify subtle cyan glow appears
- [ ] Verify glow is stronger in dark mode