### PR TITLE
feat(chat): clickable expand-all on +N earlier tool-output marker

### DIFF
--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -66,6 +66,20 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
   const [sessionId, setSessionId] = useState<string | undefined>();
   const [model, setModel] = useState('sonnet');
   const spinnerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Per-message expansion state for tool-use history. Default view caps at the
+  // last 3 tool calls; clicking the "+N earlier" marker reveals the full list.
+  const [expandedToolUses, setExpandedToolUses] = useState<Set<string>>(new Set());
+  const toggleToolUseExpansion = useCallback((messageId: string) => {
+    setExpandedToolUses(prev => {
+      const next = new Set(prev);
+      if (next.has(messageId)) {
+        next.delete(messageId);
+      } else {
+        next.add(messageId);
+      }
+      return next;
+    });
+  }, []);
 
   // Load persisted messages on mount or chat switch, reconnect active streams
   useEffect(() => {
@@ -552,27 +566,39 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
                     {msg.gates && msg.gates.length > 0 && (
                       <GateIndicator gates={msg.gates} />
                     )}
-                    {/* Tool use blocks — show at most the last 3 so the stream
-                        stays scannable; older calls collapse to a "+N earlier"
-                        marker above them. Full history is still stored on
-                        msg.toolUses and can be revisited later if we add an
-                        "expand all" affordance. */}
-                    {msg.toolUses && msg.toolUses.length > 0 && (
-                      <div className="mt-2 space-y-0.5">
-                        {msg.toolUses.length > 3 && (
-                          <div className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] opacity-60 px-1 py-0.5">
-                            +{msg.toolUses.length - 3} earlier tool call{msg.toolUses.length - 3 === 1 ? '' : 's'}
-                          </div>
-                        )}
-                        {msg.toolUses.slice(-3).map((tu, i) => (
-                          <ToolUseBlock
-                            key={tu.toolId || i}
-                            toolUse={tu}
-                            result={msg.toolResults?.find(r => r.toolId === tu.toolId)}
-                          />
-                        ))}
-                      </div>
-                    )}
+                    {/* Tool use blocks — capped at the last 3 by default so the
+                        stream stays scannable; the "+N earlier" marker is a
+                        button that reveals the full history per message. */}
+                    {msg.toolUses && msg.toolUses.length > 0 && (() => {
+                      const isExpanded = expandedToolUses.has(msg.id);
+                      const hiddenCount = msg.toolUses.length - 3;
+                      const visibleToolUses = isExpanded
+                        ? msg.toolUses
+                        : msg.toolUses.slice(-3);
+                      return (
+                        <div className="mt-2 space-y-0.5">
+                          {hiddenCount > 0 && (
+                            <button
+                              type="button"
+                              onClick={() => toggleToolUseExpansion(msg.id)}
+                              aria-expanded={isExpanded}
+                              className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] opacity-60 hover:opacity-100 hover:text-[var(--foreground)] px-1 py-0.5 transition-opacity text-left cursor-pointer"
+                            >
+                              {isExpanded
+                                ? `\u25BE collapse to last 3`
+                                : `\u25B8 +${hiddenCount} earlier tool call${hiddenCount === 1 ? '' : 's'}`}
+                            </button>
+                          )}
+                          {visibleToolUses.map((tu, i) => (
+                            <ToolUseBlock
+                              key={tu.toolId || i}
+                              toolUse={tu}
+                              result={msg.toolResults?.find(r => r.toolId === tu.toolId)}
+                            />
+                          ))}
+                        </div>
+                      );
+                    })()}
                     {msg.streaming && (
                       <span className="inline-block w-0.5 h-4 bg-[var(--primary)] ml-0.5 animate-[cursor-blink_1s_ease-in-out_infinite]" />
                     )}


### PR DESCRIPTION
## Summary

PR #94 capped tool-use rendering at the last 3 calls per assistant message and collapsed the rest behind a static "+N earlier tool call" marker, with a code comment noting the full history was retained on \`msg.toolUses\` for a future expand affordance. This is that affordance.

The marker becomes a button. Click toggles expansion for THAT message only (per-message \`Set<string>\` keyed on \`msg.id\`), so revealing one long history does not inflate every other message in the chat. Caret glyph flips between collapsed (▸) and expanded (▾) so the affordance is visually obvious without adding new icons.

## Implementation

- **New state**: \`expandedToolUses: Set<string>\` in \`ChatInterface\`, with a \`toggleToolUseExpansion(msg.id)\` callback wrapped in \`useCallback\`. Set updates use the immutable \`new Set(prev)\` pattern so React picks up the change.
- **Render block**: the tool-use section becomes a small IIFE that selects the visible slice (full list when expanded, \`.slice(-3)\` otherwise) and renders the marker as a \`<button>\` with \`aria-expanded\` for accessibility.
- **Hover state**: lifts opacity from 60 to 100 and shifts colour from \`--muted-foreground\` to \`--foreground\`, matching the muted-to-active hover pattern used elsewhere in the chat stream.
- **Persistence**: expansion is component state, intentionally NOT persisted to chat-storage. Reloading a chat resets to the default collapsed view, matching how other chat UI affordances (scroll position, focus) behave.

## Hypothesis H040

Registered 2026-04-15: \"Expand-all affordance: making the '+N earlier' marker a clickable button with per-message expanded state ships under 80 LOC in a single-file edit to ChatInterface.tsx with no regressions to streaming or persistence.\"

Result: **47 insertions / 21 deletions** = 26 net LOC, well under budget.

## Diff

\`\`\`
src/components/Engine/ChatInterface.tsx | 68 +++++++++++++++++++++++----------
1 file changed, 47 insertions(+), 21 deletions(-)
\`\`\`

## Test plan

- [ ] Open a chat with an assistant message containing >3 tool calls — see \"▸ +N earlier tool calls\" marker above the visible 3.
- [ ] Click the marker — caret flips to ▾, label becomes \"collapse to last 3\", all earlier tool calls render in chronological order above the original 3.
- [ ] Click again — collapses back to last 3 + marker.
- [ ] Open a second chat with multiple long-tool-history messages — expanding one does NOT expand the others (per-message state).
- [ ] Switch chat tabs — return to original chat — expansion state resets to collapsed (intentional, matches other ephemeral UI state).
- [ ] Stream a new assistant response with tool calls — marker appears live as soon as count crosses 3, can be expanded mid-stream.
- [ ] \`aria-expanded\` is correctly toggled (visible in DevTools accessibility tree).

## Risk

Very low. Single-file additive change. The existing \`.slice(-3)\` rendering path is preserved as the default branch of the new conditional. State is local to \`ChatInterface\`, not persisted, not coupled to streaming or chat-storage logic.

## Pre-existing issues (Rule 19 acknowledgement)

Two ESLint warnings exist on \`ChatInterface.tsx\` before this PR:
- \`getActiveChatId\` imported but never used
- \`onModelChange\` prop declared but never used

Neither is touched by this PR. Tracked for a separate cleanup pass.