### PR TITLE
feat: ModeQuickSwitch animated dropdown and ConvergenceIndicator CSS pulse

### DIFF
--- a/src/components/Engine/ConvergenceIndicator.tsx
+++ b/src/components/Engine/ConvergenceIndicator.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-
 interface ConvergenceIndicatorProps {
   /** Current convergence depth (0 = surface, higher = deeper) */
   depth?: number;
@@ -25,20 +23,12 @@ export default function ConvergenceIndicator({
   active = false,
   criterion,
 }: ConvergenceIndicatorProps) {
-  const [pulse, setPulse] = useState(false);
-
-  useEffect(() => {
-    if (!active) return;
-    const interval = setInterval(() => setPulse(p => !p), 1500);
-    return () => clearInterval(interval);
-  }, [active]);
-
   const rings = Math.min(5, maxDepth);
   const filledRings = Math.ceil((depth / maxDepth) * rings);
 
   return (
     <div className="flex items-center gap-3">
-      {/* Concentric rings */}
+      {/* Concentric rings — CSS-only pulse when active (no JS timers) */}
       <div className="relative w-8 h-8 flex items-center justify-center">
         {Array.from({ length: rings }).map((_, i) => {
           const size = 8 + i * 5;
@@ -46,22 +36,19 @@ export default function ConvergenceIndicator({
           return (
             <div
               key={i}
-              className="absolute border transition-all"
+              className={`absolute border transition-all ${active && isFilled ? 'grip-pulse-bar' : ''}`}
               style={{
                 width: size,
                 height: size,
                 borderColor: isFilled ? 'var(--primary)' : 'var(--border)',
-                opacity: active && pulse && isFilled ? 0.6 : 1,
+                animationDelay: active ? `${i * 300}ms` : undefined,
                 transitionDuration: '0.6s',
               }}
             />
           );
         })}
         {active && (
-          <div
-            className="absolute w-2 h-2 bg-[var(--primary)]"
-            style={{ opacity: pulse ? 1 : 0.4, transition: 'opacity 0.6s' }}
-          />
+          <div className="absolute w-2 h-2 bg-[var(--primary)] grip-pulse-bar" />
         )}
       </div>
 

--- a/src/components/Engine/ModeQuickSwitch.tsx
+++ b/src/components/Engine/ModeQuickSwitch.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 import { Layers, ChevronDown } from 'lucide-react';
 import { GRIP_MODES, getModesByCategory, type ModeCategory } from '@/lib/grip-modes';
 
@@ -14,11 +15,23 @@ import { GRIP_MODES, getModesByCategory, type ModeCategory } from '@/lib/grip-mo
 export default function ModeQuickSwitch() {
   const [isOpen, setIsOpen] = useState(false);
   const [activeMode, setActiveMode] = useState('code');
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [isOpen]);
 
   const currentMode = GRIP_MODES.find(m => m.id === activeMode);
 
   return (
-    <div className="relative">
+    <div className="relative" ref={containerRef}>
       <button
         onClick={() => setIsOpen(!isOpen)}
         className="w-full flex items-center justify-between gap-2 p-2 border border-[var(--border)] hover:border-[var(--primary)]/50 transition-colors"
@@ -32,8 +45,14 @@ export default function ModeQuickSwitch() {
         <ChevronDown className={`w-3 h-3 text-[var(--muted-foreground)] transition-transform ${isOpen ? 'rotate-180' : ''}`} strokeWidth={1.5} />
       </button>
 
-      {isOpen && (
-        <div className="absolute top-full left-0 right-0 mt-1 border border-[var(--border)] bg-[var(--card)] z-50 max-h-[300px] overflow-y-auto animate-fade-in">
+      <AnimatePresence>
+        {isOpen && (
+        <motion.div
+          initial={{ opacity: 0, y: -4 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -4 }}
+          transition={{ duration: 0.15, ease: 'easeOut' }}
+          className="absolute top-full left-0 right-0 mt-1 border border-[var(--border)] bg-[var(--card)] z-50 max-h-[300px] overflow-y-auto">
           {(['development', 'strategy', 'content', 'research', 'operations', 'meta'] as ModeCategory[]).map(category => {
             const modes = getModesByCategory(category);
             return (
@@ -67,8 +86,9 @@ export default function ModeQuickSwitch() {
               </div>
             );
           })}
-        </div>
-      )}
+        </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- ModeQuickSwitch: AnimatePresence dropdown + click-outside-to-close
- ConvergenceIndicator: replaced JS timer with CSS grip-pulse-bar class
- Eliminated 2 useState hooks and 1 useEffect timer from ConvergenceIndicator

## Test plan
- [x] `npm test` — 773/773 pass
- [x] TypeScript clean
- [ ] Open mode quick-switch in context panel — verify animated dropdown
- [ ] Click outside dropdown — verify it closes
- [ ] Verify convergence rings pulse with CSS when active