### PR TITLE
fix: guard .toUpperCase() against non-string insight sources

### DIFF
--- a/__tests__/components/insights-toUpperCase.test.ts
+++ b/__tests__/components/insights-toUpperCase.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Regression test for: "s.toUpperCase is not a function"
+ *
+ * Root cause: insights.jsonl `source` field can be non-string
+ * (number, null, undefined, object). The Insights page called
+ * .toUpperCase() on raw values without String() coercion.
+ *
+ * Fix: all .toUpperCase() calls go through String() or toStr() helper.
+ */
+
+// Replicate the toStr helper from insights/page.tsx
+const toStr = (v: unknown): string => (typeof v === 'string' ? v : String(v || 'unknown'));
+
+describe('Insights toUpperCase safety', () => {
+  it('handles string source normally', () => {
+    expect(toStr('evo').toUpperCase()).toBe('EVO');
+  });
+
+  it('handles null source', () => {
+    expect(toStr(null).toUpperCase()).toBe('UNKNOWN');
+  });
+
+  it('handles undefined source', () => {
+    expect(toStr(undefined).toUpperCase()).toBe('UNKNOWN');
+  });
+
+  it('handles numeric source', () => {
+    expect(toStr(42).toUpperCase()).toBe('42');
+  });
+
+  it('handles empty string source without throwing', () => {
+    // Empty string is still a string — toStr returns it as-is
+    expect(() => toStr('').toUpperCase()).not.toThrow();
+  });
+
+  it('handles boolean source', () => {
+    expect(toStr(true).toUpperCase()).toBe('TRUE');
+  });
+
+  it('handles object source', () => {
+    const result = toStr({ foo: 'bar' });
+    expect(typeof result).toBe('string');
+    expect(() => result.toUpperCase()).not.toThrow();
+  });
+
+  it('produces unique filter chips from mixed source types', () => {
+    const insights = [
+      { source: 'evo' },
+      { source: null },
+      { source: undefined },
+      { source: 42 },
+      { source: 'skill' },
+      { source: '' },
+    ];
+    const sources = ['all', ...new Set(insights.map(i => toStr(i.source)))];
+    // Should not throw
+    sources.forEach(s => {
+      expect(() => String(s).toUpperCase()).not.toThrow();
+    });
+    // Should contain expected values
+    expect(sources).toContain('all');
+    expect(sources).toContain('evo');
+    expect(sources).toContain('skill');
+    expect(sources).toContain('unknown');
+  });
+});

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -82,8 +82,9 @@ export default function InsightsPage() {
   }, [fetchInsights, data]);
 
   const insights = data?.insights || [];
-  const sources = ['all', ...new Set(insights.map(i => i.source || 'unknown'))];
-  const filtered = filter === 'all' ? insights : insights.filter(i => (i.source || 'unknown') === filter);
+  const toStr = (v: unknown): string => (typeof v === 'string' ? v : String(v || 'unknown'));
+  const sources = ['all', ...new Set(insights.map(i => toStr(i.source)))];
+  const filtered = filter === 'all' ? insights : insights.filter(i => toStr(i.source) === filter);
 
   return (
     <div className="flex flex-col h-[calc(100vh-7rem)] lg:h-[calc(100vh-3rem)] pt-4 lg:pt-6 overflow-hidden">
@@ -178,7 +179,7 @@ export default function InsightsPage() {
                     : 'border-[var(--border)] text-[var(--muted-foreground)] hover:border-[var(--primary)]'
                 }`}
               >
-                {s.toUpperCase()}
+                {String(s).toUpperCase()}
               </button>
             ))}
           </div>
@@ -216,7 +217,7 @@ export default function InsightsPage() {
                         insight.consolidated ? 'text-accent-green border-accent-green/30 bg-accent-green/5' :
                         'text-[var(--muted-foreground)] border-[var(--border)]'
                       }`}>
-                        {(insight.source || 'unknown').toUpperCase()}
+                        {String(insight.source || 'unknown').toUpperCase()}
                       </span>
                       {insight.tags?.slice(0, 3).map(tag => (
                         <span key={tag} className="font-mono text-[8px] tracking-wider text-[var(--muted-foreground)] border border-[var(--border)] px-1 py-0.5">


### PR DESCRIPTION
## Summary
- Fixes `s.toUpperCase is not a function` crash on Insights page
- Root cause: `insights.jsonl` source field can be number/null/object, not just string
- Added `toStr()` helper with `String()` coercion at all 3 `.toUpperCase()` call sites
- 8 regression tests covering null, undefined, number, boolean, object, mixed arrays

## Test plan
- [x] 781/781 tests pass (8 new)
- [ ] Navigate to Insights — no crash, filter chips render