### PR TITLE
feat: enhanced suggested prompts and Swiss Nihilism badge audit

### DIFF
--- a/src/components/AgentList/AgentCard.tsx
+++ b/src/components/AgentList/AgentCard.tsx
@@ -98,7 +98,7 @@ export function AgentCard({ agent, isSelected, onSelect, onEdit, index = 0 }: Ag
               >
                 <Pencil className="w-3.5 h-3.5 text-text-muted hover:text-accent-blue" />
               </button>
-              <span className={`text-xs px-2 py-0.5 rounded-full ${
+              <span className={`text-xs px-2 py-0.5 font-mono tracking-wider ${
                 isSuper && agent.status === 'running'
                   ? 'bg-amber-500/20 text-amber-400'
                   : `${statusConfig.bg} ${statusConfig.text}`

--- a/src/components/AgentList/AgentDetailPanel.tsx
+++ b/src/components/AgentList/AgentDetailPanel.tsx
@@ -68,7 +68,7 @@ export function AgentDetailPanel({
                 </span>
               )}
               {agent.branchName && (
-                <span className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-accent-purple/20 text-accent-purple text-xs">
+                <span className="flex items-center gap-1 px-2 py-0.5 bg-accent-purple/20 text-accent-purple text-xs">
                   <GitBranch className="w-3 h-3" />
                   {agent.branchName}
                 </span>
@@ -141,7 +141,7 @@ export function AgentDetailPanel({
           {agent.skills.map((skill) => (
             <span
               key={skill}
-              className="px-2 py-0.5 rounded-full bg-accent-purple/20 text-accent-purple text-xs shrink-0"
+              className="px-2 py-0.5 bg-accent-purple/20 text-accent-purple text-xs shrink-0"
             >
               {skill}
             </span>

--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -45,10 +45,10 @@ function persistStreamContent(
 }
 
 const SUGGESTED_PROMPTS = [
-  { text: 'What can GRIP help me with?', icon: '?' },
-  { text: 'Review this code for security issues', icon: 'S' },
-  { text: 'Help me write a project proposal', icon: 'W' },
-  { text: 'Analyse this business decision', icon: 'D' },
+  { text: 'Explore this codebase and suggest architecture improvements', icon: 'A' },
+  { text: 'Review my last 5 commits for security issues', icon: 'S' },
+  { text: 'Draft a technical proposal with GRIP design principles', icon: 'W' },
+  { text: 'Red-team this decision using the Devil\'s Advocate framework', icon: 'R' },
 ];
 
 interface ChatInterfaceProps {


### PR DESCRIPTION
## Summary
- Suggested prompts: showcase GRIP capabilities (architecture, security, design principles, red-teaming)
- Agent badges: removed rounded-full from status and skill badges
- Small status dots keep rounded (too small for corners)

## Test plan
- [x] 773/773 pass, TypeScript clean