### PR TITLE
fix(tests): resolve vault-handlers.test.ts TypeScript type errors

### DIFF
--- a/__tests__/electron/handlers/vault-handlers.test.ts
+++ b/__tests__/electron/handlers/vault-handlers.test.ts
@@ -18,14 +18,23 @@ vi.mock('uuid', () => ({
 }));
 
 // Mock database
-const mockStmt = {
+interface MockStmt {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  all: ReturnType<typeof vi.fn<() => any>>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  get: ReturnType<typeof vi.fn<() => any>>;
+  run: ReturnType<typeof vi.fn>;
+}
+
+const mockStmt: MockStmt = {
   all: vi.fn(() => []),
   get: vi.fn(() => undefined),
   run: vi.fn(),
 };
 
 const mockDb = {
-  prepare: vi.fn(() => mockStmt),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  prepare: vi.fn<() => any>(() => mockStmt),
 };
 
 vi.mock('../../../electron/services/vault-db', () => ({


### PR DESCRIPTION
## Summary
- Typed `mockStmt` with a `MockStmt` interface using `any`-returning `vi.fn` generics so `mockReturnValueOnce` calls with partial stub objects no longer conflict with the inferred full-shape return type
- Typed `mockDb.prepare` as `vi.fn<() => any>` for the same reason
- No logic changes — purely type annotation fixes

## Test plan
- [ ] `npx tsc --noEmit` reports zero errors for `vault-handlers.test.ts`
- [ ] Existing vitest suite passes unchanged