### PR TITLE
feat(chat): cap visible tool calls at 3, collapse older to +N marker

### DIFF
--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -552,10 +552,19 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
                     {msg.gates && msg.gates.length > 0 && (
                       <GateIndicator gates={msg.gates} />
                     )}
-                    {/* Tool use blocks — show what the agent is doing */}
+                    {/* Tool use blocks — show at most the last 3 so the stream
+                        stays scannable; older calls collapse to a "+N earlier"
+                        marker above them. Full history is still stored on
+                        msg.toolUses and can be revisited later if we add an
+                        "expand all" affordance. */}
                     {msg.toolUses && msg.toolUses.length > 0 && (
                       <div className="mt-2 space-y-0.5">
-                        {msg.toolUses.map((tu, i) => (
+                        {msg.toolUses.length > 3 && (
+                          <div className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] opacity-60 px-1 py-0.5">
+                            +{msg.toolUses.length - 3} earlier tool call{msg.toolUses.length - 3 === 1 ? '' : 's'}
+                          </div>
+                        )}
+                        {msg.toolUses.slice(-3).map((tu, i) => (
                           <ToolUseBlock
                             key={tu.toolId || i}
                             toolUse={tu}


### PR DESCRIPTION
## Summary

V>>'s directive: *"Do not show all tool outputs under each other, replace, show max 3."*

During a long streaming response, an assistant can emit dozens of tool_use events (Read, Grep, Bash, Edit, ...) and the current rendering stacks all of them vertically. By the time the 20th tool fires, the chat view is entirely tool blocks and the user has lost the textual response above them.

## Change

One block in `src/components/Engine/ChatInterface.tsx` (~line 555) gains:

1. A `msg.toolUses.length > 3` gate that renders a compact marker **above** the visible blocks:
   ```
   +N earlier tool call(s)
   ```
2. A `.slice(-3)` on the map so only the last 3 tool-use blocks render.

**Full history is preserved** on `msg.toolUses` state — nothing is discarded. The cap is purely a rendering concern so a future "expand all" affordance can reveal the lot.

## Marker design

- Singular/plural aware (`tool call` vs `tool calls`)
- Swiss Nihilism tokens: `font-mono tracking-widest opacity-60`
- `text-[10px]` — feels like a breadcrumb, not a block
- Sits immediately above the visible group (not below) so the collapse cue is contextualised

## Behaviour

| `msg.toolUses.length` | Marker shown | Visible blocks |
|---|---|---|
| 0 | — | 0 |
| 1 | — | 1 |
| 3 | — | 3 |
| 4 | `+1 earlier tool call` | last 3 |
| 12 | `+9 earlier tool calls` | last 3 |

## Not changed

- `tool_use` / `tool_result` event handlers (state accumulates unchanged)
- `persistStreamContent` / `saveChatMessages` (storage unchanged)
- Historical messages rendered from chat storage apply the same cap — consistent between live and replay views

## Risk

**Low.** Pure view concern. `.slice(-3)` on an empty array returns empty; no crash. Singular/plural ternary is pure. The marker is skipped entirely when `length <= 3`, so the short-message case is byte-identical to before.

## Out of scope (follow-up worktrees)

- Sidebar collapse/expand + right-sidebar non-scrollable
- Cmd+K skills activation + command list
- Separate shortcut for stacked modes
- Multi-session architecture
- Performance convergence
- "Expand all" affordance on the marker (future)