### PR TITLE
feat(animations): reduce overblown durations on one-shot entrance motions

### DIFF
--- a/src/components/CanvasView/components/ConnectionLine.tsx
+++ b/src/components/CanvasView/components/ConnectionLine.tsx
@@ -28,7 +28,7 @@ export function ConnectionLine({ from, to, isActive }: ConnectionLineProps) {
         strokeDasharray={isActive ? '0' : '6,4'}
         initial={{ pathLength: 0, opacity: 0 }}
         animate={{ pathLength: 1, opacity: isActive ? 1 : 0.5 }}
-        transition={{ duration: 0.8 }}
+        transition={{ duration: 0.3 }}
       />
       {isActive && (
         <>

--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -484,7 +484,7 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
                   key={prompt.text}
                   initial={{ opacity: 0, y: 8 }}
                   animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: 0.25 + i * 0.05, duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
+                  transition={{ delay: 0.1 + i * 0.03, duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
                   onClick={() => handleSuggestedPrompt(prompt.text)}
                   className="flex items-start gap-3 p-4 border border-[var(--border)] hover:border-[var(--primary)] hover:-translate-y-px transition-all text-left group"
                 >
@@ -500,7 +500,7 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
             <motion.p
               initial={{ opacity: 0 }}
               animate={{ opacity: 0.6 }}
-              transition={{ delay: 0.5, duration: 0.4 }}
+              transition={{ delay: 0.3, duration: 0.3 }}
               className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] mt-8"
             >
               CMD+K FOR COMMANDS | LOCAL GRIP BACKEND | REAL-TIME STREAMING

--- a/src/components/Engine/ContextPanel.tsx
+++ b/src/components/Engine/ContextPanel.tsx
@@ -69,7 +69,7 @@ export default function ContextPanel({
                 className="h-full"
                 initial={reduceMotion ? { width: `${contextUsage}%` } : { width: '0%' }}
                 animate={{ width: `${contextUsage}%` }}
-                transition={{ duration: 0.8, ease: [0.16, 1, 0.3, 1] }}
+                transition={{ duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
                 style={{ backgroundColor: ctxColour }}
               />
             </div>

--- a/src/components/KanbanBoard/components/KanbanCard.tsx
+++ b/src/components/KanbanBoard/components/KanbanCard.tsx
@@ -172,7 +172,7 @@ export function KanbanCard({ task, onEdit, onDelete, onStart, onOpenTerminal, is
               className="h-full bg-green-500"
               initial={{ width: 0 }}
               animate={{ width: `${task.progress}%` }}
-              transition={{ duration: 0.5, ease: 'easeOut' }}
+              transition={{ duration: 0.3, ease: 'easeOut' }}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary

Principled reduction of **entrance** animations only. 5 line changes across 4 files. Repeating-state animations (TypingIndicator bar pulse, ThinkingIndicator concentric rings, DotGrid ambient motion, StatusIndicator loops) are **left untouched** — their tempo encodes UX intent (fast = typing, slow = deep reasoning, breathing = ambient) and reducing them corrupts the visual language.

## Changes

| File | Line | Before | After | Why |
|---|---|---|---|---|
| `ContextPanel.tsx` | 72 | `duration: 0.8` | `0.3` | One-shot context-bar entrance on mount. User wants current % quickly. |
| `ChatInterface.tsx` | 487 | `delay: 0.25 + i * 0.05` | `0.1 + i * 0.03` | Welcome-screen button stagger. Last of 4 buttons now at ~0.22s vs ~0.45s. |
| `ChatInterface.tsx` | 503 | `delay: 0.5, duration: 0.4` | `delay: 0.3, duration: 0.3` | Final Cmd+K hint shouldn't feel late. |
| `KanbanCard.tsx` | 175 | `duration: 0.5` | `0.3` | One-shot progress-fill entrance on render. |
| `ConnectionLine.tsx` | 31 | `duration: 0.8` | `0.3` | One-shot SVG `pathLength` draw on connection appear. |

## Explicitly NOT touched (read before deciding)

- **`Engine/TypingIndicator.tsx`**: `duration: 0.8` is on a `repeat: Infinity` three-bar pulse. Comment says "sharp cyan rectangles pulse in sequence". Intentional responsive tempo.
- **`Engine/ThinkingIndicator.tsx`**: `duration: 2` on `repeat: Infinity` concentric rings. Comment explicitly says _"slower pulse, different colour... to communicate deep reasoning vs text generation"_. Design intent documented inline.
- **`Engine/ChatInterface.tsx` welcome-pulse bars (line 448)**: `duration: 1.6` on `repeat: Infinity`. Ambient decoration, not a blocker.
- **`CanvasView/DotGrid.tsx`**: `4 + Math.random() * 4` ambient motion. Not a mistake — intentional.
- **`CanvasView/StatusIndicator.tsx`**: 1.5s/2s indicator loops (status/rotation). Leave.
- **`app/coffee/page.tsx`**: deliberately dramatic Easter egg. Not core workflow. Leave.

## Principle (for future animation PRs)

> **Only reduce one-shot ENTRANCE animations. Repeating ambient/state animations encode information through their tempo — reducing them corrupts the visual language.**

This is the lesson from a grep-driven approach that initially flagged TypingIndicator and ThinkingIndicator as overblown. Reading the files showed documented design intent in both. Future animation work should follow the same read-first discipline.

## Reduced-motion parity

`useReducedMotion()` is already wired via framer-motion upstream. Users with \`prefers-reduced-motion: reduce\` get instant renders regardless of this PR.

## Out of scope (follow-up worktrees)

- Tool output max-3-with-replacement
- Sidebar collapse/expand + right-sidebar non-scrollable
- Cmd+K skills activation
- Multi-session architecture
- Performance convergence