### PR TITLE
fix: bump all sub-10px font sizes for HiDPI accessibility

### DIFF
--- a/src/app/memory/page.tsx
+++ b/src/app/memory/page.tsx
@@ -162,7 +162,7 @@ function ProjectCard({
           <FolderOpen className={`w-4 h-4 shrink-0 ${isSelected ? 'text-primary' : 'text-muted-foreground group-hover:text-foreground'}`} />
           <span className="text-sm font-medium truncate">{project.projectName}</span>
           {project.provider && project.provider !== 'claude' && (
-            <span className={`text-[9px] px-1 py-0.5 font-medium uppercase tracking-wider shrink-0 ${
+            <span className={`text-[10px] px-1 py-0.5 font-medium uppercase tracking-wider shrink-0 ${
               project.provider === 'codex' ? 'bg-green-500/15 text-green-600 dark:text-green-400' :
               project.provider === 'gemini' ? 'bg-purple-500/15 text-purple-600 dark:text-purple-400' :
               'bg-secondary text-muted-foreground'
@@ -533,7 +533,7 @@ export default function MemoryPage() {
                           <div className="min-w-0 flex-1">
                             <p className="text-xs font-mono truncate">{file.name}</p>
                             {file.isEntrypoint && (
-                              <p className="text-[9px] text-primary/70 mt-0.5">entrypoint</p>
+                              <p className="text-[10px] text-primary/70 mt-0.5">entrypoint</p>
                             )}
                           </div>
                           {selectedFile?.path === file.path && (

--- a/src/app/modes/page.tsx
+++ b/src/app/modes/page.tsx
@@ -80,7 +80,7 @@ export default function ModesPage() {
             </span>
             {saving && <Loader2 className="w-3 h-3 text-[var(--primary)] animate-spin" />}
             {loaded && !saving && activeModes.length > 0 && (
-              <span className="font-mono text-[8px] tracking-widest text-[var(--success)]">SAVED</span>
+              <span className="font-mono text-[10px] tracking-widest text-[var(--success)]">SAVED</span>
             )}
           </div>
         )}
@@ -148,18 +148,18 @@ export default function ModesPage() {
                 {mode.description}
               </p>
               <div className="flex items-center gap-2">
-                <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)]">
+                <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">
                   {MODE_CATEGORIES[mode.category].label}
                 </span>
-                <span className="font-mono text-[9px] text-[var(--muted-foreground)]">|</span>
-                <span className="font-mono text-[9px] tracking-wider text-[var(--muted-foreground)]">
+                <span className="font-mono text-[10px] text-[var(--muted-foreground)]">|</span>
+                <span className="font-mono text-[10px] tracking-wider text-[var(--muted-foreground)]">
                   ~{(mode.tokenBudget / 1000).toFixed(1)}K TOKENS
                 </span>
               </div>
               {mode.skills.length > 0 && (
                 <div className="flex flex-wrap gap-1 mt-2">
                   {mode.skills.slice(0, 3).map(skill => (
-                    <span key={skill} className="font-mono text-[8px] tracking-wider text-[var(--muted-foreground)] border border-[var(--border)] px-1 py-0.5">
+                    <span key={skill} className="font-mono text-[10px] tracking-wider text-[var(--muted-foreground)] border border-[var(--border)] px-1 py-0.5">
                       {skill}
                     </span>
                   ))}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -528,7 +528,7 @@ export default function ProjectsPage() {
                     {/* Agent badge */}
                     {linkedAgents.length > 0 && (
                       <div
-                        className="absolute -top-1.5 -right-1.5 w-4 h-4 text-[9px] font-bold flex items-center justify-center text-white"
+                        className="absolute -top-1.5 -right-1.5 w-4 h-4 text-[10px] font-bold flex items-center justify-center text-white"
                         style={{ backgroundColor: color.main }}
                       >
                         {linkedAgents.length}
@@ -569,7 +569,7 @@ export default function ProjectsPage() {
                 {/* Custom badge */}
                 {isCustomProject(project.path) && (
                   <div className="absolute top-2 left-2">
-                    <span className="text-[9px] px-1.5 py-0.5 bg-purple-500/20 text-purple-400">
+                    <span className="text-[10px] px-1.5 py-0.5 bg-purple-500/20 text-purple-400">
                       Custom
                     </span>
                   </div>

--- a/src/app/usage/page.tsx
+++ b/src/app/usage/page.tsx
@@ -542,7 +542,7 @@ export default function UsagePage() {
                 <div key={item.date} className="flex-1 flex flex-col items-center gap-0.5 relative">
                   <div className="w-full flex flex-col items-center justify-end h-44">
                     {showCostLabel && (
-                      <span className={`${isDaily ? 'text-[9px]' : 'text-xs'} text-accent-green font-medium mb-0.5 whitespace-nowrap`}>
+                      <span className={`${isDaily ? 'text-[10px]' : 'text-xs'} text-accent-green font-medium mb-0.5 whitespace-nowrap`}>
                         ${item.cost < 1 ? item.cost.toFixed(2) : item.cost.toFixed(0)}
                       </span>
                     )}
@@ -554,7 +554,7 @@ export default function UsagePage() {
                       title={`${item.label}: $${item.cost.toFixed(2)}`}
                     />
                   </div>
-                  <span className={`${isDaily ? 'text-[8px]' : 'text-[10px]'} text-text-muted text-center leading-tight ${!showDateLabel ? 'invisible' : ''}`}>
+                  <span className={`${isDaily ? 'text-[10px]' : 'text-[10px]'} text-text-muted text-center leading-tight ${!showDateLabel ? 'invisible' : ''}`}>
                     {item.label}
                   </span>
                 </div>

--- a/src/components/Engine/ChatHistory.tsx
+++ b/src/components/Engine/ChatHistory.tsx
@@ -86,7 +86,7 @@ export default function ChatHistory({ onSessionChange, onNewChat, currentModel }
         {sessions.length === 0 ? (
           <div className="text-center py-8">
             <MessageSquare className="w-5 h-5 text-[var(--muted-foreground)] mx-auto mb-2 opacity-30" />
-            <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)] opacity-50">
+            <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] opacity-50">
               NO CHATS YET
             </span>
           </div>
@@ -121,13 +121,13 @@ export default function ChatHistory({ onSessionChange, onNewChat, currentModel }
                 </button>
               </div>
               <div className="flex items-center gap-2 mt-0.5">
-                <span className="font-mono text-[8px] tracking-wider text-[var(--muted-foreground)] opacity-60">
+                <span className="font-mono text-[10px] tracking-wider text-[var(--muted-foreground)] opacity-60">
                   {formatTime(session.updatedAt)}
                 </span>
-                <span className="font-mono text-[8px] tracking-wider text-[var(--muted-foreground)] opacity-40">
+                <span className="font-mono text-[10px] tracking-wider text-[var(--muted-foreground)] opacity-40">
                   {session.messageCount} MSG
                 </span>
-                <span className="font-mono text-[7px] tracking-wider text-[var(--muted-foreground)] opacity-30">
+                <span className="font-mono text-[9px] tracking-wider text-[var(--muted-foreground)] opacity-30">
                   {session.model.toUpperCase()}
                 </span>
               </div>

--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -569,18 +569,18 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
                     )}
                   </div>
                   <div className="flex items-center gap-3 mt-1">
-                    <span className="font-mono text-[9px] tracking-wider text-[var(--muted-foreground)]">
+                    <span className="font-mono text-[10px] tracking-wider text-[var(--muted-foreground)]">
                       {msg.timestamp.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })}
                     </span>
                     {msg.metrics && (
                       <>
                         {msg.metrics.totalDurationMs && (
-                          <span className="font-mono text-[8px] tracking-wider text-[var(--muted-foreground)] opacity-50">
+                          <span className="font-mono text-[10px] tracking-wider text-[var(--muted-foreground)] opacity-50">
                             {(msg.metrics.totalDurationMs / 1000).toFixed(1)}s
                           </span>
                         )}
                         {msg.metrics.model && (
-                          <span className="font-mono text-[8px] tracking-wider text-[var(--muted-foreground)] opacity-50">
+                          <span className="font-mono text-[10px] tracking-wider text-[var(--muted-foreground)] opacity-50">
                             {msg.metrics.model}
                           </span>
                         )}
@@ -611,7 +611,7 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
             exit={{ opacity: 0, y: 8 }}
             transition={{ duration: 0.15 }}
             onClick={scrollToBottom}
-            className="absolute bottom-20 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1.5 px-3 py-1.5 bg-[var(--card)] border border-[var(--border)] hover:border-[var(--primary)] transition-colors font-mono text-[9px] tracking-widest text-[var(--muted-foreground)] hover:text-[var(--primary)]"
+            className="absolute bottom-20 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1.5 px-3 py-1.5 bg-[var(--card)] border border-[var(--border)] hover:border-[var(--primary)] transition-colors font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] hover:text-[var(--primary)]"
           >
             <ArrowDown className="w-3 h-3" strokeWidth={1.5} />
             LATEST
@@ -647,7 +647,7 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
                 alt="Pasted"
                 className="max-h-16 w-auto border border-[var(--border)]"
               />
-              <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)]">
+              <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">
                 IMAGE ATTACHED
               </span>
               <button
@@ -706,14 +706,14 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
             </div>
             <div className="flex items-center gap-3">
               {input.length > 0 && (
-                <span className={`font-mono text-[8px] tracking-wider transition-colors ${
+                <span className={`font-mono text-[10px] tracking-wider transition-colors ${
                   input.length > 4000 ? 'text-[var(--warning)]' : 'text-[var(--muted-foreground)] opacity-40'
                 }`}>
                   {input.length.toLocaleString()}
                 </span>
               )}
               {sessionId && (
-                <span className="font-mono text-[8px] tracking-wider text-[var(--primary)] opacity-60">
+                <span className="font-mono text-[10px] tracking-wider text-[var(--primary)] opacity-60">
                   SESSION: {sessionId.slice(0, 8)}
                 </span>
               )}

--- a/src/components/Engine/ContextPanel.tsx
+++ b/src/components/Engine/ContextPanel.tsx
@@ -108,7 +108,7 @@ export default function ContextPanel({
               className="w-full flex items-center justify-between py-1.5 text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
             >
               <span className="font-mono text-[10px] tracking-widest">{action.label}</span>
-              <span className="font-mono text-[9px] text-[var(--muted-foreground)] opacity-50">
+              <span className="font-mono text-[10px] text-[var(--muted-foreground)] opacity-50">
                 {action.shortcut}
               </span>
             </button>

--- a/src/components/Engine/ConvergenceIndicator.tsx
+++ b/src/components/Engine/ConvergenceIndicator.tsx
@@ -59,13 +59,13 @@ export default function ConvergenceIndicator({
             {active ? 'CONVERGING' : depth > 0 ? 'CONVERGED' : 'IDLE'}
           </span>
           {depth > 0 && (
-            <span className="font-mono text-[9px] tracking-wider text-[var(--muted-foreground)]">
+            <span className="font-mono text-[10px] tracking-wider text-[var(--muted-foreground)]">
               D{depth}/{maxDepth}
             </span>
           )}
         </div>
         {criterion && (
-          <span className="font-mono text-[8px] tracking-wider text-[var(--muted-foreground)] block mt-0.5 max-w-[200px] truncate">
+          <span className="font-mono text-[10px] tracking-wider text-[var(--muted-foreground)] block mt-0.5 max-w-[200px] truncate">
             {criterion}
           </span>
         )}

--- a/src/components/Engine/FocusMode.tsx
+++ b/src/components/Engine/FocusMode.tsx
@@ -86,7 +86,7 @@ export default function FocusMode({ children, onToggle }: FocusModeProps) {
               animate={{ opacity: 0.4, x: 0 }}
               transition={{ delay: 0.2, duration: 0.3 }}
             >
-              <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)]">
+              <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">
                 FOCUS MODE
               </span>
             </motion.div>

--- a/src/components/Engine/GateIndicator.tsx
+++ b/src/components/Engine/GateIndicator.tsx
@@ -71,7 +71,7 @@ export default function GateIndicator({ gates }: GateIndicatorProps) {
         <span className="font-mono text-xs text-[var(--muted-foreground)] truncate flex-1">
           {latest.gate}
         </span>
-        <span className="font-mono text-[9px] text-[var(--muted-foreground)] opacity-50 flex-shrink-0">
+        <span className="font-mono text-[10px] text-[var(--muted-foreground)] opacity-50 flex-shrink-0">
           {gates.length > 1 ? `${gates.length} gates` : ''}
         </span>
         {expanded ? (
@@ -95,7 +95,7 @@ export default function GateIndicator({ gates }: GateIndicatorProps) {
                 const gStyle = TYPE_STYLES[gate.type];
                 return (
                   <div key={gate.id} className="flex items-start gap-2">
-                    <span className={`font-mono text-[9px] tracking-widest ${gStyle.labelColor} mt-0.5 flex-shrink-0`}>
+                    <span className={`font-mono text-[10px] tracking-widest ${gStyle.labelColor} mt-0.5 flex-shrink-0`}>
                       {gStyle.label}
                     </span>
                     <span className="font-mono text-xs text-[var(--muted-foreground)]">

--- a/src/components/Engine/GripPulse.tsx
+++ b/src/components/Engine/GripPulse.tsx
@@ -47,7 +47,7 @@ export default function GripPulse() {
                 }}
               />
             </div>
-            <span className="font-mono text-[6px] tracking-widest text-[var(--muted-foreground)]">
+            <span className="font-mono text-[8px] tracking-widest text-[var(--muted-foreground)]">
               {metric.label}
             </span>
           </div>

--- a/src/components/Engine/GripStatusBar.tsx
+++ b/src/components/Engine/GripStatusBar.tsx
@@ -52,7 +52,7 @@ export default function GripStatusBar({
       {/* Mode */}
       <div className="flex items-center gap-1.5">
         <Layers className="w-3 h-3 text-[var(--primary)]" strokeWidth={1.5} />
-        <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)]">
+        <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">
           {activeMode.toUpperCase()}
         </span>
       </div>
@@ -60,7 +60,7 @@ export default function GripStatusBar({
       {/* Skills */}
       <div className="flex items-center gap-1.5">
         <Sparkles className="w-3 h-3 text-[var(--muted-foreground)]" strokeWidth={1.5} />
-        <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)]">
+        <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">
           {skillCount} SKILLS
         </span>
       </div>
@@ -68,7 +68,7 @@ export default function GripStatusBar({
       {/* Context */}
       <div className="flex items-center gap-1.5">
         <Activity className="w-3 h-3 text-[var(--muted-foreground)]" strokeWidth={1.5} />
-        <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)]">
+        <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">
           CTX {contextPercent}%
         </span>
         <div className="w-16 h-1 bg-[var(--border)]">
@@ -83,7 +83,7 @@ export default function GripStatusBar({
       {isStreaming && (
         <div className="flex items-center gap-1.5">
           <Zap className="w-3 h-3 text-[var(--primary)] animate-pulse" strokeWidth={1.5} />
-          <span className="font-mono text-[9px] tracking-widest text-[var(--primary)]">
+          <span className="font-mono text-[10px] tracking-widest text-[var(--primary)]">
             STREAMING
           </span>
         </div>
@@ -92,7 +92,7 @@ export default function GripStatusBar({
       {metrics?.model && (
         <div className="flex items-center gap-1.5">
           <Cpu className="w-3 h-3 text-[var(--muted-foreground)]" strokeWidth={1.5} />
-          <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)]">
+          <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">
             {metrics.model.toUpperCase()}
           </span>
         </div>
@@ -101,14 +101,14 @@ export default function GripStatusBar({
       {metrics?.totalDurationMs && !isStreaming && (
         <div className="flex items-center gap-1.5">
           <Clock className="w-3 h-3 text-[var(--muted-foreground)]" strokeWidth={1.5} />
-          <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)]">
+          <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">
             {(metrics.totalDurationMs / 1000).toFixed(1)}s
           </span>
         </div>
       )}
 
       {metrics?.numTurns && (
-        <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)]">
+        <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">
           {metrics.numTurns} TURNS
         </span>
       )}
@@ -129,18 +129,18 @@ export default function GripStatusBar({
       {/* Safety */}
       <div className="flex items-center gap-1.5">
         <Shield className={`w-3 h-3 ${safetyActive ? 'text-[var(--success)]' : 'text-[var(--danger)]'}`} strokeWidth={1.5} />
-        <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)]">
+        <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">
           {safetyActive ? 'GATES ACTIVE' : 'GATES OFF'}
         </span>
       </div>
 
       {/* Session elapsed + GRIP version */}
       {elapsed && (
-        <span className="font-mono text-[8px] tracking-widest text-[var(--muted-foreground)] opacity-40">
+        <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] opacity-40">
           {elapsed}
         </span>
       )}
-      <span className="font-mono text-[8px] tracking-widest text-[var(--muted-foreground)] opacity-40">
+      <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] opacity-40">
         GRIP 0.1.0
       </span>
     </div>

--- a/src/components/Engine/MarkdownContent.tsx
+++ b/src/components/Engine/MarkdownContent.tsx
@@ -36,14 +36,14 @@ function CodeBlock({ code, language }: { code: string; language: string }) {
       {/* Header bar */}
       <div className="flex items-center justify-between px-3 py-1.5 border-b border-[var(--border)] bg-zinc-950">
         {language && (
-          <span className="font-mono text-[8px] tracking-widest text-[var(--muted-foreground)]">
+          <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">
             {language.toUpperCase()}
           </span>
         )}
         {!language && <span />}
         <button
           onClick={handleCopy}
-          className="flex items-center gap-1 font-mono text-[8px] tracking-widest text-[var(--muted-foreground)] hover:text-[var(--primary)] transition-colors opacity-0 group-hover:opacity-100"
+          className="flex items-center gap-1 font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] hover:text-[var(--primary)] transition-colors opacity-0 group-hover:opacity-100"
           title="Copy to clipboard"
         >
           {copied ? (

--- a/src/components/Engine/MobileToolbar.tsx
+++ b/src/components/Engine/MobileToolbar.tsx
@@ -38,7 +38,7 @@ export default function MobileToolbar() {
               className={`w-4 h-4 ${activeTab === tab.id ? 'text-[var(--primary)]' : 'text-[var(--muted-foreground)]'}`}
               strokeWidth={1.5}
             />
-            <span className={`font-mono text-[8px] tracking-widest ${
+            <span className={`font-mono text-[10px] tracking-widest ${
               activeTab === tab.id ? 'text-[var(--primary)]' : 'text-[var(--muted-foreground)]'
             }`}>
               {tab.label}

--- a/src/components/Engine/ModeQuickSwitch.tsx
+++ b/src/components/Engine/ModeQuickSwitch.tsx
@@ -58,7 +58,7 @@ export default function ModeQuickSwitch() {
             return (
               <div key={category}>
                 <div className="px-3 py-1.5 bg-[var(--secondary)]">
-                  <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)]">
+                  <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">
                     {category.toUpperCase()}
                   </span>
                 </div>
@@ -74,7 +74,7 @@ export default function ModeQuickSwitch() {
                   >
                     <div>
                       <span className="font-mono text-[10px] tracking-widest block">{mode.name}</span>
-                      <span className="text-[9px] text-[var(--muted-foreground)] block mt-0.5 max-w-[200px] truncate">
+                      <span className="text-[10px] text-[var(--muted-foreground)] block mt-0.5 max-w-[200px] truncate">
                         {mode.description}
                       </span>
                     </div>

--- a/src/components/Engine/ModelSelector.tsx
+++ b/src/components/Engine/ModelSelector.tsx
@@ -42,7 +42,7 @@ export default function ModelSelector({ value, onChange, compact = false }: Mode
       <div className="relative" ref={containerRef}>
         <button
           onClick={() => setIsOpen(!isOpen)}
-          className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)] hover:text-[var(--primary)] transition-colors flex items-center gap-1"
+          className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] hover:text-[var(--primary)] transition-colors flex items-center gap-1"
         >
           {current.label}
           <ChevronDown className={`w-2.5 h-2.5 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
@@ -66,8 +66,8 @@ export default function ModelSelector({ value, onChange, compact = false }: Mode
                       : 'text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--secondary)]'
                   }`}
                 >
-                  <span className="font-mono text-[9px] tracking-widest">{model.label}</span>
-                  <span className="font-mono text-[7px] tracking-wider opacity-50">{model.badge}</span>
+                  <span className="font-mono text-[10px] tracking-widest">{model.label}</span>
+                  <span className="font-mono text-[9px] tracking-wider opacity-50">{model.badge}</span>
                 </button>
               ))}
             </motion.div>
@@ -110,9 +110,9 @@ export default function ModelSelector({ value, onChange, compact = false }: Mode
               >
                 <div className="flex items-center justify-between">
                   <span className="font-mono text-[10px] tracking-widest">{model.label}</span>
-                  <span className="font-mono text-[8px] tracking-wider opacity-50">{model.badge}</span>
+                  <span className="font-mono text-[10px] tracking-wider opacity-50">{model.badge}</span>
                 </div>
-                <span className="text-[9px] opacity-60 block mt-0.5">{model.description}</span>
+                <span className="text-[10px] opacity-60 block mt-0.5">{model.description}</span>
               </button>
             ))}
           </motion.div>

--- a/src/components/Engine/RetrievalTierIndicator.tsx
+++ b/src/components/Engine/RetrievalTierIndicator.tsx
@@ -35,7 +35,7 @@ export default function RetrievalTierIndicator({
   if (compact) {
     return (
       <div className="flex items-center gap-1">
-        <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)]">T</span>
+        <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">T</span>
         {TIERS.map((tier) => (
           <div
             key={tier.id}
@@ -71,12 +71,12 @@ export default function RetrievalTierIndicator({
                 opacity: isActive ? 1 : isPast ? 0.3 : 0.15,
               }}
             />
-            <span className={`font-mono text-[9px] tracking-widest ${
+            <span className={`font-mono text-[10px] tracking-widest ${
               isActive ? 'text-[var(--primary)]' : 'text-[var(--muted-foreground)]'
             }`}>
               {tier.label}
             </span>
-            <span className="font-mono text-[8px] text-[var(--muted-foreground)] opacity-50">
+            <span className="font-mono text-[10px] text-[var(--muted-foreground)] opacity-50">
               {tier.tokens}
             </span>
           </div>

--- a/src/components/Engine/SkillPill.tsx
+++ b/src/components/Engine/SkillPill.tsx
@@ -21,7 +21,7 @@ export default function SkillPill({ name, active = false, paramount = false, onC
     <button
       onClick={onClick}
       className={`
-        inline-flex items-center gap-1 px-2 py-0.5 font-mono text-[9px] tracking-wider
+        inline-flex items-center gap-1 px-2 py-0.5 font-mono text-[10px] tracking-wider
         transition-colors border
         ${paramount
           ? 'border-[var(--primary)] text-[var(--primary)] bg-[var(--primary)]/5'

--- a/src/components/Engine/SystemOverview.tsx
+++ b/src/components/Engine/SystemOverview.tsx
@@ -100,7 +100,7 @@ export default function SystemOverview() {
           >
             <div className="flex items-center gap-1.5 mb-1">
               <stat.icon className={`w-3 h-3 ${stat.accent ? 'text-[var(--primary)]' : 'text-[var(--muted-foreground)]'}`} strokeWidth={1.5} />
-              <span className="font-mono text-[8px] tracking-widest text-[var(--muted-foreground)]">
+              <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">
                 {stat.label}
               </span>
             </div>

--- a/src/components/Engine/WelcomeAnimation.tsx
+++ b/src/components/Engine/WelcomeAnimation.tsx
@@ -74,7 +74,7 @@ export default function WelcomeAnimation({ onComplete }: { onComplete: () => voi
           <span className="font-mono text-2xl font-bold tracking-widest text-[var(--foreground)]">
             GRIP
           </span>
-          <span className="block font-mono text-[9px] tracking-widest text-[var(--muted-foreground)] mt-1">
+          <span className="block font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] mt-1">
             KNOWLEDGE WORK ENGINE
           </span>
         </div>

--- a/src/components/KeyboardShortcutsHelp.tsx
+++ b/src/components/KeyboardShortcutsHelp.tsx
@@ -128,7 +128,7 @@ export default function KeyboardShortcutsHelp() {
 
           {/* Footer */}
           <div className="px-6 py-3 border-t border-[var(--border)]">
-            <span className="font-mono text-[9px] tracking-widest text-[var(--muted-foreground)]">
+            <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">
               PRESS ? TO TOGGLE | ESC TO CLOSE
             </span>
           </div>

--- a/src/components/Memory/AgentKnowledgeGraph.tsx
+++ b/src/components/Memory/AgentKnowledgeGraph.tsx
@@ -957,7 +957,7 @@ export default function AgentKnowledgeGraph() {
         {legendOpen ? (
           <div className="bg-black/70 border border-white/10 p-3 text-[10px] text-white/70 space-y-1.5 backdrop-blur-sm min-w-[140px]">
             <div className="flex items-center justify-between mb-2">
-              <span className="text-white/40 uppercase tracking-wider text-[9px]">Legend</span>
+              <span className="text-white/40 uppercase tracking-wider text-[10px]">Legend</span>
               <button onClick={() => setLegendOpen(false)} className="text-white/30 hover:text-white/70">✕</button>
             </div>
             {(Object.entries(KIND_COLOR) as [NodeKind, typeof KIND_COLOR[NodeKind]][]).map(([kind, c]) => (
@@ -966,7 +966,7 @@ export default function AgentKnowledgeGraph() {
                 <span className="capitalize">{kind === 'mcp' ? 'MCP server' : kind === 'instructions' ? 'CLAUDE.md' : kind}</span>
               </div>
             ))}
-            <p className="text-white/30 text-[9px] mt-2 border-t border-white/10 pt-2">Scroll to zoom · drag to pan<br/>Click agent to isolate</p>
+            <p className="text-white/30 text-[10px] mt-2 border-t border-white/10 pt-2">Scroll to zoom · drag to pan<br/>Click agent to isolate</p>
           </div>
         ) : (
           <button

--- a/src/components/SchedulerCalendar.tsx
+++ b/src/components/SchedulerCalendar.tsx
@@ -451,7 +451,7 @@ export default function SchedulerCalendar({
       {hasAllDay && (
         <div className="grid border-b border-border" style={{ gridTemplateColumns: '44px repeat(7, 1fr)' }}>
           <div className="border-r border-border flex items-center justify-end pr-1.5">
-            <span className="text-[9px] text-muted-foreground/60 rotate-0 leading-tight">all‑day</span>
+            <span className="text-[10px] text-muted-foreground/60 rotate-0 leading-tight">all‑day</span>
           </div>
           {Array.from({ length: 7 }, (_, dayOffset) => {
             const dayAllDay = allDayEvents.filter(e => e.dayOffset === dayOffset);
@@ -479,7 +479,7 @@ export default function SchedulerCalendar({
                         ) : (
                           <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${color.dot}`} />
                         )}
-                        <span className="text-[9px] font-medium truncate">{event.label}</span>
+                        <span className="text-[10px] font-medium truncate">{event.label}</span>
                       </div>
                     </button>
                   );
@@ -501,7 +501,7 @@ export default function SchedulerCalendar({
                 className="border-b border-border/40 flex items-start justify-end pr-1.5 pt-0.5"
                 style={{ height: `${HOUR_HEIGHT}px` }}
               >
-                <span className="text-[9px] text-muted-foreground/50 tabular-nums">{formatHour(hour)}</span>
+                <span className="text-[10px] text-muted-foreground/50 tabular-nums">{formatHour(hour)}</span>
               </div>
             ))}
           </div>

--- a/src/components/Settings/TerminalSection.tsx
+++ b/src/components/Settings/TerminalSection.tsx
@@ -51,7 +51,7 @@ export const TerminalSection = ({ appSettings, onSaveAppSettings }: TerminalSect
             </div>
             {/* Mini preview */}
             <div className="rounded-sm overflow-hidden border border-border">
-              <div className="bg-[#1a1a2e] p-2 h-16 font-mono text-[9px] leading-relaxed">
+              <div className="bg-[#1a1a2e] p-2 h-16 font-mono text-[10px] leading-relaxed">
                 <span className="text-[#22c55e]">$</span>{' '}
                 <span className="text-[#e4e4e7]">npm start</span>
                 <br />
@@ -79,7 +79,7 @@ export const TerminalSection = ({ appSettings, onSaveAppSettings }: TerminalSect
             </div>
             {/* Mini preview */}
             <div className="rounded-sm overflow-hidden border border-border">
-              <div className="bg-[#FFFFFF] p-2 h-16 font-mono text-[9px] leading-relaxed">
+              <div className="bg-[#FFFFFF] p-2 h-16 font-mono text-[10px] leading-relaxed">
                 <span className="text-[#16a34a]">$</span>{' '}
                 <span className="text-[#1a1a2e]">npm start</span>
                 <br />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -91,7 +91,7 @@ export default function Sidebar({ isMobile = false }: SidebarProps) {
         <div className="relative shrink-0">
           <item.icon className="w-4 h-4" strokeWidth={1.5} />
           {item.href === '/vault' && vaultUnreadCount > 0 && !showLabels && (
-            <span className="absolute -top-1 -right-1 min-w-[12px] h-[12px] flex items-center justify-center text-[7px] font-bold bg-[var(--primary)] text-[var(--primary-foreground)] px-0.5">
+            <span className="absolute -top-1 -right-1 min-w-[12px] h-[12px] flex items-center justify-center text-[9px] font-bold bg-[var(--primary)] text-[var(--primary-foreground)] px-0.5">
               {vaultUnreadCount}
             </span>
           )}
@@ -108,13 +108,13 @@ export default function Sidebar({ isMobile = false }: SidebarProps) {
         )}
         {/* Collapsed tooltip — shows label on hover when sidebar is collapsed */}
         {!showLabels && (
-          <span className="absolute left-full ml-2 px-2 py-1 bg-[var(--card)] border border-[var(--border)] font-mono text-[9px] tracking-widest text-[var(--foreground)] whitespace-nowrap opacity-0 group-hover/nav:opacity-100 pointer-events-none transition-opacity z-50">
+          <span className="absolute left-full ml-2 px-2 py-1 bg-[var(--card)] border border-[var(--border)] font-mono text-[10px] tracking-widest text-[var(--foreground)] whitespace-nowrap opacity-0 group-hover/nav:opacity-100 pointer-events-none transition-opacity z-50">
             {item.label}
             {item.shortcut && <span className="text-[var(--muted-foreground)] ml-2">{item.shortcut}</span>}
           </span>
         )}
         {item.href === '/vault' && vaultUnreadCount > 0 && showLabels && (
-          <span className="min-w-[18px] h-[18px] flex items-center justify-center text-[9px] font-mono font-bold bg-[var(--primary)] text-[var(--primary-foreground)] px-0.5">
+          <span className="min-w-[18px] h-[18px] flex items-center justify-center text-[10px] font-mono font-bold bg-[var(--primary)] text-[var(--primary-foreground)] px-0.5">
             {vaultUnreadCount}
           </span>
         )}
@@ -140,7 +140,7 @@ export default function Sidebar({ isMobile = false }: SidebarProps) {
               <span className="font-mono text-sm font-bold tracking-widest text-[var(--foreground)] transition-all duration-300 hover:text-[var(--primary)] hover:drop-shadow-[0_0_6px_var(--primary)]">
                 GRIP
               </span>
-              <span className="block font-mono text-[9px] tracking-widest text-[var(--muted-foreground)] leading-none mt-0.5">
+              <span className="block font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] leading-none mt-0.5">
                 KNOWLEDGE WORK ENGINE
               </span>
             </div>

--- a/src/components/SkillBrowser.tsx
+++ b/src/components/SkillBrowser.tsx
@@ -125,7 +125,7 @@ export default function SkillBrowser() {
             <p className="text-[11px] text-[var(--muted-foreground)] leading-relaxed mb-2">
               {skill.description}
             </p>
-            <span className="font-mono text-[8px] tracking-widest text-[var(--muted-foreground)] opacity-60">
+            <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] opacity-60">
               {SKILL_CATEGORIES[skill.category]?.label || skill.category.toUpperCase()}
             </span>
           </motion.div>

--- a/src/components/VaultView/components/FolderTree.tsx
+++ b/src/components/VaultView/components/FolderTree.tsx
@@ -21,16 +21,16 @@ function DocTags({ tags }: { tags: string[] }) {
   if (tags.length === 0) return null;
   return (
     <span className="relative flex items-center gap-0.5 shrink-0 group/tags">
-      <span className="px-1 text-[9px] rounded bg-secondary text-muted-foreground">
+      <span className="px-1 text-[10px] rounded bg-secondary text-muted-foreground">
         {tags[0]}
       </span>
       {tags.length > 1 && (
-        <span className="text-[9px] text-muted-foreground">+{tags.length - 1}</span>
+        <span className="text-[10px] text-muted-foreground">+{tags.length - 1}</span>
       )}
       {tags.length > 1 && (
         <span className="absolute right-0 top-full mt-1 z-50 hidden group-hover/tags:flex flex-col gap-0.5 p-1.5 bg-popover border border-border rounded min-w-max">
           {tags.map(tag => (
-            <span key={tag} className="px-1.5 py-0.5 text-[9px] rounded bg-secondary text-muted-foreground whitespace-nowrap">
+            <span key={tag} className="px-1.5 py-0.5 text-[10px] rounded bg-secondary text-muted-foreground whitespace-nowrap">
               {tag}
             </span>
           ))}


### PR DESCRIPTION
## Summary
- Audits and bumps all font sizes below 10px across 27 files (71 replacements)
- Mapping: 6px->8px, 7px->9px, 8px->10px, 9px->10px
- Preserves visual hierarchy while ensuring readability on HiDPI displays

## Test plan
- [ ] Verify 773/773 tests pass
- [ ] Visual check: status bar, sidebar badges, mode labels, chat timestamps
- [ ] HiDPI display legibility verification
- [ ] No layout shifts from size bumps