### PR TITLE
refactor: migrate provider shell quoting to posixQuote utility

### DIFF
--- a/electron/providers/claude-provider.ts
+++ b/electron/providers/claude-provider.ts
@@ -35,16 +35,16 @@ export class ClaudeProvider implements CLIProvider {
   }
 
   buildInteractiveCommand(params: InteractiveCommandParams): string {
-    let command = `'${params.binaryPath.replace(/'/g, "'\\''")}'`;
+    let command = posixQuote(params.binaryPath);
 
     // MCP config
     if (params.mcpConfigPath && fs.existsSync(params.mcpConfigPath)) {
-      command += ` --mcp-config '${params.mcpConfigPath.replace(/'/g, "'\\''")}'`;
+      command += ` --mcp-config ${posixQuote(params.mcpConfigPath)}`;
     }
 
     // System prompt file (Super Agent instructions)
     if (params.systemPromptFile && fs.existsSync(params.systemPromptFile)) {
-      command += ` --append-system-prompt-file '${params.systemPromptFile.replace(/'/g, "'\\''")}'`;
+      command += ` --append-system-prompt-file ${posixQuote(params.systemPromptFile)}`;
     }
 
     // Model
@@ -67,22 +67,20 @@ export class ClaudeProvider implements CLIProvider {
 
     // Secondary project
     if (params.secondaryProjectPath) {
-      const escaped = params.secondaryProjectPath.replace(/'/g, "'\\''");
-      command += ` --add-dir '${escaped}'`;
+      command += ` --add-dir ${posixQuote(params.secondaryProjectPath)}`;
     }
 
     // Obsidian vaults (read-only access)
     if (params.obsidianVaultPaths) {
       for (const vp of params.obsidianVaultPaths) {
         if (fs.existsSync(vp)) {
-          const escaped = vp.replace(/'/g, "'\\''");
-          command += ` --add-dir '${escaped}'`;
+          command += ` --add-dir ${posixQuote(vp)}`;
         }
       }
     }
 
     // GRIP's CLAUDE.md via ~/.grip
-    command += ` --add-dir '${os.homedir()}/.grip'`;
+    command += ` --add-dir ${posixQuote(`${os.homedir()}/.grip`)}`;
 
     // Prompt with skills directive
     let finalPrompt = params.prompt;
@@ -92,8 +90,7 @@ export class ClaudeProvider implements CLIProvider {
     }
 
     if (finalPrompt) {
-      const escaped = finalPrompt.replace(/'/g, "'\\''");
-      command += ` '${escaped}'`;
+      command += ` ${posixQuote(finalPrompt)}`;
     }
 
     return command;
@@ -120,14 +117,13 @@ export class ClaudeProvider implements CLIProvider {
 
     command += ` --add-dir "${os.homedir()}/.grip"`;
 
-    const escaped = params.prompt.replace(/'/g, "'\\''");
-    command += ` -p '${escaped}'`;
+    command += ` -p ${posixQuote(params.prompt)}`;
 
     return command;
   }
 
   buildOneShotCommand(params: OneShotCommandParams): string {
-    let command = `'${params.binaryPath.replace(/'/g, "'\\''")}'`;
+    let command = posixQuote(params.binaryPath);
 
     command += ' -p';
 
@@ -135,8 +131,7 @@ export class ClaudeProvider implements CLIProvider {
       command += ` --model ${params.model}`;
     }
 
-    const escaped = params.prompt.replace(/'/g, "'\\''");
-    command += ` '${escaped}'`;
+    command += ` ${posixQuote(params.prompt)}`;
 
     return command;
   }

--- a/electron/providers/codex-provider.ts
+++ b/electron/providers/codex-provider.ts
@@ -11,6 +11,7 @@ import type {
   ProviderModel,
   HookConfig,
 } from './cli-provider';
+import { posixQuote } from '../utils/shell';
 
 export class CodexProvider implements CLIProvider {
   readonly id = 'codex' as const;
@@ -32,7 +33,7 @@ export class CodexProvider implements CLIProvider {
   }
 
   buildInteractiveCommand(params: InteractiveCommandParams): string {
-    let command = `'${params.binaryPath.replace(/'/g, "'\\''")}'`;
+    let command = posixQuote(params.binaryPath);
 
     // Model
     if (params.model) {
@@ -49,16 +50,14 @@ export class CodexProvider implements CLIProvider {
 
     // Secondary project
     if (params.secondaryProjectPath) {
-      const escaped = params.secondaryProjectPath.replace(/'/g, "'\\''");
-      command += ` --add-dir '${escaped}'`;
+      command += ` --add-dir ${posixQuote(params.secondaryProjectPath)}`;
     }
 
     // Obsidian vaults (read-only access)
     if (params.obsidianVaultPaths) {
       for (const vp of params.obsidianVaultPaths) {
         if (fs.existsSync(vp)) {
-          const escaped = vp.replace(/'/g, "'\\''");
-          command += ` --add-dir '${escaped}'`;
+          command += ` --add-dir ${posixQuote(vp)}`;
         }
       }
     }
@@ -71,8 +70,7 @@ export class CodexProvider implements CLIProvider {
     }
 
     if (finalPrompt) {
-      const escaped = finalPrompt.replace(/'/g, "'\\''");
-      command += ` '${escaped}'`;
+      command += ` ${posixQuote(finalPrompt)}`;
     }
 
     return command;
@@ -89,21 +87,19 @@ export class CodexProvider implements CLIProvider {
       command += ' --json';
     }
 
-    const escaped = params.prompt.replace(/'/g, "'\\''");
-    command += ` exec '${escaped}'`;
+    command += ` exec ${posixQuote(params.prompt)}`;
 
     return command;
   }
 
   buildOneShotCommand(params: OneShotCommandParams): string {
-    let command = `'${params.binaryPath.replace(/'/g, "'\\''")}'`;
+    let command = posixQuote(params.binaryPath);
 
     if (params.model) {
       command += ` --model ${params.model}`;
     }
 
-    const escaped = params.prompt.replace(/'/g, "'\\''");
-    command += ` exec '${escaped}'`;
+    command += ` exec ${posixQuote(params.prompt)}`;
 
     return command;
   }

--- a/electron/providers/gemini-provider.ts
+++ b/electron/providers/gemini-provider.ts
@@ -33,7 +33,7 @@ export class GeminiProvider implements CLIProvider {
   }
 
   buildInteractiveCommand(params: InteractiveCommandParams): string {
-    let command = `'${params.binaryPath.replace(/'/g, "'\\''")}'`;
+    let command = posixQuote(params.binaryPath);
 
     // Model (Gemini uses -m flag)
     if (params.model) {
@@ -52,22 +52,20 @@ export class GeminiProvider implements CLIProvider {
 
     // Secondary project (Gemini uses --include-directories)
     if (params.secondaryProjectPath) {
-      const escaped = params.secondaryProjectPath.replace(/'/g, "'\\''");
-      command += ` --include-directories '${escaped}'`;
+      command += ` --include-directories ${posixQuote(params.secondaryProjectPath)}`;
     }
 
     // Obsidian vaults (read-only access)
     if (params.obsidianVaultPaths) {
       for (const vp of params.obsidianVaultPaths) {
         if (fs.existsSync(vp)) {
-          const escaped = vp.replace(/'/g, "'\\''");
-          command += ` --include-directories '${escaped}'`;
+          command += ` --include-directories ${posixQuote(vp)}`;
         }
       }
     }
 
     // Include GRIP directory
-    command += ` --include-directories '${os.homedir()}/.grip'`;
+    command += ` --include-directories ${posixQuote(`${os.homedir()}/.grip`)}`;
 
     // Prompt with skills directive
     let finalPrompt = params.prompt;
@@ -77,8 +75,7 @@ export class GeminiProvider implements CLIProvider {
     }
 
     if (finalPrompt) {
-      const escaped = finalPrompt.replace(/'/g, "'\\''");
-      command += ` '${escaped}'`;
+      command += ` ${posixQuote(finalPrompt)}`;
     }
 
     return command;
@@ -99,14 +96,13 @@ export class GeminiProvider implements CLIProvider {
 
     command += ` --include-directories "${os.homedir()}/.grip"`;
 
-    const escaped = params.prompt.replace(/'/g, "'\\''");
-    command += ` -p '${escaped}'`;
+    command += ` -p ${posixQuote(params.prompt)}`;
 
     return command;
   }
 
   buildOneShotCommand(params: OneShotCommandParams): string {
-    let command = `'${params.binaryPath.replace(/'/g, "'\\''")}'`;
+    let command = posixQuote(params.binaryPath);
 
     command += ' -p';
 
@@ -114,8 +110,7 @@ export class GeminiProvider implements CLIProvider {
       command += ` -m ${params.model}`;
     }
 
-    const escaped = params.prompt.replace(/'/g, "'\\''");
-    command += ` '${escaped}'`;
+    command += ` ${posixQuote(params.prompt)}`;
 
     return command;
   }


### PR DESCRIPTION
## Summary

- Replace 25 inline `replace(/'/g, "'\\''")` patterns across all 3 provider files with `posixQuote()` from `electron/utils/shell.ts`
- Eliminates intermediate `escaped` variables and duplicate quoting logic
- Net -14 lines (26 added, 40 removed) — cleaner, more readable command building
- Follow-up to PR #87 which introduced the `posixQuote` utility

## Scope

Providers only (claude, gemini, codex). Services and handlers (21 remaining occurrences, some with chained escaping like `.replace(/"/g, ...').replace(/\n/g, ...)`) are a separate follow-up.

## Test plan

- [x] All 808 existing tests pass (including the 15 new tests from PR #87)
- [x] Zero inline quoting patterns remain in `electron/providers/` (verified via grep)
- [x] Existing `buildInteractiveCommand` tests validate the output format is preserved