### PR TITLE
feat: add theme engine with 17 themes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -119,24 +119,24 @@ html {
   --chart-5: #e5e5e5;
 }
 
-/* Dark mode scrollbar */
+/* Theme-aware scrollbar — uses CSS variables set by theme engine */
 .dark * {
-  scrollbar-color: #333 #171717;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
 }
 .dark *::-webkit-scrollbar-track {
-  background: #171717;
+  background: var(--scrollbar-track);
 }
 .dark *::-webkit-scrollbar-thumb {
-  background: #333;
+  background: var(--scrollbar-thumb);
 }
 .dark *::-webkit-scrollbar-thumb:hover {
-  background: #22d3ee;
+  background: var(--scrollbar-thumb-hover);
 }
 .dark *::-webkit-scrollbar-corner {
-  background: #171717;
+  background: var(--scrollbar-track);
 }
 .dark .xterm-viewport::-webkit-scrollbar-thumb {
-  background: #333;
+  background: var(--scrollbar-thumb);
 }
 
 @theme inline {
@@ -235,7 +235,7 @@ html {
    ============================================ */
 * {
   scrollbar-width: thin;
-  scrollbar-color: #b0b0b0 #e0e0e0;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
 }
 
 *::-webkit-scrollbar {
@@ -244,19 +244,19 @@ html {
 }
 
 *::-webkit-scrollbar-track {
-  background: #e0e0e0;
+  background: var(--scrollbar-track);
 }
 
 *::-webkit-scrollbar-thumb {
-  background: #b0b0b0;
+  background: var(--scrollbar-thumb);
 }
 
 *::-webkit-scrollbar-thumb:hover {
-  background: var(--primary);
+  background: var(--scrollbar-thumb-hover);
 }
 
 *::-webkit-scrollbar-corner {
-  background: #e0e0e0;
+  background: var(--scrollbar-track);
 }
 
 /* ============================================

--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -9,6 +9,7 @@ import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { Menu, X, Download, ExternalLink, RotateCw, Loader2 } from 'lucide-react';
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
+import { applyTheme, getTheme, DEFAULT_THEME } from '@/lib/themes';
 
 function useIsMobile() {
   const [isMobile, setIsMobile] = useState(false);
@@ -47,7 +48,7 @@ function loadVaultReadDocs(): Set<string> {
 }
 
 export default function ClientLayout({ children }: { children: React.ReactNode }) {
-  const { sidebarCollapsed, mobileMenuOpen, setMobileMenuOpen, darkMode, setDarkMode, setVaultUnreadCount } = useStore();
+  const { sidebarCollapsed, mobileMenuOpen, setMobileMenuOpen, setVaultUnreadCount } = useStore();
   const isMobile = useIsMobile();
   const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
   const [updateDismissed, setUpdateDismissed] = useState(false);
@@ -116,33 +117,40 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
     window.electronAPI?.updates?.quitAndInstall();
   }, []);
 
-  // Initialize dark mode from localStorage on mount
+  // Initialize theme from localStorage on mount
+  const setTheme = useStore(s => s.setTheme);
+  const theme = useStore(s => s.theme);
   useEffect(() => {
-    // Check system preference first, then localStorage override
-    const savedPref = localStorage.getItem('grip-dark-mode');
-    if (savedPref !== null) {
-      setDarkMode(savedPref === 'true');
-    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      setDarkMode(true);
+    const savedTheme = localStorage.getItem('grip-theme');
+    if (savedTheme) {
+      setTheme(savedTheme);
+    } else {
+      // Migrate from old darkMode preference
+      const savedPref = localStorage.getItem('grip-dark-mode');
+      if (savedPref !== null) {
+        setTheme(savedPref === 'true' ? 'swiss-nihilism-dark' : 'swiss-nihilism-light');
+      } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        setTheme('swiss-nihilism-dark');
+      } else {
+        setTheme(DEFAULT_THEME);
+      }
     }
-  }, [setDarkMode]);
+  }, [setTheme]);
 
-  // Sync dark class on <html> with smooth theme transition
+  // Apply theme CSS variables with smooth transition
   useEffect(() => {
-    // Add transitioning class to enable CSS colour transitions
     document.documentElement.classList.add('theme-transitioning');
-    document.documentElement.classList.toggle('dark', darkMode);
-    localStorage.setItem('grip-dark-mode', String(darkMode));
-    // Sync Electron window background to prevent native bg flash
+    applyTheme(theme);
+    localStorage.setItem('grip-theme', theme);
+    // Sync Electron window background
+    const themeData = getTheme(theme);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any).electronAPI?.grip?.notifyThemeChanged?.(darkMode);
-    // Remove transitioning class after animation completes to avoid
-    // unnecessary transition overhead during normal interactions
+    (window as any).electronAPI?.grip?.notifyThemeChanged?.(themeData.isDark);
     const timer = setTimeout(() => {
       document.documentElement.classList.remove('theme-transitioning');
     }, 350);
     return () => clearTimeout(timer);
-  }, [darkMode]);
+  }, [theme]);
 
   // Global vault unread badge: listen for new documents even when VaultView is not mounted
   useEffect(() => {
@@ -221,10 +229,15 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
         return;
       }
 
-      // D = toggle dark mode, M = memory
+      // D = toggle dark mode, T = cycle theme, M = memory
       if (e.key === 'd' || e.key === 'D') {
         e.preventDefault();
         useStore.getState().toggleDarkMode();
+        return;
+      }
+      if (e.key === 't' || e.key === 'T') {
+        e.preventDefault();
+        useStore.getState().cycleTheme();
         return;
       }
       if (e.key === 'm' || e.key === 'M') {

--- a/src/components/Settings/GeneralSection.tsx
+++ b/src/components/Settings/GeneralSection.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Settings, RefreshCw, Download, ExternalLink, CheckCircle, AlertCircle, Loader2, RotateCw } from 'lucide-react';
 import { Toggle } from './Toggle';
+import ThemePicker from './ThemePicker';
 import type { ClaudeInfo, AppSettings } from './types';
 
 interface UpdateInfo {
@@ -138,6 +139,11 @@ export const GeneralSection = ({ info, appSettings, onSaveAppSettings }: General
       <div>
         <h2 className="text-lg font-semibold mb-1">General Settings</h2>
         <p className="text-sm text-muted-foreground">Configure general application preferences</p>
+      </div>
+
+      {/* Theme Picker */}
+      <div className="border border-border bg-card p-6">
+        <ThemePicker />
       </div>
 
       <div className="border border-border bg-card p-6">

--- a/src/components/Settings/ThemePicker.tsx
+++ b/src/components/Settings/ThemePicker.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useStore } from '@/store';
+import { THEMES, getTheme, getThemesByCategory } from '@/lib/themes';
+
+const CATEGORY_LABELS: Record<string, string> = {
+  swiss: 'SWISS',
+  nature: 'NATURE',
+  retro: 'RETRO',
+  futuristic: 'FUTURISTIC',
+};
+
+export default function ThemePicker() {
+  const { theme, setTheme } = useStore();
+  const grouped = getThemesByCategory();
+  const currentTheme = getTheme(theme);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-bold tracking-tighter text-[var(--foreground)]">THEME</h3>
+          <p className="text-[10px] font-mono tracking-wider text-[var(--muted-foreground)] mt-0.5">
+            {currentTheme.name} | Press T to cycle, D for dark/light toggle
+          </p>
+        </div>
+      </div>
+
+      {Object.entries(grouped).map(([category, themes]) => (
+        <div key={category}>
+          <p className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] mb-2">
+            {CATEGORY_LABELS[category] || category.toUpperCase()}
+          </p>
+          <div className="grid grid-cols-4 gap-2">
+            {themes.map((t) => {
+              const isActive = t.id === theme;
+              return (
+                <button
+                  key={t.id}
+                  onClick={() => setTheme(t.id)}
+                  className={`group relative p-2 border transition-colors text-left ${
+                    isActive
+                      ? 'border-[var(--primary)] bg-[var(--secondary)]'
+                      : 'border-[var(--border)] hover:border-[var(--primary)]'
+                  }`}
+                  title={t.name}
+                >
+                  {/* Preview swatch */}
+                  <div className="flex gap-0.5 mb-1.5">
+                    <div
+                      className="w-full h-6 border border-black/10"
+                      style={{ backgroundColor: t.colors.background }}
+                    />
+                    <div
+                      className="w-3 h-6 shrink-0"
+                      style={{ backgroundColor: t.colors.primary }}
+                    />
+                  </div>
+                  <p className="font-mono text-[10px] tracking-wider text-[var(--foreground)] truncate">
+                    {t.name}
+                  </p>
+                  <p className="font-mono text-[8px] tracking-wider text-[var(--muted-foreground)]">
+                    {t.isDark ? 'DARK' : 'LIGHT'}
+                  </p>
+                  {isActive && (
+                    <div className="absolute top-1 right-1 w-2 h-2 bg-[var(--primary)]" />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Settings/index.ts
+++ b/src/components/Settings/index.ts
@@ -29,3 +29,4 @@ export { PermissionsSection } from './PermissionsSection';
 export { SkillsSection } from './SkillsSection';
 export { CLIPathsSection } from './CLIPathsSection';
 export { SystemSection } from './SystemSection';
+export { default as ThemePicker } from './ThemePicker';

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -12,8 +12,7 @@ import {
   CalendarClock,
   Zap,
   Columns,
-  Moon,
-  Sun,
+  Palette,
   Archive,
   Brain,
   Sparkles,
@@ -21,6 +20,7 @@ import {
   Layers,
 } from 'lucide-react';
 import { useStore } from '@/store';
+import { getTheme } from '@/lib/themes';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 
@@ -58,7 +58,7 @@ const navItemVariants = {
 export default function Sidebar({ isMobile = false }: SidebarProps) {
   const pathname = usePathname();
   const router = useRouter();
-  const { sidebarCollapsed, toggleSidebar, mobileMenuOpen, setMobileMenuOpen, darkMode, toggleDarkMode, vaultUnreadCount } = useStore();
+  const { sidebarCollapsed, toggleSidebar, mobileMenuOpen, setMobileMenuOpen, theme, vaultUnreadCount } = useStore();
   const reduceMotion = useReducedMotion();
 
   const sidebarWidth = isMobile ? 240 : (sidebarCollapsed ? 64 : 240);
@@ -187,11 +187,12 @@ export default function Sidebar({ isMobile = false }: SidebarProps) {
           {showLabels && <span className="text-xs tracking-widest">SETTINGS</span>}
         </Link>
         <button
-          onClick={toggleDarkMode}
+          onClick={() => useStore.getState().cycleTheme()}
           className="w-full flex items-center gap-3 px-4 py-2.5 text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors font-mono text-xs tracking-wider border-l-2 border-transparent"
+          title={`Theme: ${getTheme(theme).name} (T to cycle)`}
         >
-          {darkMode ? <Sun className="w-4 h-4" strokeWidth={1.5} /> : <Moon className="w-4 h-4" strokeWidth={1.5} />}
-          {showLabels && <span className="text-xs tracking-widest">{darkMode ? 'LIGHT' : 'DARK'}</span>}
+          <Palette className="w-4 h-4" strokeWidth={1.5} />
+          {showLabels && <span className="text-[10px] tracking-widest truncate">{getTheme(theme).name.toUpperCase()}</span>}
         </button>
         {!isMobile && (
           <button

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -1,0 +1,520 @@
+/**
+ * GRIP Theme Engine — 17 themes across 4 categories.
+ * Single source of truth for all theme data.
+ * Applied at runtime via CSS custom properties on <html>.
+ */
+
+export interface ThemeColors {
+  background: string;
+  foreground: string;
+  card: string;
+  'card-foreground': string;
+  popover: string;
+  'popover-foreground': string;
+  primary: string;
+  'primary-foreground': string;
+  secondary: string;
+  'secondary-foreground': string;
+  muted: string;
+  'muted-foreground': string;
+  accent: string;
+  'accent-foreground': string;
+  destructive: string;
+  border: string;
+  input: string;
+  ring: string;
+  success: string;
+  'success-muted': string;
+  warning: string;
+  'warning-muted': string;
+  danger: string;
+  'danger-muted': string;
+  info: string;
+  'info-muted': string;
+  'chart-1': string;
+  'chart-2': string;
+  'chart-3': string;
+  'chart-4': string;
+  'chart-5': string;
+  'scrollbar-track': string;
+  'scrollbar-thumb': string;
+  'scrollbar-thumb-hover': string;
+  'vortex-glow': string;
+}
+
+export interface ThemeDefinition {
+  id: string;
+  name: string;
+  category: 'swiss' | 'nature' | 'retro' | 'futuristic';
+  isDark: boolean;
+  colors: ThemeColors;
+}
+
+function lightScrollbar(track: string, thumb: string, accent: string) {
+  return { 'scrollbar-track': track, 'scrollbar-thumb': thumb, 'scrollbar-thumb-hover': accent };
+}
+
+function darkScrollbar(track: string, thumb: string, accent: string) {
+  return { 'scrollbar-track': track, 'scrollbar-thumb': thumb, 'scrollbar-thumb-hover': accent };
+}
+
+export const THEMES: ThemeDefinition[] = [
+  // ─── SWISS ────────────────────────────────────
+  {
+    id: 'swiss-nihilism-light',
+    name: 'Swiss Nihilism Light',
+    category: 'swiss',
+    isDark: false,
+    colors: {
+      background: '#EAEAEA', foreground: '#000000',
+      card: '#F5F5F5', 'card-foreground': '#000000',
+      popover: '#F5F5F5', 'popover-foreground': '#000000',
+      primary: '#0891b2', 'primary-foreground': '#EAEAEA',
+      secondary: '#e0e0e0', 'secondary-foreground': '#000000',
+      muted: '#d4d4d4', 'muted-foreground': '#525252',
+      accent: '#0891b2', 'accent-foreground': '#EAEAEA',
+      destructive: '#dc2626',
+      border: '#d1d5db', input: '#F5F5F5', ring: '#0891b2',
+      success: '#16a34a', 'success-muted': 'rgba(22, 163, 74, 0.12)',
+      warning: '#ca8a04', 'warning-muted': 'rgba(202, 138, 4, 0.12)',
+      danger: '#dc2626', 'danger-muted': 'rgba(220, 38, 38, 0.12)',
+      info: '#0891b2', 'info-muted': 'rgba(8, 145, 178, 0.12)',
+      'chart-1': '#0891b2', 'chart-2': '#525252', 'chart-3': '#16a34a', 'chart-4': '#dc2626', 'chart-5': '#000000',
+      ...lightScrollbar('#e0e0e0', '#b0b0b0', '#0891b2'),
+      'vortex-glow': '0 0 20px rgba(8, 145, 178, 0.3)',
+    },
+  },
+  {
+    id: 'swiss-nihilism-dark',
+    name: 'Swiss Nihilism Dark',
+    category: 'swiss',
+    isDark: true,
+    colors: {
+      background: '#0a0a0a', foreground: '#e5e5e5',
+      card: '#171717', 'card-foreground': '#e5e5e5',
+      popover: '#171717', 'popover-foreground': '#e5e5e5',
+      primary: '#22d3ee', 'primary-foreground': '#0a0a0a',
+      secondary: '#1a1a1a', 'secondary-foreground': '#e5e5e5',
+      muted: '#262626', 'muted-foreground': '#737373',
+      accent: '#22d3ee', 'accent-foreground': '#0a0a0a',
+      destructive: '#ef4444',
+      border: '#262626', input: '#171717', ring: '#22d3ee',
+      success: '#22c55e', 'success-muted': 'rgba(34, 197, 94, 0.15)',
+      warning: '#eab308', 'warning-muted': 'rgba(234, 179, 8, 0.15)',
+      danger: '#ef4444', 'danger-muted': 'rgba(239, 68, 68, 0.15)',
+      info: '#22d3ee', 'info-muted': 'rgba(34, 211, 238, 0.15)',
+      'chart-1': '#22d3ee', 'chart-2': '#a3a3a3', 'chart-3': '#22c55e', 'chart-4': '#ef4444', 'chart-5': '#e5e5e5',
+      ...darkScrollbar('#171717', '#333', '#22d3ee'),
+      'vortex-glow': '0 0 30px rgba(34, 211, 238, 0.4)',
+    },
+  },
+  {
+    id: 'swiss-neutrality',
+    name: 'Swiss Neutrality',
+    category: 'swiss',
+    isDark: false,
+    colors: {
+      background: '#F0EDE8', foreground: '#1a1a1a',
+      card: '#F7F5F0', 'card-foreground': '#1a1a1a',
+      popover: '#F7F5F0', 'popover-foreground': '#1a1a1a',
+      primary: '#B8860B', 'primary-foreground': '#F0EDE8',
+      secondary: '#E5E0D8', 'secondary-foreground': '#1a1a1a',
+      muted: '#D9D4CC', 'muted-foreground': '#6b5f50',
+      accent: '#B8860B', 'accent-foreground': '#F0EDE8',
+      destructive: '#c0392b',
+      border: '#D0C8BC', input: '#F7F5F0', ring: '#B8860B',
+      success: '#27ae60', 'success-muted': 'rgba(39, 174, 96, 0.12)',
+      warning: '#d4a017', 'warning-muted': 'rgba(212, 160, 23, 0.12)',
+      danger: '#c0392b', 'danger-muted': 'rgba(192, 57, 43, 0.12)',
+      info: '#B8860B', 'info-muted': 'rgba(184, 134, 11, 0.12)',
+      'chart-1': '#B8860B', 'chart-2': '#6b5f50', 'chart-3': '#27ae60', 'chart-4': '#c0392b', 'chart-5': '#1a1a1a',
+      ...lightScrollbar('#E5E0D8', '#C0B8A8', '#B8860B'),
+      'vortex-glow': '0 0 20px rgba(184, 134, 11, 0.3)',
+    },
+  },
+  {
+    id: 'swiss-optimism',
+    name: 'Swiss Optimism',
+    category: 'swiss',
+    isDark: false,
+    colors: {
+      background: '#F5FAF0', foreground: '#1a2e1a',
+      card: '#FAFFF5', 'card-foreground': '#1a2e1a',
+      popover: '#FAFFF5', 'popover-foreground': '#1a2e1a',
+      primary: '#16a34a', 'primary-foreground': '#F5FAF0',
+      secondary: '#E8F0E0', 'secondary-foreground': '#1a2e1a',
+      muted: '#D5E0CC', 'muted-foreground': '#4a6040',
+      accent: '#16a34a', 'accent-foreground': '#F5FAF0',
+      destructive: '#dc2626',
+      border: '#C8D8BC', input: '#FAFFF5', ring: '#16a34a',
+      success: '#16a34a', 'success-muted': 'rgba(22, 163, 74, 0.12)',
+      warning: '#ca8a04', 'warning-muted': 'rgba(202, 138, 4, 0.12)',
+      danger: '#dc2626', 'danger-muted': 'rgba(220, 38, 38, 0.12)',
+      info: '#16a34a', 'info-muted': 'rgba(22, 163, 74, 0.12)',
+      'chart-1': '#16a34a', 'chart-2': '#4a6040', 'chart-3': '#0891b2', 'chart-4': '#dc2626', 'chart-5': '#1a2e1a',
+      ...lightScrollbar('#E8F0E0', '#B0C8A0', '#16a34a'),
+      'vortex-glow': '0 0 20px rgba(22, 163, 74, 0.3)',
+    },
+  },
+  {
+    id: 'swiss-utopia',
+    name: 'Swiss Utopia',
+    category: 'swiss',
+    isDark: false,
+    colors: {
+      background: '#F5F0FF', foreground: '#1a1028',
+      card: '#FAF7FF', 'card-foreground': '#1a1028',
+      popover: '#FAF7FF', 'popover-foreground': '#1a1028',
+      primary: '#8B5CF6', 'primary-foreground': '#F5F0FF',
+      secondary: '#EDE5FF', 'secondary-foreground': '#1a1028',
+      muted: '#DDD0F5', 'muted-foreground': '#6B5A8A',
+      accent: '#8B5CF6', 'accent-foreground': '#F5F0FF',
+      destructive: '#dc2626',
+      border: '#D0C0E8', input: '#FAF7FF', ring: '#8B5CF6',
+      success: '#16a34a', 'success-muted': 'rgba(22, 163, 74, 0.12)',
+      warning: '#ca8a04', 'warning-muted': 'rgba(202, 138, 4, 0.12)',
+      danger: '#dc2626', 'danger-muted': 'rgba(220, 38, 38, 0.12)',
+      info: '#8B5CF6', 'info-muted': 'rgba(139, 92, 246, 0.12)',
+      'chart-1': '#8B5CF6', 'chart-2': '#6B5A8A', 'chart-3': '#16a34a', 'chart-4': '#dc2626', 'chart-5': '#1a1028',
+      ...lightScrollbar('#EDE5FF', '#C0A8E8', '#8B5CF6'),
+      'vortex-glow': '0 0 20px rgba(139, 92, 246, 0.3)',
+    },
+  },
+
+  // ─── NATURE ───────────────────────────────────
+  {
+    id: 'autumn',
+    name: 'Autumn',
+    category: 'nature',
+    isDark: false,
+    colors: {
+      background: '#FDF6E3', foreground: '#3C2A14',
+      card: '#FFF8EC', 'card-foreground': '#3C2A14',
+      popover: '#FFF8EC', 'popover-foreground': '#3C2A14',
+      primary: '#D97706', 'primary-foreground': '#FDF6E3',
+      secondary: '#F0E4CC', 'secondary-foreground': '#3C2A14',
+      muted: '#E5D8C0', 'muted-foreground': '#7A6548',
+      accent: '#D97706', 'accent-foreground': '#FDF6E3',
+      destructive: '#dc2626',
+      border: '#D8C8A8', input: '#FFF8EC', ring: '#D97706',
+      success: '#16a34a', 'success-muted': 'rgba(22, 163, 74, 0.12)',
+      warning: '#D97706', 'warning-muted': 'rgba(217, 119, 6, 0.12)',
+      danger: '#dc2626', 'danger-muted': 'rgba(220, 38, 38, 0.12)',
+      info: '#D97706', 'info-muted': 'rgba(217, 119, 6, 0.12)',
+      'chart-1': '#D97706', 'chart-2': '#7A6548', 'chart-3': '#16a34a', 'chart-4': '#dc2626', 'chart-5': '#3C2A14',
+      ...lightScrollbar('#F0E4CC', '#C8B090', '#D97706'),
+      'vortex-glow': '0 0 20px rgba(217, 119, 6, 0.3)',
+    },
+  },
+  {
+    id: 'summer',
+    name: 'Summer',
+    category: 'nature',
+    isDark: false,
+    colors: {
+      background: '#FFFBF0', foreground: '#2D1810',
+      card: '#FFFDF5', 'card-foreground': '#2D1810',
+      popover: '#FFFDF5', 'popover-foreground': '#2D1810',
+      primary: '#EF4444', 'primary-foreground': '#FFFBF0',
+      secondary: '#FFF0E0', 'secondary-foreground': '#2D1810',
+      muted: '#F0E0D0', 'muted-foreground': '#8B6050',
+      accent: '#EF4444', 'accent-foreground': '#FFFBF0',
+      destructive: '#b91c1c',
+      border: '#E8D4C0', input: '#FFFDF5', ring: '#EF4444',
+      success: '#16a34a', 'success-muted': 'rgba(22, 163, 74, 0.12)',
+      warning: '#ca8a04', 'warning-muted': 'rgba(202, 138, 4, 0.12)',
+      danger: '#b91c1c', 'danger-muted': 'rgba(185, 28, 28, 0.12)',
+      info: '#EF4444', 'info-muted': 'rgba(239, 68, 68, 0.12)',
+      'chart-1': '#EF4444', 'chart-2': '#8B6050', 'chart-3': '#16a34a', 'chart-4': '#ca8a04', 'chart-5': '#2D1810',
+      ...lightScrollbar('#FFF0E0', '#D8C0A8', '#EF4444'),
+      'vortex-glow': '0 0 20px rgba(239, 68, 68, 0.3)',
+    },
+  },
+  {
+    id: 'winter',
+    name: 'Winter',
+    category: 'nature',
+    isDark: false,
+    colors: {
+      background: '#F0F4F8', foreground: '#0F172A',
+      card: '#F8FAFC', 'card-foreground': '#0F172A',
+      popover: '#F8FAFC', 'popover-foreground': '#0F172A',
+      primary: '#3B82F6', 'primary-foreground': '#F0F4F8',
+      secondary: '#E2E8F0', 'secondary-foreground': '#0F172A',
+      muted: '#CBD5E1', 'muted-foreground': '#475569',
+      accent: '#3B82F6', 'accent-foreground': '#F0F4F8',
+      destructive: '#dc2626',
+      border: '#C0CCD8', input: '#F8FAFC', ring: '#3B82F6',
+      success: '#16a34a', 'success-muted': 'rgba(22, 163, 74, 0.12)',
+      warning: '#ca8a04', 'warning-muted': 'rgba(202, 138, 4, 0.12)',
+      danger: '#dc2626', 'danger-muted': 'rgba(220, 38, 38, 0.12)',
+      info: '#3B82F6', 'info-muted': 'rgba(59, 130, 246, 0.12)',
+      'chart-1': '#3B82F6', 'chart-2': '#475569', 'chart-3': '#16a34a', 'chart-4': '#dc2626', 'chart-5': '#0F172A',
+      ...lightScrollbar('#E2E8F0', '#A0B0C0', '#3B82F6'),
+      'vortex-glow': '0 0 20px rgba(59, 130, 246, 0.3)',
+    },
+  },
+  {
+    id: 'storm',
+    name: 'Storm',
+    category: 'nature',
+    isDark: true,
+    colors: {
+      background: '#1A1A2E', foreground: '#E0E0F0',
+      card: '#22223A', 'card-foreground': '#E0E0F0',
+      popover: '#22223A', 'popover-foreground': '#E0E0F0',
+      primary: '#7C3AED', 'primary-foreground': '#E0E0F0',
+      secondary: '#2A2A42', 'secondary-foreground': '#E0E0F0',
+      muted: '#33334D', 'muted-foreground': '#8888AA',
+      accent: '#7C3AED', 'accent-foreground': '#E0E0F0',
+      destructive: '#ef4444',
+      border: '#33334D', input: '#22223A', ring: '#7C3AED',
+      success: '#22c55e', 'success-muted': 'rgba(34, 197, 94, 0.15)',
+      warning: '#eab308', 'warning-muted': 'rgba(234, 179, 8, 0.15)',
+      danger: '#ef4444', 'danger-muted': 'rgba(239, 68, 68, 0.15)',
+      info: '#7C3AED', 'info-muted': 'rgba(124, 58, 237, 0.15)',
+      'chart-1': '#7C3AED', 'chart-2': '#8888AA', 'chart-3': '#22c55e', 'chart-4': '#ef4444', 'chart-5': '#E0E0F0',
+      ...darkScrollbar('#22223A', '#444466', '#7C3AED'),
+      'vortex-glow': '0 0 30px rgba(124, 58, 237, 0.4)',
+    },
+  },
+  {
+    id: 'forest',
+    name: 'Forest',
+    category: 'nature',
+    isDark: true,
+    colors: {
+      background: '#0D1B0E', foreground: '#D0E8D0',
+      card: '#152418', 'card-foreground': '#D0E8D0',
+      popover: '#152418', 'popover-foreground': '#D0E8D0',
+      primary: '#22C55E', 'primary-foreground': '#0D1B0E',
+      secondary: '#1A2E1C', 'secondary-foreground': '#D0E8D0',
+      muted: '#243828', 'muted-foreground': '#6A9A6E',
+      accent: '#22C55E', 'accent-foreground': '#0D1B0E',
+      destructive: '#ef4444',
+      border: '#2A3E2C', input: '#152418', ring: '#22C55E',
+      success: '#22C55E', 'success-muted': 'rgba(34, 197, 94, 0.15)',
+      warning: '#eab308', 'warning-muted': 'rgba(234, 179, 8, 0.15)',
+      danger: '#ef4444', 'danger-muted': 'rgba(239, 68, 68, 0.15)',
+      info: '#22C55E', 'info-muted': 'rgba(34, 197, 94, 0.15)',
+      'chart-1': '#22C55E', 'chart-2': '#6A9A6E', 'chart-3': '#0891b2', 'chart-4': '#ef4444', 'chart-5': '#D0E8D0',
+      ...darkScrollbar('#152418', '#2E4830', '#22C55E'),
+      'vortex-glow': '0 0 30px rgba(34, 197, 94, 0.4)',
+    },
+  },
+
+  // ─── RETRO ────────────────────────────────────
+  {
+    id: 'retrowave',
+    name: 'Retrowave',
+    category: 'retro',
+    isDark: true,
+    colors: {
+      background: '#2D1B69', foreground: '#F0D0FF',
+      card: '#3A2580', 'card-foreground': '#F0D0FF',
+      popover: '#3A2580', 'popover-foreground': '#F0D0FF',
+      primary: '#FF6B9D', 'primary-foreground': '#2D1B69',
+      secondary: '#3D2888', 'secondary-foreground': '#F0D0FF',
+      muted: '#4A3098', 'muted-foreground': '#B090D0',
+      accent: '#FF6B9D', 'accent-foreground': '#2D1B69',
+      destructive: '#FF4060',
+      border: '#4A3098', input: '#3A2580', ring: '#FF6B9D',
+      success: '#50FA7B', 'success-muted': 'rgba(80, 250, 123, 0.15)',
+      warning: '#FFB86C', 'warning-muted': 'rgba(255, 184, 108, 0.15)',
+      danger: '#FF4060', 'danger-muted': 'rgba(255, 64, 96, 0.15)',
+      info: '#FF6B9D', 'info-muted': 'rgba(255, 107, 157, 0.15)',
+      'chart-1': '#FF6B9D', 'chart-2': '#B090D0', 'chart-3': '#50FA7B', 'chart-4': '#FF4060', 'chart-5': '#F0D0FF',
+      ...darkScrollbar('#3A2580', '#5A40A8', '#FF6B9D'),
+      'vortex-glow': '0 0 30px rgba(255, 107, 157, 0.4)',
+    },
+  },
+  {
+    id: 'synthwave',
+    name: 'Synthwave',
+    category: 'retro',
+    isDark: true,
+    colors: {
+      background: '#0F0A2E', foreground: '#E0D0FF',
+      card: '#1A1240', 'card-foreground': '#E0D0FF',
+      popover: '#1A1240', 'popover-foreground': '#E0D0FF',
+      primary: '#FF00FF', 'primary-foreground': '#0F0A2E',
+      secondary: '#201850', 'secondary-foreground': '#E0D0FF',
+      muted: '#2A2060', 'muted-foreground': '#9080C0',
+      accent: '#FF00FF', 'accent-foreground': '#0F0A2E',
+      destructive: '#FF2060',
+      border: '#2A2060', input: '#1A1240', ring: '#FF00FF',
+      success: '#00FF80', 'success-muted': 'rgba(0, 255, 128, 0.15)',
+      warning: '#FFD700', 'warning-muted': 'rgba(255, 215, 0, 0.15)',
+      danger: '#FF2060', 'danger-muted': 'rgba(255, 32, 96, 0.15)',
+      info: '#FF00FF', 'info-muted': 'rgba(255, 0, 255, 0.15)',
+      'chart-1': '#FF00FF', 'chart-2': '#9080C0', 'chart-3': '#00FF80', 'chart-4': '#FF2060', 'chart-5': '#E0D0FF',
+      ...darkScrollbar('#1A1240', '#3A2870', '#FF00FF'),
+      'vortex-glow': '0 0 30px rgba(255, 0, 255, 0.5)',
+    },
+  },
+  {
+    id: 'vapor',
+    name: 'Vapor',
+    category: 'retro',
+    isDark: false,
+    colors: {
+      background: '#FFE4F0', foreground: '#2A1520',
+      card: '#FFF0F7', 'card-foreground': '#2A1520',
+      popover: '#FFF0F7', 'popover-foreground': '#2A1520',
+      primary: '#14B8A6', 'primary-foreground': '#FFE4F0',
+      secondary: '#F8D0E0', 'secondary-foreground': '#2A1520',
+      muted: '#F0C0D4', 'muted-foreground': '#805068',
+      accent: '#14B8A6', 'accent-foreground': '#FFE4F0',
+      destructive: '#dc2626',
+      border: '#E8B0C8', input: '#FFF0F7', ring: '#14B8A6',
+      success: '#16a34a', 'success-muted': 'rgba(22, 163, 74, 0.12)',
+      warning: '#ca8a04', 'warning-muted': 'rgba(202, 138, 4, 0.12)',
+      danger: '#dc2626', 'danger-muted': 'rgba(220, 38, 38, 0.12)',
+      info: '#14B8A6', 'info-muted': 'rgba(20, 184, 166, 0.12)',
+      'chart-1': '#14B8A6', 'chart-2': '#805068', 'chart-3': '#16a34a', 'chart-4': '#dc2626', 'chart-5': '#2A1520',
+      ...lightScrollbar('#F8D0E0', '#D8A0B8', '#14B8A6'),
+      'vortex-glow': '0 0 20px rgba(20, 184, 166, 0.3)',
+    },
+  },
+
+  // ─── FUTURISTIC ───────────────────────────────
+  {
+    id: 'matrix',
+    name: 'Matrix',
+    category: 'futuristic',
+    isDark: true,
+    colors: {
+      background: '#000000', foreground: '#00FF00',
+      card: '#0A0A0A', 'card-foreground': '#00FF00',
+      popover: '#0A0A0A', 'popover-foreground': '#00FF00',
+      primary: '#00FF00', 'primary-foreground': '#000000',
+      secondary: '#0A1A0A', 'secondary-foreground': '#00FF00',
+      muted: '#102010', 'muted-foreground': '#008800',
+      accent: '#00FF00', 'accent-foreground': '#000000',
+      destructive: '#FF0000',
+      border: '#003300', input: '#0A0A0A', ring: '#00FF00',
+      success: '#00FF00', 'success-muted': 'rgba(0, 255, 0, 0.15)',
+      warning: '#FFFF00', 'warning-muted': 'rgba(255, 255, 0, 0.15)',
+      danger: '#FF0000', 'danger-muted': 'rgba(255, 0, 0, 0.15)',
+      info: '#00FF00', 'info-muted': 'rgba(0, 255, 0, 0.15)',
+      'chart-1': '#00FF00', 'chart-2': '#008800', 'chart-3': '#00FFFF', 'chart-4': '#FF0000', 'chart-5': '#00FF00',
+      ...darkScrollbar('#0A0A0A', '#003300', '#00FF00'),
+      'vortex-glow': '0 0 30px rgba(0, 255, 0, 0.5)',
+    },
+  },
+  {
+    id: 'cyberpunk',
+    name: 'Cyberpunk',
+    category: 'futuristic',
+    isDark: true,
+    colors: {
+      background: '#1A1A1A', foreground: '#E8E8E0',
+      card: '#242424', 'card-foreground': '#E8E8E0',
+      popover: '#242424', 'popover-foreground': '#E8E8E0',
+      primary: '#FACC15', 'primary-foreground': '#1A1A1A',
+      secondary: '#2A2A2A', 'secondary-foreground': '#E8E8E0',
+      muted: '#333333', 'muted-foreground': '#999990',
+      accent: '#FACC15', 'accent-foreground': '#1A1A1A',
+      destructive: '#ef4444',
+      border: '#3A3A3A', input: '#242424', ring: '#FACC15',
+      success: '#22c55e', 'success-muted': 'rgba(34, 197, 94, 0.15)',
+      warning: '#FACC15', 'warning-muted': 'rgba(250, 204, 21, 0.15)',
+      danger: '#ef4444', 'danger-muted': 'rgba(239, 68, 68, 0.15)',
+      info: '#FACC15', 'info-muted': 'rgba(250, 204, 21, 0.15)',
+      'chart-1': '#FACC15', 'chart-2': '#999990', 'chart-3': '#22c55e', 'chart-4': '#ef4444', 'chart-5': '#E8E8E0',
+      ...darkScrollbar('#242424', '#444444', '#FACC15'),
+      'vortex-glow': '0 0 30px rgba(250, 204, 21, 0.4)',
+    },
+  },
+  {
+    id: 'techno',
+    name: 'Techno',
+    category: 'futuristic',
+    isDark: true,
+    colors: {
+      background: '#050510', foreground: '#C0D0F0',
+      card: '#0D0D20', 'card-foreground': '#C0D0F0',
+      popover: '#0D0D20', 'popover-foreground': '#C0D0F0',
+      primary: '#3B82F6', 'primary-foreground': '#050510',
+      secondary: '#10102A', 'secondary-foreground': '#C0D0F0',
+      muted: '#1A1A38', 'muted-foreground': '#6080B0',
+      accent: '#3B82F6', 'accent-foreground': '#050510',
+      destructive: '#ef4444',
+      border: '#1A1A38', input: '#0D0D20', ring: '#3B82F6',
+      success: '#22c55e', 'success-muted': 'rgba(34, 197, 94, 0.15)',
+      warning: '#eab308', 'warning-muted': 'rgba(234, 179, 8, 0.15)',
+      danger: '#ef4444', 'danger-muted': 'rgba(239, 68, 68, 0.15)',
+      info: '#3B82F6', 'info-muted': 'rgba(59, 130, 246, 0.15)',
+      'chart-1': '#3B82F6', 'chart-2': '#6080B0', 'chart-3': '#22c55e', 'chart-4': '#ef4444', 'chart-5': '#C0D0F0',
+      ...darkScrollbar('#0D0D20', '#2A2A50', '#3B82F6'),
+      'vortex-glow': '0 0 30px rgba(59, 130, 246, 0.5)',
+    },
+  },
+  {
+    id: 'hologram',
+    name: 'Hologram',
+    category: 'futuristic',
+    isDark: true,
+    colors: {
+      background: '#0A0A14', foreground: '#C8E0F0',
+      card: '#12121E', 'card-foreground': '#C8E0F0',
+      popover: '#12121E', 'popover-foreground': '#C8E0F0',
+      primary: '#06B6D4', 'primary-foreground': '#0A0A14',
+      secondary: '#161628', 'secondary-foreground': '#C8E0F0',
+      muted: '#1E1E32', 'muted-foreground': '#6890A8',
+      accent: '#06B6D4', 'accent-foreground': '#0A0A14',
+      destructive: '#ef4444',
+      border: '#1E1E32', input: '#12121E', ring: '#06B6D4',
+      success: '#22c55e', 'success-muted': 'rgba(34, 197, 94, 0.15)',
+      warning: '#eab308', 'warning-muted': 'rgba(234, 179, 8, 0.15)',
+      danger: '#ef4444', 'danger-muted': 'rgba(239, 68, 68, 0.15)',
+      info: '#06B6D4', 'info-muted': 'rgba(6, 182, 212, 0.15)',
+      'chart-1': '#06B6D4', 'chart-2': '#6890A8', 'chart-3': '#22c55e', 'chart-4': '#ef4444', 'chart-5': '#C8E0F0',
+      ...darkScrollbar('#12121E', '#2A2A44', '#06B6D4'),
+      'vortex-glow': '0 0 30px rgba(6, 182, 212, 0.5)',
+    },
+  },
+];
+
+export const DEFAULT_THEME = 'swiss-nihilism-dark';
+
+export function getTheme(id: string): ThemeDefinition {
+  return THEMES.find(t => t.id === id) || THEMES.find(t => t.id === DEFAULT_THEME)!;
+}
+
+export function getThemeBackground(id: string): string {
+  return getTheme(id).colors.background;
+}
+
+export function isDarkTheme(id: string): boolean {
+  return getTheme(id).isDark;
+}
+
+/** Apply theme CSS variables to the document root */
+export function applyTheme(id: string): void {
+  const theme = getTheme(id);
+  const root = document.documentElement;
+
+  for (const [key, value] of Object.entries(theme.colors)) {
+    root.style.setProperty(`--${key}`, value);
+  }
+
+  // Toggle .dark class for scrollbar CSS and backward compat
+  root.classList.toggle('dark', theme.isDark);
+}
+
+/** Get the next theme in the list (cycling) */
+export function getNextThemeId(currentId: string): string {
+  const idx = THEMES.findIndex(t => t.id === currentId);
+  return THEMES[(idx + 1) % THEMES.length].id;
+}
+
+/** Get all themes grouped by category */
+export function getThemesByCategory(): Record<string, ThemeDefinition[]> {
+  const grouped: Record<string, ThemeDefinition[]> = {};
+  for (const theme of THEMES) {
+    if (!grouped[theme.category]) grouped[theme.category] = [];
+    grouped[theme.category].push(theme);
+  }
+  return grouped;
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import type { Agent, Task, Project, Skill, Entity, Chat, DashboardStats } from '@/types';
+import { DEFAULT_THEME, isDarkTheme, getNextThemeId } from '@/lib/themes';
 
 // Sample data generators
 const generateId = () => Math.random().toString(36).substring(2, 15);
@@ -219,7 +220,8 @@ interface AppState {
   selectedChat: string | null;
   sidebarCollapsed: boolean;
   mobileMenuOpen: boolean;
-  darkMode: boolean;
+  darkMode: boolean; // computed from theme — backward compat
+  theme: string;
   vaultUnreadCount: number;
 
   // Actions - Agents
@@ -253,6 +255,8 @@ interface AppState {
   toggleMobileMenu: () => void;
   setDarkMode: (dark: boolean) => void;
   toggleDarkMode: () => void;
+  setTheme: (id: string) => void;
+  cycleTheme: () => void;
   setVaultUnreadCount: (count: number) => void;
 
   // Computed
@@ -277,7 +281,8 @@ export const useStore = create<AppState>((set, get) => ({
   selectedChat: null,
   sidebarCollapsed: false,
   mobileMenuOpen: false,
-  darkMode: false,
+  darkMode: true, // computed default — matches DEFAULT_THEME (swiss-nihilism-dark)
+  theme: DEFAULT_THEME,
   vaultUnreadCount: 0,
 
   // Agent Actions
@@ -406,8 +411,18 @@ export const useStore = create<AppState>((set, get) => ({
   toggleSidebar: () => set((state) => ({ sidebarCollapsed: !state.sidebarCollapsed })),
   setMobileMenuOpen: (open) => set({ mobileMenuOpen: open }),
   toggleMobileMenu: () => set((state) => ({ mobileMenuOpen: !state.mobileMenuOpen })),
-  setDarkMode: (dark) => set({ darkMode: dark }),
-  toggleDarkMode: () => set((state) => ({ darkMode: !state.darkMode })),
+  setDarkMode: (dark) => set({ darkMode: dark, theme: dark ? 'swiss-nihilism-dark' : 'swiss-nihilism-light' }),
+  toggleDarkMode: () => set((state) => {
+    const newTheme = state.theme === 'swiss-nihilism-dark' ? 'swiss-nihilism-light'
+      : state.theme === 'swiss-nihilism-light' ? 'swiss-nihilism-dark'
+      : isDarkTheme(state.theme) ? 'swiss-nihilism-light' : 'swiss-nihilism-dark';
+    return { darkMode: isDarkTheme(newTheme), theme: newTheme };
+  }),
+  setTheme: (id) => set({ theme: id, darkMode: isDarkTheme(id) }),
+  cycleTheme: () => set((state) => {
+    const next = getNextThemeId(state.theme);
+    return { theme: next, darkMode: isDarkTheme(next) };
+  }),
   setVaultUnreadCount: (count) => set({ vaultUnreadCount: count }),
 
   // Computed


### PR DESCRIPTION
## Summary
- Replaces boolean `darkMode` with full theme engine supporting 17 themes across 4 categories (Swiss, Nature, Retro, Futuristic)
- New `src/lib/themes.ts` — single source of truth for all theme definitions, applied via CSS custom properties at runtime
- ThemePicker visual grid in Settings > General, with preview swatches per theme
- Keyboard shortcuts: `T` cycles themes, `D` toggles dark/light (backward compat)
- Scrollbar CSS now uses theme-aware variables instead of hardcoded colours

## Test plan
- [ ] Verify 773/773 tests pass
- [ ] Cycle through all 17 themes with T key
- [ ] Verify theme persists across page reloads (localStorage)
- [ ] Check ThemePicker in Settings renders correctly
- [ ] Verify Electron window background syncs with theme
- [ ] Test D key still toggles between light/dark Swiss Nihilism
- [ ] Verify smooth 300ms transition between themes