### PR TITLE
feat: keyboard shortcut toast notifications

### DIFF
--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -10,6 +10,7 @@ import { Menu, X, Download, ExternalLink, RotateCw, Loader2 } from 'lucide-react
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { applyTheme, getTheme, DEFAULT_THEME } from '@/lib/themes';
+import KeyboardToast, { showKeyboardToast } from './KeyboardToast';
 
 function useIsMobile() {
   const [isMobile, setIsMobile] = useState(false);
@@ -216,16 +217,19 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
       if ((e.metaKey || e.ctrlKey) && e.key === ',') {
         e.preventDefault();
         router.push('/settings');
+        showKeyboardToast('\u2318,', 'SETTINGS');
         return;
       }
 
       if (e.metaKey || e.ctrlKey || e.altKey) return;
 
       // Number key navigation
+      const NAV_LABELS = ['ENGINE', 'AGENTS', 'TASKS', 'VAULT', 'SKILLS', 'MODES', 'AUTOMATIONS', 'SCHEDULED', 'USAGE'];
       const num = parseInt(e.key, 10);
       if (num >= 1 && num <= 9 && NAV_ROUTES[num - 1]) {
         e.preventDefault();
         router.push(NAV_ROUTES[num - 1]);
+        showKeyboardToast(e.key, NAV_LABELS[num - 1]);
         return;
       }
 
@@ -233,16 +237,20 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
       if (e.key === 'd' || e.key === 'D') {
         e.preventDefault();
         useStore.getState().toggleDarkMode();
+        const isDark = useStore.getState().darkMode;
+        showKeyboardToast('D', isDark ? 'DARK MODE' : 'LIGHT MODE');
         return;
       }
       if (e.key === 't' || e.key === 'T') {
         e.preventDefault();
         useStore.getState().cycleTheme();
+        showKeyboardToast('T', getTheme(useStore.getState().theme).name.toUpperCase());
         return;
       }
       if (e.key === 'm' || e.key === 'M') {
         e.preventDefault();
         router.push('/memory');
+        showKeyboardToast('M', 'MEMORY');
         return;
       }
     };
@@ -306,6 +314,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
       {/* Command Palette */}
       <CommandPalette />
       <KeyboardShortcutsHelp />
+      <KeyboardToast />
 
       {/* Main Content */}
       <motion.main

--- a/src/components/KeyboardToast.tsx
+++ b/src/components/KeyboardToast.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { motion, AnimatePresence } from 'framer-motion';
+import { useState, useCallback, useEffect } from 'react';
+
+interface ToastMessage {
+  id: number;
+  key: string;
+  label: string;
+}
+
+let toastCounter = 0;
+const listeners = new Set<(msg: ToastMessage) => void>();
+
+/** Show a keyboard shortcut toast from anywhere */
+export function showKeyboardToast(key: string, label: string) {
+  const msg: ToastMessage = { id: ++toastCounter, key, label };
+  listeners.forEach(fn => fn(msg));
+}
+
+export default function KeyboardToast() {
+  const [toast, setToast] = useState<ToastMessage | null>(null);
+
+  const handleToast = useCallback((msg: ToastMessage) => {
+    setToast(msg);
+  }, []);
+
+  useEffect(() => {
+    listeners.add(handleToast);
+    return () => { listeners.delete(handleToast); };
+  }, [handleToast]);
+
+  // Auto-dismiss after 1.5s
+  useEffect(() => {
+    if (!toast) return;
+    const timer = setTimeout(() => setToast(null), 1500);
+    return () => clearTimeout(timer);
+  }, [toast]);
+
+  return (
+    <AnimatePresence>
+      {toast && (
+        <motion.div
+          key={toast.id}
+          initial={{ opacity: 0, y: 8, scale: 0.95 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: -4, scale: 0.98 }}
+          transition={{ duration: 0.15, ease: 'easeOut' }}
+          className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-2 px-4 py-2 bg-[var(--card)] border border-[var(--border)] font-mono text-[10px] tracking-widest text-[var(--foreground)]"
+        >
+          <kbd className="px-1.5 py-0.5 bg-[var(--secondary)] border border-[var(--border)] text-[var(--primary)] font-bold">
+            {toast.key}
+          </kbd>
+          <span className="text-[var(--muted-foreground)]">{toast.label}</span>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}


### PR DESCRIPTION
## Summary
- New `KeyboardToast` component with Swiss Nihilism styling (monospace kbd element, border-based)
- Shows toast on all keyboard shortcuts: 1-9 navigation, D (dark mode), T (theme cycle), M (memory), Cmd+, (settings)
- Auto-dismisses after 1.5s with smooth exit animation via framer-motion
- Event-driven architecture (pub/sub pattern) — `showKeyboardToast()` callable from anywhere

## Test plan
- [ ] Verify 773/773 tests pass
- [ ] Press 1-9 keys and verify toast shows correct page name
- [ ] Press T and verify toast shows theme name
- [ ] Press D and verify toast shows DARK MODE / LIGHT MODE
- [ ] Verify toast auto-dismisses after ~1.5s