### PR TITLE
fix: Swiss Nihilism — remove rounded-lg from modals and plugins

### DIFF
--- a/src/app/plugins/page.tsx
+++ b/src/app/plugins/page.tsx
@@ -560,7 +560,7 @@ export default function PluginsPage() {
         </div>
 
         {/* Claude-only banner */}
-        <div className="flex rounded-lg items-center gap-2 px-3 py-2 bg-blue-500/10 border border-blue-500/10 text-xs text-blue-600">
+        <div className="flex items-center gap-2 px-3 py-2 bg-blue-500/10 border border-blue-500/10 text-xs text-blue-600">
           <Info className="w-3.5 h-3.5 shrink-0" />
           <span>Plugins are only available for <strong>Claude Code</strong>. Codex and Gemini CLI do not support plugins.</span>
         </div>

--- a/src/components/NewChatModal/OrchestratorModeToggle.tsx
+++ b/src/components/NewChatModal/OrchestratorModeToggle.tsx
@@ -126,7 +126,7 @@ export default function OrchestratorModeToggle({
   }
 
   return (
-    <div className="p-4 rounded-lg border border-accent-purple/30 bg-accent-purple/5">
+    <div className="p-4 border border-accent-purple/30 bg-accent-purple/5">
       <div className="flex items-start gap-3">
         <button
           onClick={() => {
@@ -171,7 +171,7 @@ export default function OrchestratorModeToggle({
               <button
                 onClick={handleSetup}
                 disabled={isSettingUp}
-                className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-accent-purple/20 text-accent-purple text-sm font-medium hover:bg-accent-purple/30 transition-colors disabled:opacity-50"
+                className="flex items-center gap-2 px-3 py-1.5 bg-accent-purple/20 text-accent-purple text-sm font-medium hover:bg-accent-purple/30 transition-colors disabled:opacity-50"
               >
                 {isSettingUp ? (
                   <>

--- a/src/components/NewChatModal/StepProject.tsx
+++ b/src/components/NewChatModal/StepProject.tsx
@@ -88,7 +88,7 @@ const StepProject = React.memo(function StepProject({
             value={search}
             onChange={(e) => { setSearch(e.target.value); setShowAll(false); }}
             placeholder="Search projects..."
-            className="w-full pl-10 pr-4 py-2 rounded-lg text-sm"
+            className="w-full pl-10 pr-4 py-2 text-sm"
           />
         </div>
       )}
@@ -100,7 +100,7 @@ const StepProject = React.memo(function StepProject({
             key={project.path}
             onClick={() => onSelectProject(project.path)}
             className={`
-              text-left p-3 rounded-lg border transition-all
+              text-left p-3 border transition-all
               ${selectedProject === project.path
                 ? 'border-accent-blue bg-accent-blue/10'
                 : 'border-border-primary hover:border-border-accent bg-bg-tertiary/30'
@@ -155,7 +155,7 @@ const StepProject = React.memo(function StepProject({
             value={customPath}
             onChange={(e) => onCustomPathChange(e.target.value)}
             placeholder="/path/to/your/project"
-            className="flex-1 px-4 py-3 rounded-lg font-mono text-sm"
+            className="flex-1 px-4 py-3 font-mono text-sm"
           />
           {onBrowseFolder && (
             <button
@@ -164,7 +164,7 @@ const StepProject = React.memo(function StepProject({
                 const path = await onBrowseFolder();
                 if (path) onCustomPathChange(path);
               }}
-              className="px-4 py-3 rounded-lg bg-bg-tertiary border border-border-primary hover:border-accent-blue transition-colors flex items-center gap-2"
+              className="px-4 py-3 bg-bg-tertiary border border-border-primary hover:border-accent-blue transition-colors flex items-center gap-2"
             >
               <FolderOpen className="w-4 h-4 text-accent-blue" />
               <span className="text-sm">Browse</span>
@@ -174,7 +174,7 @@ const StepProject = React.memo(function StepProject({
       </div>
 
       {/* Secondary Project (Collapsible) */}
-      <div className="border border-border-primary rounded-lg overflow-hidden">
+      <div className="border border-border-primary overflow-hidden">
         <button
           onClick={onToggleSecondary}
           className="w-full flex items-center justify-between px-4 py-3 bg-bg-tertiary/30 hover:bg-bg-tertiary/50 transition-colors"
@@ -215,7 +215,7 @@ const StepProject = React.memo(function StepProject({
                         key={project.path}
                         onClick={() => onSelectSecondaryProject(project.path)}
                         className={`
-                          text-left p-3 rounded-lg border transition-all text-sm
+                          text-left p-3 border transition-all text-sm
                           ${selectedSecondaryProject === project.path
                             ? 'border-accent-purple bg-accent-purple/10'
                             : 'border-border-primary hover:border-border-accent bg-bg-tertiary/30'
@@ -248,7 +248,7 @@ const StepProject = React.memo(function StepProject({
                     value={customSecondaryPath}
                     onChange={(e) => onCustomSecondaryPathChange(e.target.value)}
                     placeholder="/path/to/secondary/project"
-                    className="flex-1 px-3 py-2 rounded-lg font-mono text-sm"
+                    className="flex-1 px-3 py-2 font-mono text-sm"
                   />
                   {onBrowseFolder && (
                     <button
@@ -257,7 +257,7 @@ const StepProject = React.memo(function StepProject({
                         const path = await onBrowseFolder();
                         if (path) onCustomSecondaryPathChange(path);
                       }}
-                      className="px-3 py-2 rounded-lg bg-bg-tertiary border border-border-primary hover:border-accent-purple transition-colors flex items-center gap-2"
+                      className="px-3 py-2 bg-bg-tertiary border border-border-primary hover:border-accent-purple transition-colors flex items-center gap-2"
                     >
                       <FolderOpen className="w-4 h-4 text-accent-purple" />
                       <span className="text-sm">Browse</span>

--- a/src/components/NewChatModal/index.tsx
+++ b/src/components/NewChatModal/index.tsx
@@ -328,7 +328,7 @@ export default function NewChatModal({
             </div>
             <button
               onClick={onClose}
-              className="p-2 rounded-lg hover:bg-bg-tertiary transition-colors ml-2"
+              className="p-2 hover:bg-bg-tertiary transition-colors ml-2"
             >
               <X className="w-5 h-5" />
             </button>
@@ -412,7 +412,7 @@ export default function NewChatModal({
             <button
               onClick={() => step > 1 && setStep(step - 1)}
               disabled={step === 1}
-              className="px-4 py-2 rounded-lg text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="px-4 py-2 text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Back
             </button>
@@ -420,7 +420,7 @@ export default function NewChatModal({
             <div className="flex items-center gap-3">
               <button
                 onClick={onClose}
-                className="px-4 py-2 rounded-lg text-muted-foreground hover:text-foreground transition-colors"
+                className="px-4 py-2 text-muted-foreground hover:text-foreground transition-colors"
               >
                 Cancel
               </button>
@@ -429,7 +429,7 @@ export default function NewChatModal({
                 <button
                   onClick={() => setStep(step + 1)}
                   disabled={!canContinue}
-                  className="flex items-center gap-2 px-4 py-2 rounded-lg bg-foreground text-background font-medium hover:bg-foreground/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="flex items-center gap-2 px-4 py-2 bg-foreground text-background font-medium hover:bg-foreground/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Continue
                   <ChevronRight className="w-4 h-4" />
@@ -438,7 +438,7 @@ export default function NewChatModal({
                 <button
                   onClick={handleSubmit}
                   disabled={!canStart}
-                  className="flex items-center gap-2 px-4 py-2 rounded-lg bg-accent-green text-white font-medium hover:bg-accent-green/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="flex items-center gap-2 px-4 py-2 bg-accent-green text-white font-medium hover:bg-accent-green/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   <Play className="w-4 h-4" />
                   Start Agent


### PR DESCRIPTION
## Summary
- Removed 16 rounded-lg instances from NewChatModal, OrchestratorMode, StepProject, plugins
- Theme sets 0px radius — rounded-lg was overriding

## Test plan
- [x] 773/773 pass, TypeScript clean