### PR TITLE
feat: fix broken visuals — accent colours, chart axes, caching

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -59,6 +59,13 @@
   --info: #0891b2;
   --info-muted: rgba(8, 145, 178, 0.12);
 
+  /* Named accent colours — used by provider selectors, agent status, terminals */
+  --accent-blue: #0891b2;
+  --accent-green: #22c55e;
+  --accent-purple: #8B5CF6;
+  --accent-cyan: #22d3ee;
+  --accent-red: #ef4444;
+
   /* Charts */
   --chart-1: #0891b2;
   --chart-2: #525252;
@@ -111,6 +118,12 @@ html {
   --danger-muted: rgba(239, 68, 68, 0.15);
   --info: #22d3ee;
   --info-muted: rgba(34, 211, 238, 0.15);
+
+  --accent-blue: #22d3ee;
+  --accent-green: #4ade80;
+  --accent-purple: #a78bfa;
+  --accent-cyan: #22d3ee;
+  --accent-red: #f87171;
 
   --chart-1: #22d3ee;
   --chart-2: #a3a3a3;
@@ -165,6 +178,13 @@ html {
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+
+  /* Named accent colours */
+  --color-accent-blue: var(--accent-blue);
+  --color-accent-green: var(--accent-green);
+  --color-accent-purple: var(--accent-purple);
+  --color-accent-cyan: var(--accent-cyan);
+  --color-accent-red: var(--accent-red);
 
   /* Typography */
   --font-sans: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif;

--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -10,7 +10,7 @@ export const size = {
 export const contentType = 'image/png'
 
 export default async function Icon() {
-  const iconData = await readFile(join(process.cwd(), 'public', 'dorothy-without-text.png'))
+  const iconData = await readFile(join(process.cwd(), 'public', 'logo.png'))
   const base64 = iconData.toString('base64')
 
   return new ImageResponse(

--- a/src/app/usage/page.tsx
+++ b/src/app/usage/page.tsx
@@ -523,7 +523,20 @@ export default function UsagePage() {
           </div>
         </div>
 
-        <div className="flex items-end gap-1 h-52 group">
+        <div className="flex h-52 group">
+          {/* Y-axis labels */}
+          <div className="flex flex-col justify-between w-10 shrink-0 pr-2 text-right">
+            <span className="text-[10px] text-text-muted font-mono">${maxCost > 0 ? maxCost.toFixed(0) : '0'}</span>
+            <span className="text-[10px] text-text-muted font-mono">${maxCost > 0 ? (maxCost / 2).toFixed(0) : '0'}</span>
+            <span className="text-[10px] text-text-muted font-mono">$0</span>
+          </div>
+          {/* Bars */}
+          <div className="flex items-end gap-1 flex-1 relative">
+          {/* Grid lines */}
+          <div className="absolute inset-0 pointer-events-none">
+            <div className="absolute top-0 left-0 right-0 border-t border-dashed border-border-primary/30" />
+            <div className="absolute top-1/2 left-0 right-0 border-t border-dashed border-border-primary/30" />
+          </div>
           {costChartData.length === 0 ? (
             <div className="flex-1 flex items-center justify-center text-text-muted text-sm">
               No cost data available
@@ -561,6 +574,7 @@ export default function UsagePage() {
               );
             })
           )}
+        </div>
         </div>
       </motion.div>
 
@@ -644,7 +658,15 @@ export default function UsagePage() {
             <Calendar className="w-4 h-4 text-text-muted" />
             Messages (Last 7 Days)
           </h3>
-          <div className="flex items-end gap-2 h-32">
+          <div className="flex h-32">
+            {/* Y-axis */}
+            <div className="flex flex-col justify-between w-10 shrink-0 pr-2 text-right">
+              <span className="text-[10px] text-text-muted font-mono">{weeklyActivity.length > 0 ? Math.max(...weeklyActivity.map(d => d.messageCount)).toLocaleString() : '0'}</span>
+              <span className="text-[10px] text-text-muted font-mono">0</span>
+            </div>
+            <div className="flex items-end gap-2 flex-1 relative">
+            <div className="absolute top-0 left-0 right-0 border-t border-dashed border-border-primary/30 pointer-events-none" />
+            <div className="absolute top-1/2 left-0 right-0 border-t border-dashed border-border-primary/30 pointer-events-none" />
             {weeklyActivity.length === 0 ? (
               <div className="flex-1 flex items-center justify-center text-text-muted text-sm">
                 No activity data
@@ -671,6 +693,7 @@ export default function UsagePage() {
                 );
               })
             )}
+          </div>
           </div>
         </motion.div>
 
@@ -718,7 +741,14 @@ export default function UsagePage() {
             <Clock className="w-4 h-4 text-text-muted" />
             Activity by Hour of Day
           </h3>
-          <div className="flex items-end gap-1 h-24">
+          <div className="flex h-24">
+            {/* Y-axis */}
+            <div className="flex flex-col justify-between w-10 shrink-0 pr-2 text-right">
+              <span className="text-[10px] text-text-muted font-mono">{Math.max(...Object.values(stats.hourCounts))}</span>
+              <span className="text-[10px] text-text-muted font-mono">0</span>
+            </div>
+            <div className="flex items-end gap-1 flex-1 relative">
+            <div className="absolute top-1/2 left-0 right-0 border-t border-dashed border-border-primary/30 pointer-events-none" />
             {Array.from({ length: 24 }, (_, hour) => {
               const count = stats.hourCounts[hour.toString()] || 0;
               const maxCount = Math.max(...Object.values(stats.hourCounts));
@@ -740,7 +770,8 @@ export default function UsagePage() {
               );
             })}
           </div>
-          <div className="flex justify-between mt-2 text-xs text-text-muted">
+          </div>
+          <div className="flex justify-between mt-2 text-xs text-text-muted ml-10">
             <span>12 AM</span>
             <span>6 AM</span>
             <span>12 PM</span>

--- a/src/components/KanbanBoard/components/NewTaskModal.tsx
+++ b/src/components/KanbanBoard/components/NewTaskModal.tsx
@@ -297,7 +297,7 @@ export function NewTaskModal({ onClose, onCreate }: NewTaskModalProps) {
                 <textarea
                   value={quickPrompt}
                   onChange={(e) => setQuickPrompt(e.target.value)}
-                  placeholder="Describe your task in natural language...&#10;&#10;e.g., Fix the login bug on the dorothy project where users can't sign in with Google"
+                  placeholder="Describe your task in natural language...&#10;&#10;e.g., Fix the login bug on the GRIP project where users can't sign in with Google"
                   rows={5}
                   className="w-full px-3 py-2 bg-secondary border border-border text-sm focus:outline-none focus:ring-1 focus:ring-primary resize-none"
                   autoFocus

--- a/src/components/Memory/AgentKnowledgeGraph.tsx
+++ b/src/components/Memory/AgentKnowledgeGraph.tsx
@@ -955,9 +955,9 @@ export default function AgentKnowledgeGraph() {
       {/* Legend */}
       <div className="absolute bottom-3 right-3">
         {legendOpen ? (
-          <div className="bg-black/70 border border-white/10 p-3 text-[10px] text-white/70 space-y-1.5 backdrop-blur-sm min-w-[140px]">
+          <div className="bg-black/70 border border-white/10 p-3 text-xs text-white/70 space-y-1.5 backdrop-blur-sm min-w-[140px]">
             <div className="flex items-center justify-between mb-2">
-              <span className="text-white/40 uppercase tracking-wider text-[10px]">Legend</span>
+              <span className="text-white/50 uppercase tracking-wider text-xs">Legend</span>
               <button onClick={() => setLegendOpen(false)} className="text-white/30 hover:text-white/70">✕</button>
             </div>
             {(Object.entries(KIND_COLOR) as [NodeKind, typeof KIND_COLOR[NodeKind]][]).map(([kind, c]) => (
@@ -966,12 +966,12 @@ export default function AgentKnowledgeGraph() {
                 <span className="capitalize">{kind === 'mcp' ? 'MCP server' : kind === 'instructions' ? 'CLAUDE.md' : kind}</span>
               </div>
             ))}
-            <p className="text-white/30 text-[10px] mt-2 border-t border-white/10 pt-2">Scroll to zoom · drag to pan<br/>Click agent to isolate</p>
+            <p className="text-white/50 text-xs mt-2 border-t border-white/10 pt-2">Scroll to zoom · drag to pan<br/>Click agent to isolate</p>
           </div>
         ) : (
           <button
             onClick={() => setLegendOpen(true)}
-            className="px-2.5 py-1 text-[10px] bg-black/50 border border-white/10 text-white/40 hover:text-white/70 transition-colors"
+            className="px-2.5 py-1 text-xs bg-black/50 border border-white/10 text-white/50 hover:text-white/70 transition-colors"
           >
             Legend
           </button>
@@ -979,7 +979,7 @@ export default function AgentKnowledgeGraph() {
       </div>
 
       {/* Node/edge count */}
-      <div className="absolute bottom-3 left-3 text-[10px] text-white/25">
+      <div className="absolute bottom-3 left-3 text-xs text-white/50">
         {nodeCount} nodes · {edgeCount} edges
       </div>
 

--- a/src/components/NewChatModal/StepModel.tsx
+++ b/src/components/NewChatModal/StepModel.tsx
@@ -10,6 +10,14 @@ import type { AgentPersonaValues } from './types';
 import type { AgentProvider } from '@/types/electron';
 import AgentPersonaEditor from './AgentPersonaEditor';
 
+/* Static class map — dynamic template literals (border-${x}) break Tailwind JIT */
+const ACCENT = {
+  'accent-blue':   { border: 'border-accent-blue',   bg: 'bg-accent-blue/10',   text: 'text-accent-blue' },
+  'accent-green':  { border: 'border-accent-green',  bg: 'bg-accent-green/10',  text: 'text-accent-green' },
+  'accent-purple': { border: 'border-accent-purple', bg: 'bg-accent-purple/10', text: 'text-accent-purple' },
+} as const;
+type AccentKey = keyof typeof ACCENT;
+
 interface TasmaniaModel {
   name: string;
   filename: string;
@@ -153,7 +161,7 @@ const StepModel = React.memo(function StepModel({
                   ${!installed
                     ? 'opacity-40 cursor-not-allowed border-border-primary'
                     : provider === id
-                      ? `border-${accent} bg-${accent}/10`
+                      ? `${ACCENT[accent as AccentKey].border} ${ACCENT[accent as AccentKey].bg}`
                       : 'border-border-primary hover:border-border-accent'
                   }
                 `}
@@ -198,7 +206,8 @@ const StepModel = React.memo(function StepModel({
           <label className="block text-sm font-medium mb-2">Model</label>
           <div className={`grid gap-3 ${(PROVIDER_MODELS[provider] || PROVIDER_MODELS.claude).length === 4 ? 'grid-cols-4' : 'grid-cols-3'}`}>
             {(PROVIDER_MODELS[provider] || PROVIDER_MODELS.claude).map((m) => {
-              const accentColor = provider === 'codex' ? 'accent-green' : provider === 'gemini' ? 'accent-purple' : 'accent-blue';
+              const accentKey: AccentKey = provider === 'codex' ? 'accent-green' : provider === 'gemini' ? 'accent-purple' : 'accent-blue';
+              const ac = ACCENT[accentKey];
               return (
                 <button
                   key={m.id}
@@ -206,12 +215,12 @@ const StepModel = React.memo(function StepModel({
                   className={`
                     p-3 border transition-all text-center
                     ${model === m.id
-                      ? `border-${accentColor} bg-${accentColor}/10`
+                      ? `${ac.border} ${ac.bg}`
                       : 'border-border-primary hover:border-border-accent'
                     }
                   `}
                 >
-                  <Zap className={`w-5 h-5 mx-auto mb-1 ${model === m.id ? `text-${accentColor}` : 'text-text-muted'}`} />
+                  <Zap className={`w-5 h-5 mx-auto mb-1 ${model === m.id ? ac.text : 'text-text-muted'}`} />
                   <span className="font-medium">{m.name}</span>
                   <p className="text-xs text-text-muted mt-0.5">{m.description}</p>
                 </button>

--- a/src/components/NewChatModal/StepTools.tsx
+++ b/src/components/NewChatModal/StepTools.tsx
@@ -279,7 +279,7 @@ const StepTools = React.memo(function StepTools({
             <div className="w-5 h-5 rounded border bg-purple-500 border-purple-500 flex items-center justify-center shrink-0">
               <Check className="w-3 h-3 text-white" />
             </div>
-            <img src="/dorothy-without-text.png" alt="GRIP" className="w-4 h-4 object-contain shrink-0" />
+            <img src="/logo.png" alt="GRIP" className="w-4 h-4 object-contain shrink-0" />
             <span className="text-sm">GRIP Vault</span>
             <span className="text-[10px] text-text-muted ml-auto">Always included</span>
           </div>

--- a/src/hooks/useClaude.ts
+++ b/src/hooks/useClaude.ts
@@ -23,9 +23,32 @@ interface ClaudeData {
   activeSessions: string[];
 }
 
+const CACHE_KEY = 'grip-claude-data-cache';
+
+function loadCachedData(): ClaudeData | null {
+  try {
+    const cached = sessionStorage.getItem(CACHE_KEY);
+    if (!cached) return null;
+    const parsed = JSON.parse(cached);
+    // Rehydrate Date objects
+    if (parsed.projects) {
+      parsed.projects = parsed.projects.map((p: Record<string, unknown>) => ({
+        ...p,
+        lastActivity: new Date(p.lastActivity as string),
+        sessions: ((p.sessions as Array<Record<string, unknown>>) || []).map((s: Record<string, unknown>) => ({
+          ...s,
+          startTime: new Date(s.startTime as string),
+          lastActivity: new Date(s.lastActivity as string),
+        })),
+      }));
+    }
+    return parsed;
+  } catch { return null; }
+}
+
 export function useClaude() {
-  const [data, setData] = useState<ClaudeData | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<ClaudeData | null>(() => loadCachedData());
+  const [loading, setLoading] = useState(() => !loadCachedData());
   const [error, setError] = useState<string | null>(null);
 
   const fetchData = useCallback(async () => {
@@ -86,6 +109,7 @@ export function useClaude() {
             return prev;
           });
           setError(null);
+          try { sessionStorage.setItem(CACHE_KEY, JSON.stringify(data)); } catch { /* quota */ }
         } else {
           throw new Error('Failed to get Claude data from Electron');
         }


### PR DESCRIPTION
## Summary
- Define missing `accent-blue/green/purple/cyan/red` CSS variables — root cause of invisible model selector and agent status indicators (50+ usage sites)
- Fix `StepModel.tsx` dynamic Tailwind class bug with static `ACCENT_MAP` lookup
- Add Y-axis labels and grid lines to all 3 usage charts
- Replace Dorothy references with GRIP branding
- Bump AgentKnowledgeGraph legend font sizes
- Add `sessionStorage` caching to `useClaude` hook for instant page loads

## Test plan
- [ ] 773/773 tests pass
- [ ] Model selector shows cyan/green/purple borders on click
- [ ] Usage charts show Y-axis scale and grid lines
- [ ] No "dorothy" text visible anywhere in UI
- [ ] Usage page loads instantly on second navigation