### PR TITLE
feat(sidebar): Cmd+B toggle, localStorage persistence, fix nested scroll

### DIFF
--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -190,6 +190,33 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
     }
   }, [isMobile, mobileMenuOpen, setMobileMenuOpen]);
 
+  // Persist sidebarCollapsed to localStorage (survives reload / app restart).
+  // Single source of truth lives in the zustand store; this effect just syncs it.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = window.localStorage.getItem('grip.sidebarCollapsed');
+      if (stored !== null) {
+        const parsed = stored === 'true';
+        if (parsed !== useStore.getState().sidebarCollapsed) {
+          useStore.setState({ sidebarCollapsed: parsed });
+        }
+      }
+    } catch {
+      // localStorage unavailable (SSR, privacy mode) — ignore, use in-memory default
+    }
+    const unsub = useStore.subscribe((state, prev) => {
+      if (state.sidebarCollapsed !== prev.sidebarCollapsed) {
+        try {
+          window.localStorage.setItem('grip.sidebarCollapsed', String(state.sidebarCollapsed));
+        } catch {
+          // ignore write failures
+        }
+      }
+    });
+    return unsub;
+  }, []);
+
   const mainMarginLeft = isMobile ? 0 : (sidebarCollapsed ? 72 : 240);
 
   // Page transitions
@@ -219,6 +246,15 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
         e.preventDefault();
         router.push('/settings');
         showKeyboardToast('\u2318,', 'SETTINGS');
+        return;
+      }
+
+      // Cmd+B = toggle sidebar (VS Code convention) — must be before modifier guard
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'b' || e.key === 'B')) {
+        e.preventDefault();
+        useStore.getState().toggleSidebar();
+        const collapsed = useStore.getState().sidebarCollapsed;
+        showKeyboardToast('\u2318B', collapsed ? 'SIDEBAR COLLAPSED' : 'SIDEBAR EXPANDED');
         return;
       }
 

--- a/src/components/KeyboardShortcutsHelp.tsx
+++ b/src/components/KeyboardShortcutsHelp.tsx
@@ -14,6 +14,7 @@ const SHORTCUTS = [
   ]},
   { category: 'COMMANDS', items: [
     { keys: ['Cmd', 'K'], description: 'Command Palette' },
+    { keys: ['Cmd', 'B'], description: 'Toggle Sidebar' },
     { keys: ['Cmd', 'Shift', 'F'], description: 'Focus Mode' },
     { keys: ['Cmd', ','], description: 'Settings' },
     { keys: ['D'], description: 'Toggle Dark Mode' },

--- a/src/components/TerminalsView/components/SidebarSkillsPalette.tsx
+++ b/src/components/TerminalsView/components/SidebarSkillsPalette.tsx
@@ -56,8 +56,8 @@ export default function SidebarSkillsPalette({ installedSkills }: SidebarSkillsP
         </div>
       </div>
 
-      {/* Skills list */}
-      <div className="flex-1 overflow-y-auto">
+      {/* Skills list — no nested overflow; parent panel owns the scroll container */}
+      <div className="flex-1">
         {installedSkills.length > 0 && (
           <p className="px-2.5 py-1 text-[10px] text-muted-foreground">
             Drag a skill onto a terminal to use it


### PR DESCRIPTION
## Summary

- **Cmd+B toggles the main sidebar** — VS Code convention, wired in `ClientLayout` keydown handler next to the existing `Cmd+,` pattern (before the modifier guard), shows a `KeyboardToast` with the new state.
- **`sidebarCollapsed` persists across reloads** via `localStorage['grip.sidebarCollapsed']` — the store stays the single source of truth; a subscription effect in `ClientLayout` hydrates on mount and writes on change. Wrapped in `try/catch` so SSR and browsers that throw on storage access fall back to the in-memory default.
- **Right-sidebar (TerminalsView panel) no longer double-scrolls** — removed the nested `overflow-y-auto` from `SidebarSkillsPalette`. The parent `Sidebar` panel already owns one scroll container, so the Skills tab was inheriting its own second scrollbar while Agents and Projects did not. All three tabs now share the same "same as left sidebar" single-scroll model.
- **`KeyboardShortcutsHelp`** documents the new `Cmd+B` binding in the COMMANDS category.

## Why

W6 of the GRIP Commander UI RSI sprint. Left sidebar already had collapse/expand wired up in the store and in `Sidebar.tsx`, but:

1. No keyboard shortcut — mouse-only via the chevron button at the bottom.
2. State reset on every reload, so collapsing felt lossy.
3. The right panel (TerminalsView Sidebar) had nested `overflow-y-auto`, producing inconsistent wheel-capture behaviour across its three tabs.

Clarification captured during planning: "non-scrollable right sidebar" = match the left sidebar's single-scroll-container model, not hard-clip the content.

## Diff

```
src/components/ClientLayout.tsx                                  | 36 ++++++++++++++++++++++
src/components/KeyboardShortcutsHelp.tsx                         |  1 +
src/components/TerminalsView/components/SidebarSkillsPalette.tsx |  4 +--
3 files changed, 39 insertions(+), 2 deletions(-)
```

Well under the 200 LOC hypothesis budget (H038).

## Test plan

- [ ] Press \`Cmd+B\` on the main GRIP Commander window — sidebar toggles, toast displays \`⌘B SIDEBAR COLLAPSED\` or \`SIDEBAR EXPANDED\`.
- [ ] Press \`Cmd+B\` inside an input field — does NOT toggle (input-field guard).
- [ ] Collapse the sidebar, reload the app — stays collapsed.
- [ ] Expand the sidebar, reload the app — stays expanded.
- [ ] Open the TerminalsView right panel, switch between Agents / Skills / Projects tabs — all three scroll (when content overflows) via the same single outer scroll container; no double-scroll regions; no scrollbar inside scrollbar.
- [ ] Press \`?\` — keyboard shortcuts overlay shows \`Cmd + B — Toggle Sidebar\` in COMMANDS.
- [ ] Disable JS localStorage (privacy mode) — app still runs, sidebar defaults to expanded, no console errors.

## Pre-existing issues (Rule 19 acknowledgement)

Not introduced by this PR, confirmed failing on main before this branch:

- \`__tests__/electron/handlers/vault-handlers.test.ts\` — 11+ TS errors around \`vi.fn<() => never[]>\` inference vs concrete mock return types. Logged as follow-up task.

## Hypothesis

H038 (registered 2026-04-15): "W6 sidebar polish ships in under 200 LOC across 4 files with no regressions to keyboard nav, scroll behaviour, or theme cycling."

Result so far: **39 insertions / 2 deletions across 3 files** — well under budget. Regression verification pending manual test plan above.