### PR TITLE
feat(palette): commands category, full skill search, Cmd+Shift+M stacked modes

### DIFF
--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -258,6 +258,18 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
         return;
       }
 
+      // Cmd+Shift+M = stacked mode picker — opens the command palette pre-filtered
+      // to MODES. Uses a window event so the palette stays stateless and we don't
+      // have to lift palette open-state into the layout.
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === 'm' || e.key === 'M')) {
+        e.preventDefault();
+        window.dispatchEvent(new CustomEvent('grip:open-palette', {
+          detail: { presetFilter: 'MODES' },
+        }));
+        showKeyboardToast('\u2318\u21E7M', 'STACKED MODES');
+        return;
+      }
+
       if (e.metaKey || e.ctrlKey || e.altKey) return;
 
       // Number key navigation

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -4,18 +4,27 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { Search } from 'lucide-react';
 import { GRIP_MODES } from '@/lib/grip-modes';
 import { GRIP_SKILLS, searchSkills } from '@/lib/grip-skills';
+import { GRIP_COMMANDS } from '@/lib/grip-commands';
 import { useRouter } from 'next/navigation';
+
+type Category = 'RECENT' | 'NAVIGATE' | 'COMMANDS' | 'MODES' | 'PARAMOUNT' | 'SKILLS' | 'ACTIONS' | 'HIDDEN';
 
 interface CommandItem {
   id: string;
   label: string;
   description: string;
-  category: string;
+  category: Category;
   action: () => void;
 }
 
 const RECENT_KEY = 'grip-command-palette-recent';
 const MAX_RECENT = 5;
+const OPEN_EVENT = 'grip:open-palette';
+
+interface OpenPaletteDetail {
+  presetFilter?: Category;
+  query?: string;
+}
 
 function getRecentCommands(): string[] {
   try {
@@ -24,100 +33,188 @@ function getRecentCommands(): string[] {
 }
 
 function saveRecentCommand(id: string): void {
-  const recent = getRecentCommands().filter(r => r !== id);
-  recent.unshift(id);
-  localStorage.setItem(RECENT_KEY, JSON.stringify(recent.slice(0, MAX_RECENT)));
+  try {
+    const recent = getRecentCommands().filter(r => r !== id);
+    recent.unshift(id);
+    localStorage.setItem(RECENT_KEY, JSON.stringify(recent.slice(0, MAX_RECENT)));
+  } catch { /* privacy mode — ignore */ }
+}
+
+/**
+ * Dispatch a window-level intent event. Listeners choose what "activation" means:
+ * today they are unwired (no-op after the palette closes), but the contract lets
+ * future chat/terminal subsystems pick up skills and commands without touching
+ * the palette itself.
+ */
+function dispatchIntent(type: 'grip:activate-skill' | 'grip:run-command', id: string) {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(type, { detail: { id } }));
 }
 
 export default function CommandPalette() {
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [presetFilter, setPresetFilter] = useState<Category | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
 
-  // Build command list
-  const commands: CommandItem[] = [
-    // Navigation
+  // Navigation commands — routing to top-level pages
+  const navigationCommands: CommandItem[] = [
     { id: 'nav-engine', label: 'Engine', description: 'Open chat interface', category: 'NAVIGATE', action: () => router.push('/') },
     { id: 'nav-agents', label: 'Agents', description: 'Manage agent pool', category: 'NAVIGATE', action: () => router.push('/agents') },
     { id: 'nav-tasks', label: 'Tasks', description: 'Kanban task board', category: 'NAVIGATE', action: () => router.push('/kanban') },
     { id: 'nav-vault', label: 'Vault', description: 'Document storage', category: 'NAVIGATE', action: () => router.push('/vault') },
-    { id: 'nav-skills', label: 'Skills', description: 'Browse 149 skills', category: 'NAVIGATE', action: () => router.push('/skills') },
+    { id: 'nav-skills', label: 'Skills', description: `Browse ${GRIP_SKILLS.length} skills`, category: 'NAVIGATE', action: () => router.push('/skills') },
     { id: 'nav-modes', label: 'Modes', description: 'Switch operating mode', category: 'NAVIGATE', action: () => router.push('/modes') },
     { id: 'nav-learn', label: 'Learn', description: 'Understanding GRIP', category: 'NAVIGATE', action: () => router.push('/learn') },
     { id: 'nav-settings', label: 'Settings', description: 'Configuration', category: 'NAVIGATE', action: () => router.push('/settings') },
+  ];
 
-    // Modes
-    ...GRIP_MODES.map(mode => ({
-      id: `mode-${mode.id}`,
-      label: `/mode ${mode.id}`,
-      description: mode.description,
-      category: 'MODES',
-      action: () => { router.push('/modes'); },
-    })),
+  // Slash commands — dispatch a run intent and land on the engine view so the
+  // operator is one keystroke away from typing the command into a terminal
+  const slashCommands: CommandItem[] = GRIP_COMMANDS.map(cmd => ({
+    id: `cmd-${cmd.id}`,
+    label: cmd.name,
+    description: cmd.description,
+    category: 'COMMANDS' as Category,
+    action: () => {
+      dispatchIntent('grip:run-command', cmd.id);
+      router.push('/');
+    },
+  }));
 
-    // Top skills
-    ...GRIP_SKILLS.slice(0, 20).map(skill => ({
-      id: `skill-${skill.id}`,
-      label: skill.name,
-      description: skill.description,
-      category: skill.paramount ? 'PARAMOUNT' : 'SKILLS',
-      action: () => { router.push('/skills'); },
-    })),
+  // Modes — click toggles active set via /api/grip/modes
+  const modeCommands: CommandItem[] = GRIP_MODES.map(mode => ({
+    id: `mode-${mode.id}`,
+    label: `/mode ${mode.id}`,
+    description: mode.description,
+    category: 'MODES',
+    action: () => {
+      void toggleModeViaApi(mode.id);
+    },
+  }));
 
-    // Actions
+  // Skills — narrow to top-20 when there's no query so the palette isn't
+  // dominated by 149 rows, but use the full registry via searchSkills() when
+  // the user actually types something
+  const skillSource = query ? searchSkills(query) : GRIP_SKILLS.slice(0, 20);
+  const skillCommands: CommandItem[] = skillSource.map(skill => ({
+    id: `skill-${skill.id}`,
+    label: skill.name,
+    description: skill.description,
+    category: skill.paramount ? 'PARAMOUNT' : 'SKILLS',
+    action: () => {
+      dispatchIntent('grip:activate-skill', skill.id);
+      router.push(`/skills?highlight=${encodeURIComponent(skill.id)}`);
+    },
+  }));
+
+  const actionCommands: CommandItem[] = [
     { id: 'action-new-chat', label: 'New Chat', description: 'Start a fresh conversation', category: 'ACTIONS', action: () => router.push('/') },
     { id: 'action-dark-mode', label: 'Toggle Dark Mode', description: 'Switch between light and dark', category: 'ACTIONS', action: () => {
       document.documentElement.classList.toggle('dark');
     }},
+  ];
 
-    // Hidden: only appears when searching "vortex"
+  const hiddenCommands: CommandItem[] = [
     { id: 'easter-vortex', label: 'Vortex', description: 'Enter the knowledge double helix', category: 'HIDDEN', action: () => router.push('/vortex') },
   ];
 
-  // Recently used commands (shown when no query)
+  const allCommands: CommandItem[] = [
+    ...navigationCommands,
+    ...slashCommands,
+    ...modeCommands,
+    ...skillCommands,
+    ...actionCommands,
+    ...hiddenCommands,
+  ];
+
+  // Recently used commands (shown when no query and no preset filter)
   const recentIds = getRecentCommands();
   const recentCommands = recentIds
-    .map(id => commands.find(c => c.id === id))
+    .map(id => allCommands.find(c => c.id === id))
     .filter((c): c is CommandItem => c != null)
-    .map(c => ({ ...c, category: 'RECENT' }));
+    .map(c => ({ ...c, category: 'RECENT' as Category }));
 
-  // Filter commands
-  const filtered = query
-    ? commands.filter(cmd =>
-        cmd.label.toLowerCase().includes(query.toLowerCase()) ||
-        cmd.description.toLowerCase().includes(query.toLowerCase())
-      )
-    : [
-        ...recentCommands,
-        ...commands.filter(cmd => cmd.category === 'NAVIGATE' || cmd.category === 'ACTIONS')
-          .filter(cmd => cmd.category !== 'HIDDEN'),
-      ];
+  // Filtering strategy:
+  // - With a preset filter → strictly restrict to that category (Cmd+Shift+M → MODES)
+  // - With a query → fuzzy match label + description across everything
+  // - Idle → recents + navigation + actions (plus a few top commands as discoverability)
+  let filtered: CommandItem[];
+  if (presetFilter) {
+    filtered = allCommands.filter(cmd => cmd.category === presetFilter);
+    if (query) {
+      const q = query.toLowerCase();
+      filtered = filtered.filter(cmd =>
+        cmd.label.toLowerCase().includes(q) ||
+        cmd.description.toLowerCase().includes(q),
+      );
+    }
+  } else if (query) {
+    const q = query.toLowerCase();
+    filtered = allCommands.filter(cmd =>
+      cmd.category !== 'HIDDEN' || cmd.label.toLowerCase().includes(q),
+    ).filter(cmd =>
+      cmd.label.toLowerCase().includes(q) ||
+      cmd.description.toLowerCase().includes(q),
+    );
+  } else {
+    const topCommandIds = new Set(['cmd-save', 'cmd-recall', 'cmd-converge', 'cmd-broly', 'cmd-create-pr', 'cmd-shipit']);
+    filtered = [
+      ...recentCommands,
+      ...navigationCommands,
+      ...slashCommands.filter(c => topCommandIds.has(c.id)),
+      ...actionCommands,
+    ];
+  }
 
-  // Group by category
+  // Group by category — preserve insertion order across categories
   const grouped = filtered.reduce<Record<string, CommandItem[]>>((acc, cmd) => {
     if (!acc[cmd.category]) acc[cmd.category] = [];
     acc[cmd.category].push(cmd);
     return acc;
   }, {});
 
-  // Keyboard shortcut to open
+  const openWith = useCallback((detail: OpenPaletteDetail) => {
+    setIsOpen(true);
+    setPresetFilter(detail.presetFilter ?? null);
+    setQuery(detail.query ?? '');
+    setSelectedIndex(0);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setPresetFilter(null);
+    setQuery('');
+  }, []);
+
+  // Keyboard + window-event bindings
   useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
+    const keyHandler = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
         e.preventDefault();
-        setIsOpen(prev => !prev);
-        setQuery('');
-        setSelectedIndex(0);
+        if (isOpen) {
+          close();
+        } else {
+          openWith({});
+        }
       }
       if (e.key === 'Escape' && isOpen) {
-        setIsOpen(false);
+        close();
       }
     };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [isOpen]);
+    const openHandler = (e: Event) => {
+      const detail = (e as CustomEvent<OpenPaletteDetail>).detail ?? {};
+      openWith(detail);
+    };
+    window.addEventListener('keydown', keyHandler);
+    window.addEventListener(OPEN_EVENT, openHandler as EventListener);
+    return () => {
+      window.removeEventListener('keydown', keyHandler);
+      window.removeEventListener(OPEN_EVENT, openHandler as EventListener);
+    };
+  }, [isOpen, openWith, close]);
 
   // Focus input when opened
   useEffect(() => {
@@ -126,7 +223,7 @@ export default function CommandPalette() {
     }
   }, [isOpen]);
 
-  // Keyboard navigation
+  // Keyboard navigation inside the palette
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'ArrowDown') {
       e.preventDefault();
@@ -136,24 +233,30 @@ export default function CommandPalette() {
       setSelectedIndex(prev => Math.max(prev - 1, 0));
     } else if (e.key === 'Enter') {
       e.preventDefault();
-      if (filtered[selectedIndex]) {
-        saveRecentCommand(filtered[selectedIndex].id);
-        filtered[selectedIndex].action();
-        setIsOpen(false);
+      const selected = filtered[selectedIndex];
+      if (selected) {
+        saveRecentCommand(selected.id);
+        selected.action();
+        // For MODES preset we keep the palette open so the operator can stack
+        // multiple modes in a single session without re-invoking Cmd+Shift+M
+        if (presetFilter !== 'MODES') close();
       }
     }
-  }, [filtered, selectedIndex]);
+  }, [filtered, selectedIndex, presetFilter, close]);
 
   if (!isOpen) return null;
 
   let flatIndex = 0;
+  const placeholder = presetFilter === 'MODES'
+    ? 'Stack modes — press Enter to toggle, Esc when done...'
+    : 'Search commands, skills, modes...';
 
   return (
     <div className="fixed inset-0 z-[200]">
       {/* Backdrop */}
       <div
         className="absolute inset-0 bg-black/40"
-        onClick={() => setIsOpen(false)}
+        onClick={close}
       />
 
       {/* Palette */}
@@ -167,15 +270,20 @@ export default function CommandPalette() {
             value={query}
             onChange={(e) => { setQuery(e.target.value); setSelectedIndex(0); }}
             onKeyDown={handleKeyDown}
-            placeholder="Search commands, skills, modes..."
+            placeholder={placeholder}
             className="flex-1 bg-transparent border-none text-sm text-[var(--foreground)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-0 focus:border-none"
             style={{ boxShadow: 'none' }}
           />
+          {presetFilter && (
+            <span className="font-mono text-[10px] tracking-widest text-[var(--primary)] border border-[var(--primary)] px-1.5 py-0.5">
+              {presetFilter}
+            </span>
+          )}
           <span className="font-mono text-[10px] text-[var(--muted-foreground)] border border-[var(--border)] px-1.5 py-0.5">
             ESC
           </span>
           <span className="font-mono text-[10px] text-[var(--muted-foreground)] opacity-50">
-            ⌘K
+            {presetFilter === 'MODES' ? '⌘⇧M' : '⌘K'}
           </span>
         </div>
 
@@ -193,7 +301,11 @@ export default function CommandPalette() {
                 return (
                   <button
                     key={item.id}
-                    onClick={() => { saveRecentCommand(item.id); item.action(); setIsOpen(false); }}
+                    onClick={() => {
+                      saveRecentCommand(item.id);
+                      item.action();
+                      if (presetFilter !== 'MODES') close();
+                    }}
                     className={`w-full flex items-center justify-between px-4 py-2.5 text-left transition-colors ${
                       currentIndex === selectedIndex
                         ? 'bg-[var(--primary)]/10 text-[var(--foreground)]'
@@ -227,4 +339,34 @@ export default function CommandPalette() {
       </div>
     </div>
   );
+}
+
+/**
+ * Toggle an active mode via the existing /api/grip/modes endpoint without
+ * depending on the modes page being mounted. Keeps the palette stateless —
+ * the next GET from the modes page reflects the new selection.
+ */
+async function toggleModeViaApi(modeId: string): Promise<void> {
+  try {
+    const current: string[] = await fetch('/api/grip/modes')
+      .then(res => res.json())
+      .then(data => Array.isArray(data.modes) ? data.modes : [])
+      .catch(() => []);
+    const MAX_ACTIVE_MODES = 5;
+    let next: string[];
+    if (current.includes(modeId)) {
+      next = current.filter(m => m !== modeId);
+    } else if (current.length >= MAX_ACTIVE_MODES) {
+      next = [...current.slice(1), modeId];
+    } else {
+      next = [...current, modeId];
+    }
+    await fetch('/api/grip/modes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ modes: next }),
+    });
+  } catch {
+    // silent — matches the page's existing "silent fail" posture
+  }
 }

--- a/src/components/KeyboardShortcutsHelp.tsx
+++ b/src/components/KeyboardShortcutsHelp.tsx
@@ -15,6 +15,7 @@ const SHORTCUTS = [
   { category: 'COMMANDS', items: [
     { keys: ['Cmd', 'K'], description: 'Command Palette' },
     { keys: ['Cmd', 'B'], description: 'Toggle Sidebar' },
+    { keys: ['Cmd', 'Shift', 'M'], description: 'Stacked Modes' },
     { keys: ['Cmd', 'Shift', 'F'], description: 'Focus Mode' },
     { keys: ['Cmd', ','], description: 'Settings' },
     { keys: ['D'], description: 'Toggle Dark Mode' },

--- a/src/lib/grip-commands.ts
+++ b/src/lib/grip-commands.ts
@@ -1,0 +1,93 @@
+export interface GripCommand {
+  id: string;
+  name: string;
+  description: string;
+  category: CommandCategory;
+}
+
+export type CommandCategory =
+  | 'workflow'
+  | 'code'
+  | 'session'
+  | 'research'
+  | 'system'
+  | 'meta';
+
+export const COMMAND_CATEGORIES: Record<CommandCategory, { label: string }> = {
+  workflow: { label: 'WORKFLOW' },
+  code: { label: 'CODE' },
+  session: { label: 'SESSION' },
+  research: { label: 'RESEARCH' },
+  system: { label: 'SYSTEM' },
+  meta: { label: 'META / RSI' },
+};
+
+export const GRIP_COMMANDS: GripCommand[] = [
+  // Workflow — the core RSI + converge loop
+  { id: 'save', name: '/save', description: 'Persist session state across memory subsystems', category: 'workflow' },
+  { id: 'recall', name: '/recall', description: 'One-shot recall of all GRIP memory subsystems', category: 'workflow' },
+  { id: 'converge', name: '/converge', description: 'Single-wave recursive convergence on a goal', category: 'workflow' },
+  { id: 'rsi', name: '/rsi', description: 'Recursive self-improvement sprint', category: 'workflow' },
+  { id: 'auto-rsi', name: '/auto-rsi', description: 'Fire-and-forget autonomous RSI sprint', category: 'workflow' },
+  { id: 'broly', name: '/broly', description: 'Multi-framework reasoning meta-agent', category: 'workflow' },
+  { id: 'broly-auto', name: '/broly-auto', description: 'Autonomous broly council execution', category: 'workflow' },
+  { id: 'focus', name: '/focus', description: 'Kanban session tracking with checklists', category: 'workflow' },
+  { id: 'steer', name: '/steer', description: 'Queue steering items during active loops', category: 'workflow' },
+
+  // Code — shipping and review
+  { id: 'create-pr', name: '/create-pr', description: 'Branch + commit + push + PR in one command', category: 'code' },
+  { id: 'shipit', name: '/shipit', description: 'Batch commit-push-PR workflow', category: 'code' },
+  { id: 'gitops', name: '/gitops', description: 'Trunk-based git workflow automation', category: 'code' },
+  { id: 'feature-complete', name: '/feature-complete', description: '7-phase feature development with design principles', category: 'code' },
+  { id: 'ui-complete', name: '/ui-complete', description: 'Mobile-first responsive UI with anti-slop aesthetics', category: 'code' },
+  { id: 'figma', name: '/figma', description: 'Translate Figma designs into production code', category: 'code' },
+  { id: 'generate-e2e-tests', name: '/generate-e2e-tests', description: 'Playwright + Vitest + MSW test scaffolding', category: 'code' },
+  { id: 'prune-branches', name: '/prune-branches', description: 'Clean up merged local + remote branches', category: 'code' },
+
+  // Session — lifecycle and mode
+  { id: 'activate-grip', name: '/activate-grip', description: 'Identity and onboarding wizard', category: 'session' },
+  { id: 'onboard', name: '/onboard', description: 'Deploy GRIP to a new project', category: 'session' },
+  { id: 'mode', name: '/mode', description: 'Switch or stack operating modes', category: 'session' },
+  { id: 'pair', name: '/pair', description: 'Real-time cross-instance pair programming', category: 'session' },
+  { id: 'delegate', name: '/delegate', description: 'Spawn worker agents for delegated tasks', category: 'session' },
+  { id: 'chat', name: '/chat', description: 'Start a fresh conversation context', category: 'session' },
+  { id: 'closeout', name: '/closeout', description: 'End-of-session checklist with git + memory save', category: 'session' },
+
+  // Research — knowledge retrieval
+  { id: 'remind-yourself', name: '/remind-yourself', description: 'Search past conversations and plans', category: 'research' },
+  { id: 'catch-me-up', name: '/catch-me-up', description: 'Reason about reasoning and audit achievements', category: 'research' },
+  { id: 'check-last-plan', name: '/check-last-plan', description: 'Resume and verify the last plan', category: 'research' },
+  { id: 'detect-insights', name: '/detect-insights', description: 'Pattern detection pipeline', category: 'research' },
+  { id: 'preplan', name: '/preplan', description: 'Prepare executable plans for future sessions', category: 'research' },
+
+  // System — diagnostics and ops
+  { id: 'grip-doctor', name: '/grip-doctor', description: 'GRIP infrastructure health diagnostic', category: 'system' },
+  { id: 'grip-inspect', name: '/grip-inspect', description: 'Deep introspection of GRIP installation state', category: 'system' },
+  { id: 'grip-config', name: '/grip-config', description: 'Configure GRIP settings and thresholds', category: 'system' },
+  { id: 'backup-grip', name: '/backup-grip', description: 'Tiered backup of GRIP infrastructure', category: 'system' },
+  { id: 'restore-grip', name: '/restore-grip', description: 'Restore GRIP from a backup snapshot', category: 'system' },
+  { id: 'install-mcp', name: '/install-mcp', description: 'Install an MCP server', category: 'system' },
+  { id: 'caffeinate', name: '/caffeinate', description: 'Prevent macOS sleep during long sessions', category: 'system' },
+  { id: 'node-clean', name: '/node-clean', description: 'Terminate lingering Node.js processes', category: 'system' },
+
+  // Meta — learning and self-improvement
+  { id: 'learn', name: '/learn', description: 'Extract patterns from errors and successes', category: 'meta' },
+  { id: 'refresh-context', name: '/refresh-context', description: 'Rebuild mental model of the repository', category: 'meta' },
+  { id: 'update-docs', name: '/update-docs', description: 'Auto-update project docs from session history', category: 'meta' },
+  { id: 'audit-efficiency', name: '/audit-efficiency', description: 'Detect workflow inefficiencies with patterns', category: 'meta' },
+  { id: 'rave', name: '/rave', description: 'Italian Brainrot milestone narration', category: 'meta' },
+];
+
+/**
+ * Fuzzy search commands by name or description.
+ */
+export function searchCommands(query: string): GripCommand[] {
+  if (!query) return GRIP_COMMANDS;
+  const q = query.toLowerCase().replace(/^\//, '');
+  return GRIP_COMMANDS.filter(
+    cmd =>
+      cmd.name.toLowerCase().includes(q) ||
+      cmd.id.toLowerCase().includes(q) ||
+      cmd.description.toLowerCase().includes(q),
+  );
+}


### PR DESCRIPTION
## Summary

Refactors the Cmd+K command palette around three goals: make skills first-class activatable items, add slash commands as a new category, and give the stacked-mode picker its own dedicated shortcut so it does not have to overload the generic palette entry point.

### New: \`src/lib/grip-commands.ts\`
- 41 curated slash commands from \`~/.claude/commands/\` (71 total in GRIP) grouped into six categories: \`workflow\`, \`code\`, \`session\`, \`research\`, \`system\`, \`meta\`.
- \`searchCommands()\` mirrors the existing \`searchSkills()\` API for consistency.

### Refactored: \`CommandPalette.tsx\`
- **Commands category** — populated from \`GRIP_COMMANDS\`. Selecting a command dispatches a \`grip:run-command\` window event carrying the id, then routes to \`/\` so the operator lands one keystroke away from typing it into a focused terminal. The event is a contract for future chat/terminal subsystems to pick up without touching the palette itself.
- **Full skill search** — expands skills from the fixed \`slice(0, 20)\` to the full 149-skill registry via \`searchSkills(query)\` when the user types, falling back to the top-20 idle view so the palette is not dominated by rows.
- **Skill activation intent** — selecting a skill dispatches \`grip:activate-skill\` and navigates to \`/skills?highlight=<id>\`, priming a future highlight affordance on the skills page.
- **Preset filter** — new \`presetFilter\` state wired to a \`grip:open-palette\` window event. Cmd+Shift+M opens the palette pre-filtered to \`MODES\` and keeps it open after each pick so the operator can stack multiple modes in one session without re-invoking the shortcut.
- **Mode activation** — selecting a mode calls \`/api/grip/modes\` directly (GET + toggle + POST) so activation works regardless of whether the /modes page is mounted, reusing the existing 5-mode FIFO eviction rule (\`MAX_ACTIVE_MODES = 5\`).
- **Cleanup** — extracts a single \`Category\` union type, tightens the \`CommandItem\` shape, and splits filtering into three explicit strategies (preset / query / idle) for readability.

### \`ClientLayout.tsx\`
- Adds the Cmd+Shift+M handler in the pre-modifier-guard slot next to Cmd+B. Dispatches \`grip:open-palette\` with \`presetFilter: 'MODES'\` and surfaces a keyboard toast. No collision with the existing plain-\`M\` memory shortcut (plain-M fires AFTER the modifier guard; Cmd+Shift+M early-returns BEFORE it).

### \`KeyboardShortcutsHelp.tsx\`
- Documents \`Cmd+Shift+M — Stacked Modes\` in the COMMANDS group, next to \`Cmd+B\`.

## Why

W7 of the GRIP Commander UI RSI sprint. The Cmd+K palette under-indexed skills (top-20 static slice out of 149), had no slash commands at all, and overloaded mode switching with a generic route to \`/modes\` that lost the stacking flow. The user's ask was specific: skills become activatable from the palette, commands get listed, and stacked-mode picking gets its own shortcut.

## Diff

\`\`\`
src/components/ClientLayout.tsx          |  12 ++
src/components/CommandPalette.tsx        | 270 ++++++++++++++++++++++++--------
src/components/KeyboardShortcutsHelp.tsx |   1 +
src/lib/grip-commands.ts                 | 111 +++++++++++++ (new file)
4 files changed, 312 insertions(+), 64 deletions(-)
\`\`\`

Well under the 400 LOC hypothesis budget (H039).

## Hypothesis H039

Registered 2026-04-15: "W7 palette refactor ships under 400 LOC across 4 files. Adds Cmd+Shift+M preset-mode picker via window event bus and a COMMANDS category of slash commands, expands skill search from top-20 to full registry via \`searchSkills()\`, routes skill picks to \`/skills?highlight=<id>\`, and does not regress existing Cmd+K behaviour."

Result: **312 insertions / 64 deletions** — well under budget. Regression verification pending the manual test plan below.

## Test plan

- [ ] Press \`Cmd+K\` — palette opens, default idle view shows RECENT, NAVIGATE, top-6 COMMANDS (\`save\`, \`recall\`, \`converge\`, \`broly\`, \`create-pr\`, \`shipit\`), ACTIONS.
- [ ] Type \`save\` — filtering matches \`/save\` command, \`New Chat\` action, \`SKILLS: saving-state\` skill.
- [ ] Type \`ultra\` — matches \`ultraplan\`, \`ultrathink\`, \`ultrado\` skills via full \`searchSkills\` registry.
- [ ] Press \`Enter\` on a skill — palette closes, navigates to \`/skills?highlight=<id>\`, fires \`grip:activate-skill\` (observable via \`window.addEventListener\` in devtools).
- [ ] Press \`Enter\` on a command — palette closes, navigates to \`/\`, fires \`grip:run-command\`.
- [ ] Press \`Cmd+Shift+M\` — palette opens with the \`MODES\` tag chip visible in the header, placeholder is "Stack modes — press Enter to toggle, Esc when done...", only MODES category items visible.
- [ ] Select a mode in the MODES preset — \`/api/grip/modes\` POST fires, palette STAYS OPEN, selected mode becomes active.
- [ ] Press \`Esc\` in MODES preset — palette closes, \`presetFilter\` resets.
- [ ] Open \`/modes\` page directly — \`activeModes\` state reflects any modes picked from the palette (round-trips through the file).
- [ ] Press \`?\` — shortcut help shows \`Cmd + Shift + M — Stacked Modes\`.
- [ ] Press plain \`M\` (no modifiers) outside an input — still navigates to \`/memory\` (no regression).

## Pre-existing issues (Rule 19 acknowledgement)

Not introduced by this PR, confirmed failing on \`main\` before this branch and tracked separately:
- \`__tests__/electron/handlers/vault-handlers.test.ts\` — Mock type inference errors (follow-up #1101).
- \`__tests__/electron/migration.test.ts\` — TS2367 comparison errors referencing \`dorothy-world-v1\`.
- \`__tests__/electron/providers/*.test.ts\` — TS2348 \`Mock<Procedure | Constructable>\` not callable.
- \`__tests__/electron/services.test.ts\` — TS2345 \`KanbanTask\` schema drift.
- \`__tests__/mcp/*.test.ts\` — TS2339 / TS2358 schema drift around \`slice\`, \`join\`, \`length\` on \`never\`.

None of these are in the palette / layout / keyboard subsystem, none are touched by this PR, and all are pre-existing.

## Risk

Low. The preset-filter mechanism is opt-in (no effect on the existing Cmd+K flow unless \`grip:open-palette\` is dispatched). Skill / command / mode actions are additive — existing click handlers still route as they did. The \`toggleModeViaApi\` helper reuses the same endpoint and eviction rule as the modes page. Cmd+Shift+M is a brand new keybinding with no collision against the existing plain-\`M\` memory shortcut (different modifier path).

## Future work

- Wire a terminal-panel listener for \`grip:run-command\` and \`grip:activate-skill\` to actually inject the text into the focused panel's input buffer. Currently these events are unwired (no-op), so the palette is a "discoverability + navigation" tool rather than a "one-keystroke invocation" tool. Hooking the listener requires either lifting terminal input state or a new imperative API on \`TerminalsView\` — both bigger than this PR's scope.
- Add a \`highlight=<skill-id>\` query-param handler on the skills page.
- Lift \`activeModes\` to the zustand store so the modes page and the palette share a live reactive state instead of round-tripping through the file.