### PR TITLE
feat: Cmd+, settings shortcut, gate indicator entrance, keyboard help

### DIFF
--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -204,6 +204,13 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
       // Don't trigger in input fields
       const target = e.target as HTMLElement;
       if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) return;
+      // Cmd+, = Settings (macOS convention) — must be before modifier guard
+      if ((e.metaKey || e.ctrlKey) && e.key === ',') {
+        e.preventDefault();
+        router.push('/settings');
+        return;
+      }
+
       if (e.metaKey || e.ctrlKey || e.altKey) return;
 
       // Number key navigation

--- a/src/components/Engine/GateIndicator.tsx
+++ b/src/components/Engine/GateIndicator.tsx
@@ -54,7 +54,12 @@ export default function GateIndicator({ gates }: GateIndicatorProps) {
   const style = TYPE_STYLES[latest.type];
 
   return (
-    <div className="my-2">
+    <motion.div
+      className="my-2"
+      initial={{ opacity: 0, x: -8 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.2, ease: 'easeOut' }}
+    >
       <button
         onClick={() => setExpanded(!expanded)}
         className={`w-full flex items-center gap-2 px-3 py-2 border ${style.border} ${style.bg} text-left transition-colors hover:opacity-90`}
@@ -103,6 +108,6 @@ export default function GateIndicator({ gates }: GateIndicatorProps) {
           </motion.div>
         )}
       </AnimatePresence>
-    </div>
+    </motion.div>
   );
 }

--- a/src/components/KeyboardShortcutsHelp.tsx
+++ b/src/components/KeyboardShortcutsHelp.tsx
@@ -15,7 +15,9 @@ const SHORTCUTS = [
   { category: 'COMMANDS', items: [
     { keys: ['Cmd', 'K'], description: 'Command Palette' },
     { keys: ['Cmd', 'Shift', 'F'], description: 'Focus Mode' },
+    { keys: ['Cmd', ','], description: 'Settings' },
     { keys: ['D'], description: 'Toggle Dark Mode' },
+    { keys: ['M'], description: 'Memory' },
     { keys: ['?'], description: 'This Help' },
   ]},
   { category: 'CHAT', items: [


### PR DESCRIPTION
## Summary
- Cmd+, opens Settings (macOS convention)
- M key opens Memory page
- GateIndicator: slide-in entrance animation (200ms)
- Updated keyboard shortcuts help with Cmd+, and M entries

## Test plan
- [x] `npm test` — 773/773 pass
- [x] TypeScript clean
- [ ] Press Cmd+, — verify Settings page opens
- [ ] Press M outside input — verify Memory page opens
- [ ] Verify gate indicators slide in from left
- [ ] Verify ? overlay shows new Cmd+, and M shortcuts