### PR TITLE
feat(gui): Fleet Commander UI + 21 themes + full HAL API client

### DIFF
--- a/src/components/Fleet/AgentCard.tsx
+++ b/src/components/Fleet/AgentCard.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import type { HalAgent } from '@/lib/hal-client';
+
+interface AgentCardProps {
+  agent: HalAgent;
+}
+
+const STRATEGY_COLORS: Record<string, string> = {
+  fallback: 'var(--info)',
+  sentinel: 'var(--warning)',
+  council: 'var(--primary)',
+  fixed: 'var(--muted-foreground)',
+};
+
+export function AgentCard({ agent }: AgentCardProps) {
+  const stratColor = STRATEGY_COLORS[agent.routing_strategy] ?? 'var(--foreground)';
+  const age = formatAge(agent.created_at);
+
+  return (
+    <div className="bg-[var(--card)] border border-[var(--border)] p-4 card-hover">
+      <div className="flex items-start justify-between mb-2">
+        <h3 className="font-mono font-bold text-sm text-[var(--foreground)]">
+          {agent.name}
+        </h3>
+        <span className="text-xs font-mono text-[var(--muted-foreground)]">
+          v{agent.version}
+        </span>
+      </div>
+
+      <div className="space-y-1 text-xs">
+        <div className="flex justify-between">
+          <span className="text-[var(--muted-foreground)]">MODEL</span>
+          <span className="font-mono text-[var(--foreground)]">
+            {agent.model || 'auto'}
+          </span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-[var(--muted-foreground)]">ROUTING</span>
+          <span className="font-mono" style={{ color: stratColor }}>
+            {agent.routing_strategy.toUpperCase()}
+          </span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-[var(--muted-foreground)]">AGE</span>
+          <span className="font-mono text-[var(--foreground)]">{age}</span>
+        </div>
+      </div>
+
+      <div className="mt-3 pt-2 border-t border-[var(--border)]">
+        <span className="text-[10px] font-mono text-[var(--muted-foreground)] tracking-wider">
+          {agent.agent_id}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function formatAge(timestamp: number): string {
+  const diff = (Date.now() / 1000) - timestamp;
+  if (diff < 60) return `${Math.floor(diff)}s`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h`;
+  return `${Math.floor(diff / 86400)}d`;
+}

--- a/src/components/Fleet/FleetDashboard.tsx
+++ b/src/components/Fleet/FleetDashboard.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { halFleet, halAgents, halTasks, halProviders, type HalFleetSnapshot, type HalAgent, type HalTask, type HalProvider } from '@/lib/hal-client';
+import { AgentCard } from './AgentCard';
+import { ProviderHealthBar } from './ProviderHealthBar';
+
+export function FleetDashboard() {
+  const [fleet, setFleet] = useState<HalFleetSnapshot | null>(null);
+  const [agents, setAgents] = useState<HalAgent[]>([]);
+  const [tasks, setTasks] = useState<HalTask[]>([]);
+  const [providers, setProviders] = useState<HalProvider[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      const [f, a, t, p] = await Promise.all([
+        halFleet(), halAgents(), halTasks(), halProviders(),
+      ]);
+      setFleet(f);
+      setAgents(a);
+      setTasks(t);
+      setProviders(p);
+      setLoading(false);
+    }
+    load();
+    const interval = setInterval(load, 10_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-pulse text-[var(--muted-foreground)] font-mono text-sm tracking-wider">
+          FLEET COMMAND LOADING
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 p-4">
+      {/* Fleet Overview */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <StatCard label="AGENTS" value={fleet?.total_agents ?? 0} />
+        <StatCard label="SESSIONS" value={fleet?.total_sessions ?? 0} />
+        <StatCard label="TASKS DONE" value={fleet?.completed_tasks ?? 0} />
+        <StatCard
+          label="COST"
+          value={`$${(fleet?.total_cost_usd ?? 0).toFixed(4)}`}
+        />
+      </div>
+
+      {/* Provider Health */}
+      <section>
+        <h2 className="grip-label mb-3">PROVIDER HEALTH</h2>
+        <div className="space-y-2">
+          {providers.map((p) => (
+            <ProviderHealthBar key={p.name} provider={p} />
+          ))}
+          {providers.length === 0 && (
+            <p className="text-sm text-[var(--muted-foreground)]">No providers detected</p>
+          )}
+        </div>
+      </section>
+
+      {/* Agents */}
+      <section>
+        <h2 className="grip-label mb-3">FLEET AGENTS</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+          {agents.map((a) => (
+            <AgentCard key={a.agent_id} agent={a} />
+          ))}
+          {agents.length === 0 && (
+            <p className="text-sm text-[var(--muted-foreground)]">No agents defined</p>
+          )}
+        </div>
+      </section>
+
+      {/* Tasks */}
+      <section>
+        <h2 className="grip-label mb-3">BACKGROUND TASKS</h2>
+        <div className="space-y-2">
+          {tasks.map((t) => (
+            <TaskRow key={t.task_id} task={t} />
+          ))}
+          {tasks.length === 0 && (
+            <p className="text-sm text-[var(--muted-foreground)]">No tasks running</p>
+          )}
+        </div>
+      </section>
+
+      {/* Fleet Metrics */}
+      <section>
+        <h2 className="grip-label mb-3">FLEET METRICS</h2>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <StatCard
+            label="ZERO COST"
+            value={`${((fleet?.zero_cost_ratio ?? 0) * 100).toFixed(0)}%`}
+          />
+          <StatCard label="PROVIDERS" value={fleet?.provider_diversity ?? 0} />
+          <StatCard label="COUNCIL" value={fleet?.council_usage ?? 0} />
+          <StatCard label="SENTINEL" value={fleet?.sentinel_interventions ?? 0} />
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="bg-[var(--card)] border border-[var(--border)] p-3">
+      <div className="grip-label text-[var(--muted-foreground)]">{label}</div>
+      <div className="text-xl font-mono font-bold text-[var(--foreground)] mt-1">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function TaskRow({ task }: { task: HalTask }) {
+  const statusColor = {
+    queued: 'var(--muted-foreground)',
+    running: 'var(--warning)',
+    completed: 'var(--success)',
+    failed: 'var(--danger)',
+    cancelled: 'var(--muted-foreground)',
+  }[task.status] ?? 'var(--foreground)';
+
+  return (
+    <div className="flex items-center justify-between bg-[var(--card)] border border-[var(--border)] p-3">
+      <div>
+        <span className="font-mono text-sm">{task.task_id}</span>
+        <span className="mx-2 text-[var(--muted-foreground)]">|</span>
+        <span className="text-sm">{task.description.slice(0, 60)}</span>
+      </div>
+      <div className="flex items-center gap-3">
+        <span className="text-xs font-mono" style={{ color: statusColor }}>
+          {task.status.toUpperCase()}
+        </span>
+        <span className="text-xs text-[var(--muted-foreground)] font-mono">
+          ${task.cost_usd.toFixed(4)}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Fleet/ProviderHealthBar.tsx
+++ b/src/components/Fleet/ProviderHealthBar.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import type { HalProvider } from '@/lib/hal-client';
+
+interface ProviderHealthBarProps {
+  provider: HalProvider;
+}
+
+export function ProviderHealthBar({ provider }: ProviderHealthBarProps) {
+  const integrity = provider.integrity ?? 1.0;
+  const target = provider.target_integrity ?? 1.0;
+  const pct = Math.round(integrity * 100);
+  const isHealthy = provider.healthy;
+
+  const barColor = pct > 80
+    ? 'var(--success)'
+    : pct > 50
+      ? 'var(--warning)'
+      : 'var(--danger)';
+
+  const typeLabel = provider.type === 'local' ? 'LOCAL' : 'CLOUD';
+  const typeColor = provider.type === 'local' ? 'var(--success)' : 'var(--info)';
+
+  return (
+    <div className="flex items-center gap-3 bg-[var(--card)] border border-[var(--border)] p-3">
+      {/* Status dot */}
+      <div
+        className="w-2 h-2 rounded-full flex-shrink-0"
+        style={{ backgroundColor: isHealthy ? 'var(--success)' : 'var(--danger)' }}
+      />
+
+      {/* Provider name + type */}
+      <div className="w-24 flex-shrink-0">
+        <div className="font-mono text-sm font-bold text-[var(--foreground)]">
+          {provider.name}
+        </div>
+        <div className="text-[10px] font-mono tracking-wider" style={{ color: typeColor }}>
+          {typeLabel}
+        </div>
+      </div>
+
+      {/* Integrity bar */}
+      <div className="flex-1">
+        <div className="h-2 bg-[var(--muted)] relative">
+          {/* Target line */}
+          <div
+            className="absolute top-0 bottom-0 w-px bg-[var(--foreground)] opacity-30"
+            style={{ left: `${target * 100}%` }}
+          />
+          {/* Actual bar */}
+          <div
+            className="h-full transition-all duration-500"
+            style={{ width: `${pct}%`, backgroundColor: barColor }}
+          />
+        </div>
+      </div>
+
+      {/* Percentage */}
+      <div className="w-12 text-right font-mono text-sm" style={{ color: barColor }}>
+        {pct}%
+      </div>
+
+      {/* Models count */}
+      <div className="w-16 text-right text-xs text-[var(--muted-foreground)] font-mono">
+        {provider.models?.length ?? 0} models
+      </div>
+    </div>
+  );
+}

--- a/src/components/Fleet/index.ts
+++ b/src/components/Fleet/index.ts
@@ -1,0 +1,3 @@
+export { FleetDashboard } from './FleetDashboard';
+export { AgentCard } from './AgentCard';
+export { ProviderHealthBar } from './ProviderHealthBar';

--- a/src/lib/hal-client.ts
+++ b/src/lib/hal-client.ts
@@ -1,11 +1,12 @@
 /**
- * HAL Client — typed API client for HAL backend session management.
+ * HAL Client — typed API client for HAL backend.
  *
  * When HAL backend is active (NEXT_PUBLIC_HAL_URL or localStorage 'grip-hal-url'),
- * this module provides session CRUD operations that sync with HAL's session registry.
+ * this module provides full HAL API access: sessions, chat (streaming), providers,
+ * Fleet Commander (agents, tasks, fleet snapshot), and health monitoring.
  *
- * Session data flows:
- *   GRIP-GUI sidebar <-> HAL /api/sessions <-> HAL SessionRegistry <-> disk
+ * Data flows:
+ *   GRIP-GUI <-> HAL /api/* <-> HAL registries <-> disk
  */
 
 export interface HalSession {
@@ -75,4 +76,113 @@ export async function deleteSession(sessionId: string): Promise<boolean> {
   if (!url) return false;
   const res = await fetch(`${url}/api/sessions/${sessionId}`, { method: 'DELETE' });
   return res.ok;
+}
+
+// ─── Fleet Commander API ────────────────────────────────────
+
+export interface HalAgent {
+  agent_id: string;
+  name: string;
+  version: number;
+  model: string;
+  routing_strategy: string;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface HalFleetSnapshot {
+  timestamp: number;
+  total_agents: number;
+  total_sessions: number;
+  active_sessions: number;
+  completed_tasks: number;
+  total_cost_usd: number;
+  zero_cost_ratio: number;
+  provider_diversity: number;
+  council_usage: number;
+  sentinel_interventions: number;
+}
+
+export interface HalTask {
+  task_id: string;
+  agent_id: string;
+  description: string;
+  status: string;
+  turns_completed: number;
+  cost_usd: number;
+}
+
+export interface HalProvider {
+  name: string;
+  type: string;
+  healthy: boolean;
+  models: string[];
+  integrity?: number;
+  target_integrity?: number;
+}
+
+export interface HalHealth {
+  status: string;
+  providers: HalProvider[];
+  uptime_s: number;
+}
+
+export async function halProviders(): Promise<HalProvider[]> {
+  const url = getHalUrl();
+  if (!url) return [];
+  const res = await fetch(`${url}/api/providers`);
+  if (!res.ok) return [];
+  const data = await res.json();
+  return data.providers || [];
+}
+
+export async function halFleet(): Promise<HalFleetSnapshot | null> {
+  const url = getHalUrl();
+  if (!url) return null;
+  const res = await fetch(`${url}/api/fleet`);
+  if (!res.ok) return null;
+  return res.json();
+}
+
+export async function halAgents(): Promise<HalAgent[]> {
+  const url = getHalUrl();
+  if (!url) return [];
+  const res = await fetch(`${url}/api/agents`);
+  if (!res.ok) return [];
+  const data = await res.json();
+  return data.agents || [];
+}
+
+export async function halTasks(agentId?: string): Promise<HalTask[]> {
+  const url = getHalUrl();
+  if (!url) return [];
+  const query = agentId ? `?agent_id=${agentId}` : '';
+  const res = await fetch(`${url}/api/tasks${query}`);
+  if (!res.ok) return [];
+  const data = await res.json();
+  return data.tasks || [];
+}
+
+export async function halHealth(): Promise<HalHealth | null> {
+  const url = getHalUrl();
+  if (!url) return null;
+  const res = await fetch(`${url}/api/health`);
+  if (!res.ok) return null;
+  return res.json();
+}
+
+export async function halChat(
+  sessionId: string,
+  message: string,
+  model?: string,
+): Promise<ReadableStream<string> | null> {
+  const url = getHalUrl();
+  if (!url) return null;
+  const res = await fetch(`${url}/api/chat`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ session_id: sessionId, message, model }),
+  });
+  if (!res.ok || !res.body) return null;
+  return res.body.pipeThrough(new TextDecoderStream());
 }

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -1,7 +1,12 @@
 /**
- * GRIP Theme Engine — 17 themes across 4 categories.
+ * GRIP Theme Engine — 21 themes across 4 categories.
  * Single source of truth for all theme data.
  * Applied at runtime via CSS custom properties on <html>.
+ *
+ * Swiss (6): Light, Dark, Neutrality, Optimism, Utopia, Brutalism
+ * Nature (7): Autumn, Summer, Winter, Storm, Forest, Ocean
+ * Retro (4): Retrowave, Synthwave, Vapor, Amber Terminal
+ * Futuristic (4): Matrix, Cyberpunk, Techno, Hologram, Neon
  */
 
 export interface ThemeColors {
@@ -468,6 +473,106 @@ export const THEMES: ThemeDefinition[] = [
       'chart-1': '#06B6D4', 'chart-2': '#6890A8', 'chart-3': '#22c55e', 'chart-4': '#ef4444', 'chart-5': '#C8E0F0',
       ...scrollbarColors('#12121E', '#2A2A44', '#06B6D4'),
       'vortex-glow': '0 0 30px rgba(6, 182, 212, 0.5)',
+    },
+  },
+  // ─── NEW: BRUTALISM (Swiss) ───────────────────
+  {
+    id: 'brutalism',
+    name: 'Brutalism',
+    category: 'swiss',
+    isDark: false,
+    colors: {
+      background: '#9E9E9E', foreground: '#1A1A1A',
+      card: '#B0B0B0', 'card-foreground': '#1A1A1A',
+      popover: '#B0B0B0', 'popover-foreground': '#1A1A1A',
+      primary: '#D32F2F', 'primary-foreground': '#FFFFFF',
+      secondary: '#8A8A8A', 'secondary-foreground': '#1A1A1A',
+      muted: '#7A7A7A', 'muted-foreground': '#3A3A3A',
+      accent: '#D32F2F', 'accent-foreground': '#FFFFFF',
+      destructive: '#B71C1C',
+      border: '#6A6A6A', input: '#A0A0A0', ring: '#D32F2F',
+      success: '#2E7D32', 'success-muted': 'rgba(46, 125, 50, 0.15)',
+      warning: '#F57F17', 'warning-muted': 'rgba(245, 127, 23, 0.15)',
+      danger: '#D32F2F', 'danger-muted': 'rgba(211, 47, 47, 0.15)',
+      info: '#1565C0', 'info-muted': 'rgba(21, 101, 192, 0.15)',
+      'chart-1': '#D32F2F', 'chart-2': '#3A3A3A', 'chart-3': '#2E7D32', 'chart-4': '#F57F17', 'chart-5': '#1A1A1A',
+      ...scrollbarColors('#8A8A8A', '#6A6A6A', '#D32F2F'),
+      'vortex-glow': '0 0 20px rgba(211, 47, 47, 0.3)',
+    },
+  },
+  // ─── NEW: OCEAN (Nature) ─────────────────────
+  {
+    id: 'ocean',
+    name: 'Ocean',
+    category: 'nature',
+    isDark: true,
+    colors: {
+      background: '#0D1B2A', foreground: '#C8E6F0',
+      card: '#1B2838', 'card-foreground': '#C8E6F0',
+      popover: '#1B2838', 'popover-foreground': '#C8E6F0',
+      primary: '#1B998B', 'primary-foreground': '#0D1B2A',
+      secondary: '#15253A', 'secondary-foreground': '#C8E6F0',
+      muted: '#1E3048', 'muted-foreground': '#6A9AB0',
+      accent: '#1B998B', 'accent-foreground': '#0D1B2A',
+      destructive: '#EF5350',
+      border: '#1E3048', input: '#1B2838', ring: '#1B998B',
+      success: '#26A69A', 'success-muted': 'rgba(38, 166, 154, 0.15)',
+      warning: '#FFB74D', 'warning-muted': 'rgba(255, 183, 77, 0.15)',
+      danger: '#EF5350', 'danger-muted': 'rgba(239, 83, 80, 0.15)',
+      info: '#29B6F6', 'info-muted': 'rgba(41, 182, 246, 0.15)',
+      'chart-1': '#1B998B', 'chart-2': '#6A9AB0', 'chart-3': '#26A69A', 'chart-4': '#EF5350', 'chart-5': '#C8E6F0',
+      ...scrollbarColors('#15253A', '#2A4058', '#1B998B'),
+      'vortex-glow': '0 0 25px rgba(27, 153, 139, 0.4)',
+    },
+  },
+  // ─── NEW: AMBER TERMINAL (Retro) ─────────────
+  {
+    id: 'amber-terminal',
+    name: 'Amber Terminal',
+    category: 'retro',
+    isDark: true,
+    colors: {
+      background: '#1A1A00', foreground: '#FFB000',
+      card: '#242400', 'card-foreground': '#FFB000',
+      popover: '#242400', 'popover-foreground': '#FFB000',
+      primary: '#FFB000', 'primary-foreground': '#1A1A00',
+      secondary: '#2A2A08', 'secondary-foreground': '#CC8C00',
+      muted: '#333310', 'muted-foreground': '#8A7020',
+      accent: '#FFB000', 'accent-foreground': '#1A1A00',
+      destructive: '#FF4400',
+      border: '#4A4A10', input: '#242400', ring: '#FFB000',
+      success: '#88CC00', 'success-muted': 'rgba(136, 204, 0, 0.15)',
+      warning: '#FFCC00', 'warning-muted': 'rgba(255, 204, 0, 0.15)',
+      danger: '#FF4400', 'danger-muted': 'rgba(255, 68, 0, 0.15)',
+      info: '#FFB000', 'info-muted': 'rgba(255, 176, 0, 0.15)',
+      'chart-1': '#FFB000', 'chart-2': '#8A7020', 'chart-3': '#88CC00', 'chart-4': '#FF4400', 'chart-5': '#CC8C00',
+      ...scrollbarColors('#242400', '#4A4A10', '#FFB000'),
+      'vortex-glow': '0 0 25px rgba(255, 176, 0, 0.4)',
+    },
+  },
+  // ─── NEW: NEON (Futuristic) ──────────────────
+  {
+    id: 'neon',
+    name: 'Neon',
+    category: 'futuristic',
+    isDark: true,
+    colors: {
+      background: '#000000', foreground: '#E0E0F0',
+      card: '#0A0A12', 'card-foreground': '#E0E0F0',
+      popover: '#0A0A12', 'popover-foreground': '#E0E0F0',
+      primary: '#FF006E', 'primary-foreground': '#000000',
+      secondary: '#0F0F1A', 'secondary-foreground': '#E0E0F0',
+      muted: '#1A1A28', 'muted-foreground': '#7070A0',
+      accent: '#FF006E', 'accent-foreground': '#000000',
+      destructive: '#FF1744',
+      border: '#2A2A3A', input: '#0A0A12', ring: '#FF006E',
+      success: '#00E676', 'success-muted': 'rgba(0, 230, 118, 0.15)',
+      warning: '#FFEA00', 'warning-muted': 'rgba(255, 234, 0, 0.15)',
+      danger: '#FF1744', 'danger-muted': 'rgba(255, 23, 68, 0.15)',
+      info: '#00B0FF', 'info-muted': 'rgba(0, 176, 255, 0.15)',
+      'chart-1': '#FF006E', 'chart-2': '#00B0FF', 'chart-3': '#00E676', 'chart-4': '#FF1744', 'chart-5': '#FFEA00',
+      ...scrollbarColors('#0A0A12', '#2A2A3A', '#FF006E'),
+      'vortex-glow': '0 0 35px rgba(255, 0, 110, 0.5)',
     },
   },
 ];


### PR DESCRIPTION
## Summary

- Fleet Commander dashboard with agent cards, provider health bars, task list, fleet metrics
- HAL API client extended to full Fleet Commander API (streaming chat, providers, fleet, agents, tasks, health)
- 4 new themes: Brutalism, Ocean, Amber Terminal, Neon (17 -> 21 total)

## Test plan

- [ ] Verify all 21 themes in ThemePicker
- [ ] Verify FleetDashboard loads with HAL backend
- [ ] Mobile responsive check on Fleet components

**6 files changed, +504 lines**