### PR TITLE
fix: replace block streaming cursor with sleek thin blink

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -359,6 +359,12 @@ html {
 /* ============================================
    ANIMATIONS — Minimal, respectful
    ============================================ */
+/* Sleek typing cursor blink — thin line, not block */
+@keyframes cursor-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
 @keyframes fade-in {
   from { opacity: 0; }
   to { opacity: 1; }

--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -565,7 +565,7 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
                       </div>
                     )}
                     {msg.streaming && (
-                      <span className="inline-block w-2 h-4 bg-[var(--primary)] animate-pulse ml-0.5" />
+                      <span className="inline-block w-0.5 h-4 bg-[var(--primary)] ml-0.5 animate-[cursor-blink_1s_ease-in-out_infinite]" />
                     )}
                   </div>
                   <div className="flex items-center gap-3 mt-1">


### PR DESCRIPTION
## Summary
- Replaces 8px wide cyan block cursor with 2px thin line
- New `cursor-blink` keyframe: clean opacity toggle at 1s interval
- Matches professional IDE cursor aesthetics

## Test plan
- [ ] 773/773 tests pass
- [ ] Send a message — cursor shows as thin blinking line, not block