### PR TITLE
fix: quote hook command paths for spaces in app name

### DIFF
--- a/__tests__/electron/providers/claude-provider.test.ts
+++ b/__tests__/electron/providers/claude-provider.test.ts
@@ -236,6 +236,7 @@ describe('ClaudeProvider', () => {
 
       const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
       expect(settings.hooks.Stop[0].hooks[0].command).toBe(quotedPath);
+      expect(fs.statSync(settingsPath).mtimeMs).toBe(mtimeBefore);
     });
 
     it('escapes single quotes within paths', async () => {
@@ -251,6 +252,8 @@ describe('ClaudeProvider', () => {
 
       const settings = JSON.parse(fs.readFileSync(path.join(claudeDir, 'settings.json'), 'utf-8'));
       const stopHook = settings.hooks.Stop[0].hooks[0].command;
+      expect(stopHook).toMatch(/^'/);
+      expect(stopHook).toMatch(/'$/);
       expect(stopHook).toContain("'\\''");
     });
 

--- a/__tests__/electron/providers/claude-provider.test.ts
+++ b/__tests__/electron/providers/claude-provider.test.ts
@@ -172,6 +172,107 @@ describe('ClaudeProvider', () => {
     });
   });
 
+  describe('configureHooks', () => {
+    it('writes single-quoted command paths to settings.json', async () => {
+      const provider = await getProvider();
+      const hooksDir = path.join(tmpDir, 'GRIP Commander.app', 'hooks');
+      fs.mkdirSync(hooksDir, { recursive: true });
+      fs.writeFileSync(path.join(hooksDir, 'on-stop.sh'), '#!/bin/sh\n');
+
+      const claudeDir = path.join(tmpDir, '.claude');
+      fs.mkdirSync(claudeDir, { recursive: true });
+
+      await provider.configureHooks(hooksDir);
+
+      const settings = JSON.parse(fs.readFileSync(path.join(claudeDir, 'settings.json'), 'utf-8'));
+      const stopHook = settings.hooks.Stop[0].hooks[0].command;
+      expect(stopHook).toMatch(/^'/);
+      expect(stopHook).toMatch(/'$/);
+      expect(stopHook).toContain('GRIP Commander.app');
+    });
+
+    it('updates existing unquoted paths to quoted', async () => {
+      const provider = await getProvider();
+      const hooksDir = path.join(tmpDir, 'GRIP Commander.app', 'hooks');
+      fs.mkdirSync(hooksDir, { recursive: true });
+      fs.writeFileSync(path.join(hooksDir, 'on-stop.sh'), '#!/bin/sh\n');
+
+      const claudeDir = path.join(tmpDir, '.claude');
+      fs.mkdirSync(claudeDir, { recursive: true });
+      const unquotedPath = path.join(hooksDir, 'on-stop.sh');
+      fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify({
+        hooks: {
+          Stop: [{ hooks: [{ type: 'command', command: unquotedPath, timeout: 30 }] }],
+        },
+      }));
+
+      await provider.configureHooks(hooksDir);
+
+      const settings = JSON.parse(fs.readFileSync(path.join(claudeDir, 'settings.json'), 'utf-8'));
+      const stopHook = settings.hooks.Stop[0].hooks[0].command;
+      expect(stopHook).toBe(`'${unquotedPath}'`);
+    });
+
+    it('does not rewrite when paths are already correctly quoted', async () => {
+      const provider = await getProvider();
+      const hooksDir = path.join(tmpDir, 'app', 'hooks');
+      fs.mkdirSync(hooksDir, { recursive: true });
+      fs.writeFileSync(path.join(hooksDir, 'on-stop.sh'), '#!/bin/sh\n');
+
+      const claudeDir = path.join(tmpDir, '.claude');
+      fs.mkdirSync(claudeDir, { recursive: true });
+      const quotedPath = `'${path.join(hooksDir, 'on-stop.sh')}'`;
+      const settingsPath = path.join(claudeDir, 'settings.json');
+      fs.writeFileSync(settingsPath, JSON.stringify({
+        hooks: {
+          Stop: [{ hooks: [{ type: 'command', command: quotedPath, timeout: 30 }] }],
+        },
+      }));
+      const mtimeBefore = fs.statSync(settingsPath).mtimeMs;
+
+      // Small delay so mtime would differ if file is rewritten
+      await new Promise(r => setTimeout(r, 50));
+      await provider.configureHooks(hooksDir);
+
+      const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+      expect(settings.hooks.Stop[0].hooks[0].command).toBe(quotedPath);
+    });
+
+    it('escapes single quotes within paths', async () => {
+      const provider = await getProvider();
+      const hooksDir = path.join(tmpDir, "it's an app", 'hooks');
+      fs.mkdirSync(hooksDir, { recursive: true });
+      fs.writeFileSync(path.join(hooksDir, 'on-stop.sh'), '#!/bin/sh\n');
+
+      const claudeDir = path.join(tmpDir, '.claude');
+      fs.mkdirSync(claudeDir, { recursive: true });
+
+      await provider.configureHooks(hooksDir);
+
+      const settings = JSON.parse(fs.readFileSync(path.join(claudeDir, 'settings.json'), 'utf-8'));
+      const stopHook = settings.hooks.Stop[0].hooks[0].command;
+      expect(stopHook).toContain("'\\''");
+    });
+
+    it('skips hook types whose files do not exist', async () => {
+      const provider = await getProvider();
+      const hooksDir = path.join(tmpDir, 'hooks');
+      fs.mkdirSync(hooksDir, { recursive: true });
+      // Only create on-stop.sh, not the others
+      fs.writeFileSync(path.join(hooksDir, 'on-stop.sh'), '#!/bin/sh\n');
+
+      const claudeDir = path.join(tmpDir, '.claude');
+      fs.mkdirSync(claudeDir, { recursive: true });
+
+      await provider.configureHooks(hooksDir);
+
+      const settings = JSON.parse(fs.readFileSync(path.join(claudeDir, 'settings.json'), 'utf-8'));
+      expect(settings.hooks.Stop).toHaveLength(1);
+      expect(settings.hooks.PostToolUse).toBeUndefined();
+      expect(settings.hooks.SessionStart).toBeUndefined();
+    });
+  });
+
   describe('isMcpServerRegistered', () => {
     it('returns true when server exists in mcp.json with matching path', async () => {
       const provider = await getProvider();

--- a/__tests__/electron/providers/gemini-provider.test.ts
+++ b/__tests__/electron/providers/gemini-provider.test.ts
@@ -214,12 +214,15 @@ describe('GeminiProvider', () => {
           AfterAgent: [{ hooks: [{ type: 'command', command: quotedPath, timeout: 10000 }] }],
         },
       }));
+      const mtimeBefore = fs.statSync(settingsPath).mtimeMs;
 
+      // Small delay so mtime would differ if file is rewritten
       await new Promise(r => setTimeout(r, 50));
       await provider.configureHooks(hooksDir);
 
       const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
       expect(settings.hooks.AfterAgent[0].hooks[0].command).toBe(quotedPath);
+      expect(fs.statSync(settingsPath).mtimeMs).toBe(mtimeBefore);
     });
 
     it('escapes single quotes within paths', async () => {
@@ -236,6 +239,8 @@ describe('GeminiProvider', () => {
 
       const settings = JSON.parse(fs.readFileSync(path.join(geminiDir, 'settings.json'), 'utf-8'));
       const hook = settings.hooks.AfterAgent[0].hooks[0].command;
+      expect(hook).toMatch(/^'/);
+      expect(hook).toMatch(/'$/);
       expect(hook).toContain("'\\''");
     });
 

--- a/__tests__/electron/providers/gemini-provider.test.ts
+++ b/__tests__/electron/providers/gemini-provider.test.ts
@@ -154,6 +154,110 @@ describe('GeminiProvider', () => {
     });
   });
 
+  describe('configureHooks', () => {
+    it('writes single-quoted command paths to settings.json', async () => {
+      const provider = await getProvider();
+      const hooksDir = path.join(tmpDir, 'GRIP Commander.app', 'hooks');
+      const geminiHooksDir = path.join(hooksDir, 'gemini');
+      fs.mkdirSync(geminiHooksDir, { recursive: true });
+      fs.writeFileSync(path.join(geminiHooksDir, 'on-stop.sh'), '#!/bin/sh\n');
+
+      const geminiDir = path.join(tmpDir, '.gemini');
+      fs.mkdirSync(geminiDir, { recursive: true });
+
+      await provider.configureHooks(hooksDir);
+
+      const settings = JSON.parse(fs.readFileSync(path.join(geminiDir, 'settings.json'), 'utf-8'));
+      const hook = settings.hooks.AfterAgent[0].hooks[0].command;
+      expect(hook).toMatch(/^'/);
+      expect(hook).toMatch(/'$/);
+      expect(hook).toContain('GRIP Commander.app');
+      expect(hook).toContain('gemini/on-stop.sh');
+    });
+
+    it('updates existing unquoted paths to quoted', async () => {
+      const provider = await getProvider();
+      const hooksDir = path.join(tmpDir, 'GRIP Commander.app', 'hooks');
+      const geminiHooksDir = path.join(hooksDir, 'gemini');
+      fs.mkdirSync(geminiHooksDir, { recursive: true });
+      fs.writeFileSync(path.join(geminiHooksDir, 'on-stop.sh'), '#!/bin/sh\n');
+
+      const geminiDir = path.join(tmpDir, '.gemini');
+      fs.mkdirSync(geminiDir, { recursive: true });
+      const unquotedPath = path.join(geminiHooksDir, 'on-stop.sh');
+      fs.writeFileSync(path.join(geminiDir, 'settings.json'), JSON.stringify({
+        hooks: {
+          AfterAgent: [{ hooks: [{ type: 'command', command: unquotedPath, timeout: 10000 }] }],
+        },
+      }));
+
+      await provider.configureHooks(hooksDir);
+
+      const settings = JSON.parse(fs.readFileSync(path.join(geminiDir, 'settings.json'), 'utf-8'));
+      const hook = settings.hooks.AfterAgent[0].hooks[0].command;
+      expect(hook).toBe(`'${unquotedPath}'`);
+    });
+
+    it('does not rewrite when paths are already correctly quoted', async () => {
+      const provider = await getProvider();
+      const hooksDir = path.join(tmpDir, 'app', 'hooks');
+      const geminiHooksDir = path.join(hooksDir, 'gemini');
+      fs.mkdirSync(geminiHooksDir, { recursive: true });
+      fs.writeFileSync(path.join(geminiHooksDir, 'on-stop.sh'), '#!/bin/sh\n');
+
+      const geminiDir = path.join(tmpDir, '.gemini');
+      fs.mkdirSync(geminiDir, { recursive: true });
+      const quotedPath = `'${path.join(geminiHooksDir, 'on-stop.sh')}'`;
+      const settingsPath = path.join(geminiDir, 'settings.json');
+      fs.writeFileSync(settingsPath, JSON.stringify({
+        hooks: {
+          AfterAgent: [{ hooks: [{ type: 'command', command: quotedPath, timeout: 10000 }] }],
+        },
+      }));
+
+      await new Promise(r => setTimeout(r, 50));
+      await provider.configureHooks(hooksDir);
+
+      const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+      expect(settings.hooks.AfterAgent[0].hooks[0].command).toBe(quotedPath);
+    });
+
+    it('escapes single quotes within paths', async () => {
+      const provider = await getProvider();
+      const hooksDir = path.join(tmpDir, "it's an app", 'hooks');
+      const geminiHooksDir = path.join(hooksDir, 'gemini');
+      fs.mkdirSync(geminiHooksDir, { recursive: true });
+      fs.writeFileSync(path.join(geminiHooksDir, 'on-stop.sh'), '#!/bin/sh\n');
+
+      const geminiDir = path.join(tmpDir, '.gemini');
+      fs.mkdirSync(geminiDir, { recursive: true });
+
+      await provider.configureHooks(hooksDir);
+
+      const settings = JSON.parse(fs.readFileSync(path.join(geminiDir, 'settings.json'), 'utf-8'));
+      const hook = settings.hooks.AfterAgent[0].hooks[0].command;
+      expect(hook).toContain("'\\''");
+    });
+
+    it('skips hook types whose files do not exist', async () => {
+      const provider = await getProvider();
+      const hooksDir = path.join(tmpDir, 'hooks');
+      const geminiHooksDir = path.join(hooksDir, 'gemini');
+      fs.mkdirSync(geminiHooksDir, { recursive: true });
+      fs.writeFileSync(path.join(geminiHooksDir, 'on-stop.sh'), '#!/bin/sh\n');
+
+      const geminiDir = path.join(tmpDir, '.gemini');
+      fs.mkdirSync(geminiDir, { recursive: true });
+
+      await provider.configureHooks(hooksDir);
+
+      const settings = JSON.parse(fs.readFileSync(path.join(geminiDir, 'settings.json'), 'utf-8'));
+      expect(settings.hooks.AfterAgent).toHaveLength(1);
+      expect(settings.hooks.AfterTool).toBeUndefined();
+      expect(settings.hooks.SessionStart).toBeUndefined();
+    });
+  });
+
   describe('isMcpServerRegistered', () => {
     it('returns true when server exists in settings.json with matching path', async () => {
       const provider = await getProvider();

--- a/__tests__/electron/utils.test.ts
+++ b/__tests__/electron/utils.test.ts
@@ -150,3 +150,34 @@ describe('formatSlackAgentStatus', () => {
   });
 });
 
+describe('posixQuote', () => {
+  // Import directly — no Electron dependency
+  let posixQuote: (raw: string) => string;
+  beforeEach(async () => {
+    const mod = await import('../../electron/utils/shell');
+    posixQuote = mod.posixQuote;
+  });
+
+  it('wraps simple paths in single quotes', () => {
+    expect(posixQuote('/usr/local/bin/hook.sh')).toBe("'/usr/local/bin/hook.sh'");
+  });
+
+  it('preserves spaces within quotes', () => {
+    expect(posixQuote('/Applications/GRIP Commander.app/hooks/on-stop.sh'))
+      .toBe("'/Applications/GRIP Commander.app/hooks/on-stop.sh'");
+  });
+
+  it('escapes embedded single quotes', () => {
+    expect(posixQuote("/tmp/it's a path/hook.sh"))
+      .toBe("'/tmp/it'\\''s a path/hook.sh'");
+  });
+
+  it('handles multiple single quotes', () => {
+    expect(posixQuote("a'b'c")).toBe("'a'\\''b'\\''c'");
+  });
+
+  it('handles empty string', () => {
+    expect(posixQuote('')).toBe("''");
+  });
+});
+

--- a/electron/providers/claude-provider.ts
+++ b/electron/providers/claude-provider.ts
@@ -11,6 +11,7 @@ import type {
   ProviderModel,
   HookConfig,
 } from './cli-provider';
+import { posixQuote } from '../utils/shell';
 
 export class ClaudeProvider implements CLIProvider {
   readonly id = 'claude' as const;
@@ -199,7 +200,7 @@ export class ClaudeProvider implements CLIProvider {
     for (const { type, file, matcher } of hookFiles) {
       const commandPath = path.join(hooksDir, file);
       if (!fs.existsSync(commandPath)) continue;
-      const quotedPath = `'${commandPath.replace(/'/g, "'\\''")}'`;
+      const quotedPath = posixQuote(commandPath);
 
       const existing: HookEntry[] = settings.hooks![type] || [];
       const entryIndex = existing.findIndex((h: HookEntry) =>

--- a/electron/providers/claude-provider.ts
+++ b/electron/providers/claude-provider.ts
@@ -199,6 +199,7 @@ export class ClaudeProvider implements CLIProvider {
     for (const { type, file, matcher } of hookFiles) {
       const commandPath = path.join(hooksDir, file);
       if (!fs.existsSync(commandPath)) continue;
+      const quotedPath = `'${commandPath.replace(/'/g, "'\\''")}'`;
 
       const existing: HookEntry[] = settings.hooks![type] || [];
       const entryIndex = existing.findIndex((h: HookEntry) =>
@@ -208,13 +209,13 @@ export class ClaudeProvider implements CLIProvider {
       if (entryIndex >= 0) {
         const entry: HookEntry = existing[entryIndex];
         const hookIndex = entry.hooks.findIndex((hh: { command?: string }) => hh.command?.includes(file));
-        if (hookIndex >= 0 && entry.hooks[hookIndex].command !== commandPath) {
-          entry.hooks[hookIndex].command = commandPath;
+        if (hookIndex >= 0 && entry.hooks[hookIndex].command !== quotedPath) {
+          entry.hooks[hookIndex].command = quotedPath;
           updated = true;
         }
       } else {
         const hookConfig: { matcher?: string; hooks: Array<{ type: string; command: string; timeout: number }> } = {
-          hooks: [{ type: 'command', command: commandPath, timeout: 30 }]
+          hooks: [{ type: 'command', command: quotedPath, timeout: 30 }]
         };
         if (matcher) hookConfig.matcher = matcher;
         settings.hooks![type] = [...existing, hookConfig];

--- a/electron/providers/gemini-provider.ts
+++ b/electron/providers/gemini-provider.ts
@@ -11,6 +11,7 @@ import type {
   ProviderModel,
   HookConfig,
 } from './cli-provider';
+import { posixQuote } from '../utils/shell';
 
 export class GeminiProvider implements CLIProvider {
   readonly id = 'gemini' as const;
@@ -185,7 +186,7 @@ export class GeminiProvider implements CLIProvider {
     for (const { type, file, matcher } of hookFiles) {
       const commandPath = path.join(geminiHooksDir, file);
       if (!fs.existsSync(commandPath)) continue;
-      const quotedPath = `'${commandPath.replace(/'/g, "'\\''")}'`;
+      const quotedPath = posixQuote(commandPath);
 
       const existing: HookEntry[] = settings.hooks![type] || [];
       const entryIndex = existing.findIndex((h: HookEntry) =>

--- a/electron/providers/gemini-provider.ts
+++ b/electron/providers/gemini-provider.ts
@@ -185,6 +185,7 @@ export class GeminiProvider implements CLIProvider {
     for (const { type, file, matcher } of hookFiles) {
       const commandPath = path.join(geminiHooksDir, file);
       if (!fs.existsSync(commandPath)) continue;
+      const quotedPath = `'${commandPath.replace(/'/g, "'\\''")}'`;
 
       const existing: HookEntry[] = settings.hooks![type] || [];
       const entryIndex = existing.findIndex((h: HookEntry) =>
@@ -194,13 +195,13 @@ export class GeminiProvider implements CLIProvider {
       if (entryIndex >= 0) {
         const entry: HookEntry = existing[entryIndex];
         const hookIndex = entry.hooks.findIndex((hh: { command?: string }) => hh.command?.includes(`gemini/${file}`));
-        if (hookIndex >= 0 && entry.hooks[hookIndex].command !== commandPath) {
-          entry.hooks[hookIndex].command = commandPath;
+        if (hookIndex >= 0 && entry.hooks[hookIndex].command !== quotedPath) {
+          entry.hooks[hookIndex].command = quotedPath;
           updated = true;
         }
       } else {
         const hookConfig: { matcher?: string; hooks: Array<{ type: string; command: string; timeout: number }> } = {
-          hooks: [{ type: 'command', command: commandPath, timeout: 10000 }]
+          hooks: [{ type: 'command', command: quotedPath, timeout: 10000 }]
         };
         if (matcher) hookConfig.matcher = matcher;
         settings.hooks![type] = [...existing, hookConfig];

--- a/electron/utils/shell.ts
+++ b/electron/utils/shell.ts
@@ -1,0 +1,12 @@
+/**
+ * POSIX-safe single-quoting for shell command strings.
+ *
+ * Wraps the input in single quotes and escapes any embedded single quotes
+ * using the standard close-escape-reopen technique: ' -> '\''
+ *
+ * Safe for /bin/sh, bash, and zsh. Neutralises $(), backticks, and all
+ * other shell metacharacters (they are literal inside single quotes).
+ */
+export function posixQuote(raw: string): string {
+  return `'${raw.replace(/'/g, "'\\''")}'`;
+}


### PR DESCRIPTION
## Summary

- Shell-quote hook command paths in `configureHooks()` for both Claude and Gemini providers
- Fixes `/bin/sh` word-splitting on paths containing spaces (e.g. `GRIP Commander.app`)
- Uses existing POSIX quoting pattern (`'path'` with `'\''` for embedded single quotes) already established in `buildInteractiveCommand`
- Keeps unquoted `commandPath` for `fs.existsSync()` filesystem checks; separate `quotedPath` for settings file writes

## Root cause

`hooks-manager.ts:getHooksPath()` returns `/Applications/GRIP Commander.app/Contents/Resources/app.asar.unpacked/hooks`. Both providers wrote this verbatim into `settings.json` as a shell command. When Claude Code or Gemini CLI invokes the hook via `/bin/sh -c "..."`, the space causes word-splitting: `/Applications/GRIP` is treated as the command, `Commander.app/...` as arguments.

## Test plan

- [x] 10 new tests (5 per provider) covering:
  - Paths with spaces produce single-quoted commands
  - Existing unquoted paths get updated to quoted
  - Already-quoted paths are not redundantly rewritten
  - Single quotes within paths are properly escaped (`'\''`)
  - Missing hook files are skipped (no crash)
- [x] All 803 existing tests still pass (2 pre-existing failures in mcp-socialdata unrelated)
- [x] ESLint clean