### PR TITLE
Align upgrade proposal with GRIP architecture and delivery conventions

### DIFF
--- a/docs/proposals/UPGRADE-SPEC.md
+++ b/docs/proposals/UPGRADE-SPEC.md
@@ -1,0 +1,150 @@
+# GRIP Upgrade Spec — Memory Depth + Education Triad
+
+## Overview
+
+Three targeted improvements to increase GRIP's depth without breaking existing workflows:
+
+1. **Memory metadata** — enrich the existing filesystem memory service with scoring fields
+2. **TRIAD-TEACHING mode** — a new mode that applies three-voice synthesis to learning interactions
+3. **CI coverage** — add coverage reporting to the existing `ci.yml` pipeline
+
+All changes are additive. No breaking changes to IPC channels, existing modes, or vault storage.
+
+---
+
+## 1. Memory Metadata Extension
+
+### Current baseline
+
+GRIP memory is filesystem-based markdown files surfaced via five Electron IPC channels:
+
+```
+memory:list-projects
+memory:read-file
+memory:write-file
+memory:create-file
+memory:delete-file
+```
+
+`MemoryFile` carries `name`, `path`, `content`, `modified`. No scoring or classification.
+
+### Proposed addition
+
+Extend `MemoryFile` and `memory-service` to support an optional YAML front matter block:
+
+```yaml
+---
+importance: 8          # 1–10, used to rank retrieval
+confidence: 0.9        # 0–1, how reliable this fact is
+scope: project         # user | project | global
+tags: [architecture, decision]
+source: conversation   # conversation | execution | review | manual
+---
+```
+
+Rules:
+- Field is optional — files without front matter continue to work unchanged
+- `memory:read-file` parses front matter if present and surfaces it as structured fields
+- `memory:write-file` accepts optional metadata object; serialises back to front matter
+- `memory:list-projects` ranking can use `importance` to sort/surface relevant files first
+
+### New IPC channel (additive)
+
+| Channel | Purpose |
+|---------|---------|
+| `memory:search` | Filters files by `scope`, `tags`, importance threshold |
+
+### Retrieval scoring (in `memory-service`)
+
+When `memory:search` is called, score each file:
+
+```
+score = importance × confidence × recency_decay(modified)
+```
+
+Return files sorted by score descending. Scope filter applied first.
+
+### Types to update
+
+`src/types/electron.d.ts` — add optional fields to `MemoryFile`:
+
+```ts
+importance?: number;     // 1–10
+confidence?: number;     // 0–1
+scope?: 'user' | 'project' | 'global';
+tags?: string[];
+source?: 'conversation' | 'execution' | 'review' | 'manual';
+```
+
+---
+
+## 2. TRIAD-TEACHING Mode
+
+### Pattern
+
+Three specialised sub-voices are synthesised into one response before delivery to the user:
+
+| Role | Function | GRIP analogy |
+|------|---------|-------------|
+| EXPLAINER | Clear direct answer, era/domain grounded | λ Local voice |
+| CONTEXTUALIZER | Wider connections, cross-domain patterns | μ Guide voice |
+| CHALLENGER | Probe assumptions, expose what the user hasn't asked | ν Mirror voice |
+
+The compositor blends the three into one natural response. If a question is simple and confidence is high, the compositor can collapse to a single voice.
+
+### Mode entry (add to `grip-modes.ts`)
+
+```ts
+{
+  id: 'triad-teaching',
+  name: 'TRIAD TEACHING',
+  description: 'Multi-voice teaching through Explainer, Contextualizer, and Challenger synthesis',
+  category: 'content',
+  skills: ['pedagogical-patterns', 'curriculum-design', 'research-synthesis'],
+  tokenBudget: 4000,
+},
+```
+
+### Skill definition
+
+A new skill `triad-teaching` defines the prompt scaffolding for each role and the compositor instructions. Follows the existing skill file format used throughout `.agents/skills/`.
+
+### Optional learner profile
+
+Stored in memory as a `scope: user`, `tags: [learner-profile]` file. TRIAD TEACHING reads this at session start and adjusts CHALLENGER depth (shallow for novice, deep for expert).
+
+---
+
+## 3. CI Coverage Reporting
+
+### Current baseline
+
+`ci.yml` runs `npm test` (Vitest). No coverage output is collected or reported.
+
+### Proposed addition
+
+Extend the existing single `test` job — no additional jobs, no path filters:
+
+```yaml
+- name: Run tests with coverage
+  run: npm run test:coverage
+
+- name: Upload coverage
+  uses: codecov/codecov-action@v4
+  with:
+    fail_ci_if_error: false
+```
+
+`test:coverage` already exists in `package.json` (`vitest run --coverage`). One-line step swap + one upload step.
+
+---
+
+## Rollout
+
+| Phase | What ships | Risk |
+|-------|-----------|------|
+| 1 | Memory front matter parsing + `memory:search` IPC channel | Low — additive, no breaking changes |
+| 2 | TRIAD-TEACHING mode entry + skill definition | Low — new mode, no existing code changed |
+| 3 | CI coverage step | Near-zero — extends existing job |
+
+Each phase ships as a standalone PR. No feature flags required given purely additive scope.

--- a/docs/proposals/UPGRADE-TASKS.md
+++ b/docs/proposals/UPGRADE-TASKS.md
@@ -1,0 +1,94 @@
+# GRIP Upgrade Tasks
+
+Three phases tracking delivery of the changes in `UPGRADE-SPEC.md`.
+Each phase ships as one PR. Phases are independent and can be sequenced or parallelised.
+
+---
+
+## Phase 1: Memory Metadata
+
+### 1.1 Types
+
+- [ ] Add optional fields to `MemoryFile` in `src/types/electron.d.ts`:
+  - `importance?: number`
+  - `confidence?: number`
+  - `scope?: 'user' | 'project' | 'global'`
+  - `tags?: string[]`
+  - `source?: 'conversation' | 'execution' | 'review' | 'manual'`
+
+### 1.2 Memory service
+
+- [ ] Add YAML front matter parser to `electron/services/memory-service`
+  - Parse on `readMemoryFileContent` — return metadata fields alongside content
+  - Serialise back to front matter on `writeMemoryFileContent` when metadata is provided
+  - Files without front matter continue to work unchanged
+
+### 1.3 New IPC channel
+
+- [ ] Register `memory:search` handler in `electron/handlers/memory-handlers`
+  - Accept: `{ scope?, tags?, minImportance?, query? }`
+  - Return: files scored by `importance × confidence × recency_decay(modified)`, sorted descending
+
+### 1.4 Tests (add to `__tests__/electron/handlers/memory-handlers.test.ts`)
+
+- [ ] Front matter round-trip: write with metadata → read → fields intact
+- [ ] Files without front matter: read returns `undefined` for metadata fields
+- [ ] `memory:search` filters by scope and tags
+- [ ] `memory:search` returns results sorted by score descending
+
+---
+
+## Phase 2: TRIAD-TEACHING Mode
+
+### 2.1 Mode entry
+
+- [ ] Add to `GRIP_MODES` array in `src/lib/grip-modes.ts`:
+  ```ts
+  {
+    id: 'triad-teaching',
+    name: 'TRIAD TEACHING',
+    description: 'Multi-voice teaching through Explainer, Contextualizer, and Challenger synthesis',
+    category: 'content',
+    skills: ['pedagogical-patterns', 'curriculum-design', 'research-synthesis'],
+    tokenBudget: 4000,
+  }
+  ```
+
+### 2.2 Skill definition
+
+- [ ] Create `.agents/skills/triad-teaching/SKILL.md` with:
+  - EXPLAINER role prompt scaffolding
+  - CONTEXTUALIZER role prompt scaffolding
+  - CHALLENGER role prompt scaffolding
+  - COMPOSITOR merge instructions
+  - Collapse logic (single voice when confidence is high)
+
+### 2.3 Learner profile integration
+
+- [ ] Document the memory file convention: `scope: user`, `tags: [learner-profile]`
+- [ ] Add depth-adjustment logic to the COMPOSITOR section of the skill
+
+### 2.4 Tests
+
+- [ ] Unit test: mode entry present in `GRIP_MODES` with correct fields
+- [ ] Snapshot test: skill file renders expected prompt structure
+
+---
+
+## Phase 3: CI Coverage
+
+### 3.1 Update `ci.yml`
+
+- [ ] Replace `npm test` step with `npm run test:coverage`
+- [ ] Add `codecov/codecov-action@v4` upload step with `fail_ci_if_error: false`
+- [ ] Verify coverage badge renders correctly in README
+
+---
+
+## Definition of Done
+
+| Phase | Gate |
+|-------|------|
+| 1 | All memory-handlers tests pass; no regressions in existing 5-channel tests |
+| 2 | Mode appears in `/modes` page; skill parseable by skill browser |
+| 3 | Coverage report uploads on every CI run; badge live in README |


### PR DESCRIPTION
What this PR does

Adds two proposal docs that translate the Birdhouse-inspired ideas into GRIP-native patterns, so maintainers can review and merge incrementally without architectural mismatch.

Adds an additive upgrade spec focused on:

filesystem-based memory metadata extensions (front matter + search)
a new TRIAD TEACHING mode using existing GripMode patterns
CI coverage reporting in the existing single-job pipeline
Adds a phased task list mapped to GRIP-style execution (checklist + definition-of-done gates)
Files added
docs/proposals/UPGRADE-SPEC.md
docs/proposals/UPGRADE-TASKS.md

Why this shape

This proposal intentionally follows current GRIP practices:

Memory remains markdown/filesystem + Electron IPC (no breaking DB/entity migration)
Education upgrade is expressed as a new mode/skill, not a framework rewrite
CI recommendation extends current ci.yml rather than introducing a complex multi-job matrix
Scope and safety
Additive only; no breaking API/protocol changes proposed
Each phase is independently shippable
No feature flag requirement for proposal phase (implementation can add if maintainers prefer)

Proposed rollout

Phase 1: Memory metadata + additive memory:search
Phase 2: TRIAD TEACHING mode + skill scaffolding
Phase 3: Coverage upload in existing CI job

Request for maintainer review
Please confirm:

Naming and placement of memory:search channel
Preferred location for TRIAD TEACHING skill definition
Whether to keep coverage upload non-blocking (fail_ci_if_error: false) initially

First maintainer comment to post:

Maintainer feedback request on proposal alignment:

I translated the upgrade plan to fit GRIP’s current architecture and conventions (filesystem memory + IPC, GripMode-first expansion, lean CI). Before implementation, could you confirm these three decisions?

Memory extension direction
Keep memory as markdown + optional front matter metadata
Additive IPC channel: memory:search
No breaking changes to existing 5 memory channels
Education triad integration
Ship as a new mode entry (TRIAD TEACHING) and skill definition
No refactor of existing mode framework
CI step change
Extend existing ci.yml test job with npm run test:coverage + Codecov upload
Keep upload non-blocking in first pass
If these are approved, I’ll open implementation PR #1 for Phase 1 only (memory metadata + tests), then sequence Phases 2 and 3 as separate PRs.

