### PR TITLE
feat: logo heartbeat pulse and conditional DevTools for demo mode

### DIFF
--- a/electron/core/window-manager.ts
+++ b/electron/core/window-manager.ts
@@ -60,7 +60,10 @@ export function createWindow() {
   const isDev = process.env.NODE_ENV === 'development';
   if (isDev) {
     mainWindow.loadURL('http://localhost:3000');
-    mainWindow.webContents.openDevTools();
+    // Only open DevTools if explicitly requested — keeps demo mode clean
+    if (process.env.GRIP_DEVTOOLS === '1') {
+      mainWindow.webContents.openDevTools();
+    }
   } else {
     // In production, use the custom app:// protocol to properly serve static files
     // This fixes issues with absolute paths like /logo.png not resolving correctly

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -426,6 +426,18 @@ html {
   animation: slide-up 0.2s ease-out;
 }
 
+/* Logo heartbeat — subtle breathing pulse on the GRIP identity square.
+   Slow enough to be ambient, fast enough to feel alive. */
+@keyframes grip-heartbeat {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.06); opacity: 0.85; }
+}
+
+.grip-logo-heartbeat {
+  animation: grip-heartbeat 3s ease-in-out infinite;
+  will-change: transform, opacity;
+}
+
 /* GPU compositing hints for animated elements */
 .grip-gpu-layer {
   will-change: transform, opacity;

--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -261,7 +261,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
           {mobileMenuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
         </button>
         <div className="flex items-center gap-2 ml-2">
-          <div className="w-5 h-5 bg-[var(--primary)] shrink-0" />
+          <div className="w-5 h-5 bg-[var(--primary)] shrink-0 grip-logo-heartbeat" />
           <span className="font-mono text-sm font-bold tracking-widest text-[var(--foreground)]">GRIP</span>
         </div>
       </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -127,7 +127,7 @@ export default function Sidebar({ isMobile = false }: SidebarProps) {
         }}
       >
         <div className="flex items-center gap-3">
-          <div className="w-6 h-6 bg-[var(--primary)] shrink-0" />
+          <div className="w-6 h-6 bg-[var(--primary)] shrink-0 grip-logo-heartbeat" />
           {showLabels && (
             <div>
               <span className="font-mono text-sm font-bold tracking-widest text-[var(--foreground)] transition-all duration-300 hover:text-[var(--primary)] hover:drop-shadow-[0_0_6px_var(--primary)]">


### PR DESCRIPTION
## Summary
- Logo heartbeat: 3s CSS breathing pulse on cyan GRIP square (sidebar + mobile)
- DevTools: conditional on GRIP_DEVTOOLS=1, no longer auto-opens in dev mode
- Clean demo window without inspector competing for screen space

## Test plan
- [x] `npm test` — 773/773 pass
- [x] TypeScript clean
- [ ] Verify sidebar logo square pulses subtly
- [ ] Run `npm run electron:dev` — verify no DevTools auto-open
- [ ] Run `GRIP_DEVTOOLS=1 npm run electron:dev` — verify DevTools opens