### PR TITLE
feat(ui): wire ModelSelector + ChatHistory to HAL backend

### DIFF
--- a/src/components/Engine/ChatHistory.tsx
+++ b/src/components/Engine/ChatHistory.tsx
@@ -11,6 +11,26 @@ import {
   deleteChatSession,
   type ChatSession,
 } from '@/lib/chat-storage';
+import {
+  isHalBackend,
+  listSessions as halListSessions,
+  createSession as halCreateSession,
+  deleteSession as halDeleteSession,
+  type HalSession,
+} from '@/lib/hal-client';
+
+/** Convert HAL session to ChatSession shape for unified rendering. */
+function halToChatSession(h: HalSession): ChatSession {
+  return {
+    id: h.id,
+    title: h.title,
+    createdAt: new Date(h.created_at * 1000).toISOString(),
+    updatedAt: new Date(h.updated_at * 1000).toISOString(),
+    messageCount: h.message_count,
+    model: h.model,
+    sessionId: h.id,
+  };
+}
 
 interface ChatHistoryProps {
   onSessionChange: (chatId: string) => void;
@@ -27,18 +47,37 @@ export default function ChatHistory({ onSessionChange, onNewChat, currentModel }
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
   const reduceMotion = useReducedMotion();
+  const halActive = isHalBackend();
 
+  // Load sessions from HAL or localStorage
   useEffect(() => {
-    setSessions(getChatSessions());
+    if (halActive) {
+      halListSessions().then(halSessions => {
+        setSessions(halSessions.map(halToChatSession));
+      });
+    } else {
+      setSessions(getChatSessions());
+    }
     setActiveId(getActiveChatId());
-  }, []);
+  }, [halActive]);
 
-  const handleNewChat = () => {
-    const session = createChatSession(currentModel);
-    setSessions(getChatSessions());
-    setActiveId(session.id);
-    setActiveChatId(session.id);
-    onSessionChange(session.id);
+  const handleNewChat = async () => {
+    if (halActive) {
+      const id = await halCreateSession(currentModel);
+      if (id) {
+        setActiveChatId(id);
+        setActiveId(id);
+        onSessionChange(id);
+        const updated = await halListSessions();
+        setSessions(updated.map(halToChatSession));
+      }
+    } else {
+      const session = createChatSession(currentModel);
+      setSessions(getChatSessions());
+      setActiveId(session.id);
+      setActiveChatId(session.id);
+      onSessionChange(session.id);
+    }
   };
 
   const handleSelectChat = (chatId: string) => {
@@ -47,16 +86,29 @@ export default function ChatHistory({ onSessionChange, onNewChat, currentModel }
     onSessionChange(chatId);
   };
 
-  const handleDeleteChat = (e: React.MouseEvent, chatId: string) => {
+  const handleDeleteChat = async (e: React.MouseEvent, chatId: string) => {
     e.stopPropagation();
-    deleteChatSession(chatId);
-    const updated = getChatSessions();
-    setSessions(updated);
-    if (activeId === chatId) {
-      const newActive = updated[0]?.id || null;
-      setActiveId(newActive);
-      if (newActive) onSessionChange(newActive);
-      else onNewChat();
+    if (halActive) {
+      await halDeleteSession(chatId);
+      const updated = await halListSessions();
+      const mapped = updated.map(halToChatSession);
+      setSessions(mapped);
+      if (activeId === chatId) {
+        const newActive = mapped[0]?.id || null;
+        setActiveId(newActive);
+        if (newActive) onSessionChange(newActive);
+        else onNewChat();
+      }
+    } else {
+      deleteChatSession(chatId);
+      const updated = getChatSessions();
+      setSessions(updated);
+      if (activeId === chatId) {
+        const newActive = updated[0]?.id || null;
+        setActiveId(newActive);
+        if (newActive) onSessionChange(newActive);
+        else onNewChat();
+      }
     }
   };
 

--- a/src/components/Engine/ModelSelector.tsx
+++ b/src/components/Engine/ModelSelector.tsx
@@ -3,6 +3,14 @@
 import { useState, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ChevronDown } from 'lucide-react';
+import { isHalBackend } from '@/lib/hal-client';
+
+interface ModelOption {
+  id: string;
+  label: string;
+  description: string;
+  badge: string;
+}
 
 interface ModelSelectorProps {
   value: string;
@@ -10,11 +18,39 @@ interface ModelSelectorProps {
   compact?: boolean;
 }
 
-const MODELS = [
+const CC_MODELS: ModelOption[] = [
   { id: 'sonnet', label: 'SONNET', description: 'Fast, capable', badge: 'DEFAULT' },
   { id: 'opus', label: 'OPUS', description: 'Most capable, slower', badge: 'DEEP' },
   { id: 'haiku', label: 'HAIKU', description: 'Fastest, lightweight', badge: 'QUICK' },
 ];
+
+/** Fetch provider models from HAL backend. Falls back to CC models on error. */
+function useModels(): ModelOption[] {
+  const [models, setModels] = useState<ModelOption[]>(CC_MODELS);
+
+  useEffect(() => {
+    const halUrl = isHalBackend()
+      ? (localStorage.getItem('grip-hal-url') || process.env.NEXT_PUBLIC_HAL_URL)
+      : null;
+    if (!halUrl) return;
+
+    fetch(`${halUrl}/api/providers`)
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        if (!data?.providers) return;
+        const halModels: ModelOption[] = data.providers.map((p: { name: string; type: string; models: string[] }) => ({
+          id: p.models?.[0] ? `${p.name}/${p.models[0]}` : p.name,
+          label: p.name.toUpperCase(),
+          description: p.models?.slice(0, 2).join(', ') || 'auto',
+          badge: p.type === 'local' ? 'PRIVATE' : 'CLOUD',
+        }));
+        if (halModels.length > 0) setModels(halModels);
+      })
+      .catch(() => {}); // Fall back to CC_MODELS silently
+  }, []);
+
+  return models;
+}
 
 /**
  * Model selector for the chat input area.
@@ -22,6 +58,7 @@ const MODELS = [
  */
 export default function ModelSelector({ value, onChange, compact = false }: ModelSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const MODELS = useModels();
   const current = MODELS.find(m => m.id === value) || MODELS[0];
   const containerRef = useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
## Summary
- ModelSelector fetches providers from HAL `/api/providers` via `useModels()` hook (falls back to CC models)
- ChatHistory loads/creates/deletes sessions via HAL `/api/sessions` (falls back to localStorage)
- Both additive — zero changes to non-HAL behaviour

## Test plan
- [ ] TypeScript compilation clean
- [ ] ModelSelector shows HAL providers when `grip-hal-url` set in localStorage
- [ ] ChatHistory lists HAL sessions when HAL backend active
- [ ] Both components work normally when HAL not configured