### PR TITLE
feat(modes): lift active mode cap from 3 to 5

### DIFF
--- a/src/app/memory/page.tsx
+++ b/src/app/memory/page.tsx
@@ -706,7 +706,7 @@ function GripStatusPanel() {
           <Layers className="w-4 h-4 text-accent-cyan" />
           <span className="font-mono text-xs tracking-widest text-[var(--foreground)]">ACTIVE MODES</span>
           <span className="font-mono text-[10px] text-[var(--primary)] border border-[var(--primary)] px-1.5 py-0.5">
-            {activeModes.length}/3
+            {activeModes.length}/5
           </span>
         </div>
         {activeModes.length > 0 ? (

--- a/src/app/modes/page.tsx
+++ b/src/app/modes/page.tsx
@@ -36,12 +36,13 @@ export default function ModesPage() {
     setSaving(false);
   }, []);
 
+  const MAX_ACTIVE_MODES = 5;
   const toggleMode = useCallback((modeId: string) => {
     setActiveModes(prev => {
       let next: string[];
       if (prev.includes(modeId)) {
         next = prev.filter(m => m !== modeId);
-      } else if (prev.length >= 3) {
+      } else if (prev.length >= MAX_ACTIVE_MODES) {
         next = [...prev.slice(1), modeId];
       } else {
         next = [...prev, modeId];
@@ -65,7 +66,7 @@ export default function ModesPage() {
           Modes
         </h1>
         <p className="text-[var(--muted-foreground)] mt-1">
-          Switch how GRIP thinks. Select up to 3 modes simultaneously.
+          Switch how GRIP thinks. Select up to 5 modes simultaneously.
         </p>
         {activeModes.length > 0 && (
           <div className="flex items-center gap-2 mt-3">
@@ -76,7 +77,7 @@ export default function ModesPage() {
               </span>
             ))}
             <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">
-              ({activeModes.length}/3)
+              ({activeModes.length}/{MAX_ACTIVE_MODES})
             </span>
             {saving && <Loader2 className="w-3 h-3 text-[var(--primary)] animate-spin" />}
             {loaded && !saving && activeModes.length > 0 && (


### PR DESCRIPTION
## Summary

- Mirrors the upstream GRIP core change ([CodeTonight-SA/GRIP PR #2185](https://github.com/CodeTonight-SA/GRIP/pull/2185)) in this Next.js app.
- Lifts the behavioural FIFO cap in `toggleMode()` from 3 to 5 so selecting a 4th/5th mode appends instead of evicting the oldest.
- Updates 3 display sites to match (header copy, active-count badge in modes page, ACTIVE MODES badge in memory page).
- Introduces a named constant `MAX_ACTIVE_MODES = 5` in `src/app/modes/page.tsx` so future changes land in one place.

## Why this was a bug

Pre-PR, the UI silently evicted the oldest mode when a user clicked a 4th. That behaviour was consistent with the old MCP server cap (zod `.max(3)`), so functionally it matched the backend. But V>>'s directive is `we can stack up to 5`, and the upstream GRIP core ([PR #2185](https://github.com/CodeTonight-SA/GRIP/pull/2185)) lifted the MCP server cap to 5. Without this PR, the GUI would evict at 3 while the MCP layer accepted 5.

## Files changed

| File | Change |
|---|---|
| `src/app/modes/page.tsx` | Introduce `MAX_ACTIVE_MODES = 5`; replace `prev.length >= 3` with `prev.length >= MAX_ACTIVE_MODES`; update header copy and active-count badge |
| `src/app/memory/page.tsx` | Update ACTIVE MODES badge denominator `/3` → `/5` |

## Risk

**Low.** Relaxation of an existing constraint. No new code paths.

## Out of scope (follow-up PRs)

- Animation subtle-ification
- Tool output max-3-with-replacement in Engine/ChatInterface
- Sidebar collapse/expand + right-sidebar non-scrollable
- Cmd+K to activate skills / list commands
- Multi-session architecture
- Performance convergence

Each follow-up will be in its own isolated worktree.