### PR TITLE
fix: replace grip.runCommand with /api/grip/status route

### DIFF
--- a/src/app/api/grip/status/route.ts
+++ b/src/app/api/grip/status/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import { readFile } from 'fs/promises';
+import { homedir } from 'os';
+import { join } from 'path';
+import { readdirSync } from 'fs';
+
+export async function GET() {
+  const home = homedir();
+  const claudeDir = join(home, '.claude');
+
+  // Genome
+  let genome = null;
+  try {
+    const raw = await readFile(join(claudeDir, 'cache', 'genome.json'), 'utf-8');
+    const g = JSON.parse(raw);
+    genome = { generation: g.generation || 0, geneCount: g.genes?.length || 0, fitness: g.fitness || 0 };
+  } catch { /* no genome */ }
+
+  // Active modes
+  let activeModes: string[] = [];
+  try {
+    const raw = await readFile(join(claudeDir, '.active-modes'), 'utf-8');
+    activeModes = raw.trim().split('\n').filter(Boolean);
+  } catch { /* no modes */ }
+
+  // Instance — find first project grip index
+  let instance = null;
+  try {
+    const projectsDir = join(claudeDir, 'projects');
+    const dirs = readdirSync(projectsDir, { withFileTypes: true }).filter(d => d.isDirectory());
+    for (const dir of dirs) {
+      try {
+        const indexPath = join(projectsDir, dir.name, 'grip', 'index.json');
+        const raw = await readFile(indexPath, 'utf-8');
+        const inst = JSON.parse(raw);
+        instance = { sha: (inst.sha || '').slice(0, 8) || '?', gen: inst.generation || 0, messages: inst.messages || 0 };
+        break;
+      } catch { continue; }
+    }
+  } catch { /* no projects */ }
+
+  return NextResponse.json({ genome, activeModes, instance });
+}

--- a/src/app/memory/page.tsx
+++ b/src/app/memory/page.tsx
@@ -648,37 +648,17 @@ function GripStatusPanel() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const load = async () => {
-      try {
-        // Load genome
-        if (window.electronAPI?.grip?.runCommand) {
-          const genomeRaw = await window.electronAPI.grip.runCommand('cat ~/.claude/cache/genome.json 2>/dev/null');
-          if (genomeRaw) {
-            try {
-              const g = JSON.parse(genomeRaw);
-              setGenome({ generation: g.generation || 0, geneCount: g.genes?.length || 0, fitness: g.fitness || 0 });
-            } catch { /* no genome */ }
-          }
-
-          // Load active modes
-          const modesRaw = await window.electronAPI.grip.runCommand('cat ~/.claude/.active-modes 2>/dev/null');
-          if (modesRaw) {
-            setActiveModes(modesRaw.trim().split('\n').filter(Boolean));
-          }
-
-          // Load instance
-          const instanceRaw = await window.electronAPI.grip.runCommand('cat ~/.claude/projects/*/grip/index.json 2>/dev/null | head -1');
-          if (instanceRaw) {
-            try {
-              const inst = JSON.parse(instanceRaw);
-              setInstance({ sha: inst.sha?.slice(0, 8) || '?', gen: inst.generation || 0, messages: inst.messages || 0 });
-            } catch { /* no instance */ }
-          }
+    fetch('/api/grip/status')
+      .then(res => res.ok ? res.json() : null)
+      .then(data => {
+        if (data) {
+          if (data.genome) setGenome(data.genome);
+          if (data.activeModes) setActiveModes(data.activeModes);
+          if (data.instance) setInstance(data.instance);
         }
-      } catch { /* fallback */ }
-      setLoading(false);
-    };
-    load();
+      })
+      .catch(() => { /* fallback */ })
+      .finally(() => setLoading(false));
   }, []);
 
   if (loading) {


### PR DESCRIPTION
Fixes production build: grip.runCommand does not exist in ElectronAPI. New server-side API route reads genome, modes, instance from filesystem.