### PR TITLE
feat(w9b): memory measurement harness + W9 baseline stub

### DIFF
--- a/docs/proposals/W9-PERFORMANCE-BASELINE.md
+++ b/docs/proposals/W9-PERFORMANCE-BASELINE.md
@@ -243,6 +243,19 @@ Goodhart-ing and must be rejected regardless of what the primary says.
   before any W8a implementation PR registers a hypothesis against this
   target. The harness is the precondition for honest future baselines.
 
+### 4.3.1 Measurement procedure (W9b, 2026-04-15)
+
+A reproducible measurement harness now exists at `scripts/measure-memory.sh`
+with full usage documentation in `docs/proposals/W9B-HARNESS.md`. The
+300 MB provisional estimate in §4.3 MUST be replaced by measured numbers
+from this harness before any W8a memory claim can be reviewed. V>> to run
+the three-point measurement (idle / one-panel / five-panels) and update
+§4.3 with the results.
+
+**Status**: harness ready, measurement awaiting manual run.
+**Hypothesis H-B5 status**: still WEAKENED. Will be resolved one way or the
+other by the first measurement run.
+
 ### 4.4 Static source LOC growth rate
 
 - **Primary**: per-PR net LOC delta in `src/` tracked, no hard cap

--- a/docs/proposals/W9B-HARNESS.md
+++ b/docs/proposals/W9B-HARNESS.md
@@ -1,0 +1,144 @@
+# W9b — Memory Measurement Harness
+
+**Status:** Ready — awaiting manual run by V>>
+**Owner:** L>>
+**Date:** 2026-04-15
+**Scope:** macOS only (Linux/Windows out of scope for this iteration)
+
+## Purpose
+
+W9 Performance Baseline §4.3 contains a provisional estimate of "idle
+per-window RSS ≤ 300 MB" sourced from Agent B's industry-typical range
+for Electron + Next.js + xterm.js + React apps. That number is not
+measured. W8 §12 weakened hypothesis H-B5 ("3-5 concurrent windows fit
+within a reasonable 16 GB budget") precisely because runtime memory was
+unverified. This harness replaces the estimate with real numbers captured
+from a running Commander instance on V>>'s 16 GB MacBook.
+
+## Prerequisites
+
+- macOS (Darwin). Linux and Windows are out of scope for now — `ps` field
+  ordering and RSS units differ across platforms.
+- Commander is installed and launchable (`npm run electron:dev` or the
+  packaged `.app`).
+- Bash 4+ (`bash --version`).
+- `bc` installed (ships with macOS by default).
+- No other Electron-based apps running during measurement (Slack, VS Code,
+  etc.) to avoid contaminating the process list.
+
+## How to run
+
+Run three measurements per session — one per lifecycle stage.
+
+**Step 1 — Launch Commander**
+
+```bash
+cd ~/CodeTonight/GRIP-GUI
+npm run electron:dev
+```
+
+Wait for the main window to finish loading (splash gone, sidebar visible).
+
+**Step 2 — Idle measurement**
+
+In a separate terminal:
+
+```bash
+cd ~/CodeTonight/GRIP-GUI
+bash scripts/measure-memory.sh --idle
+```
+
+**Step 3 — One-panel measurement**
+
+Open one agent panel inside Commander (click any agent to open its
+terminal/chat view). Then:
+
+```bash
+bash scripts/measure-memory.sh --one-panel
+```
+
+**Step 4 — Five-panel measurement**
+
+Open four more agent panels (total: five panels open simultaneously). Then:
+
+```bash
+bash scripts/measure-memory.sh --five-panels
+```
+
+Each run writes a timestamped JSON file and prints a summary to stdout.
+For a reliable baseline, complete three full sessions and use the median
+`total_commander_rss_mb` across runs.
+
+## Output format
+
+Each run produces `docs/proposals/W9B-MEASUREMENT-<date>-<mode>.json`:
+
+```json
+{
+  "timestamp": "2026-04-15T14:00:00Z",
+  "mode": "idle",
+  "host": "macbook-pro",
+  "host_total_ram_gb": 16,
+  "commit": "2a0e5f6",
+  "total_commander_rss_mb": 280.5,
+  "processes": [
+    { "pid": 12345, "rss_mb": 210.0, "vsz_mb": 1800.0, "role": "main", "cmd": "..." },
+    { "pid": 12346, "rss_mb": 45.2,  "vsz_mb": 600.0,  "role": "gpu",  "cmd": "..." },
+    { "pid": 12347, "rss_mb": 25.3,  "vsz_mb": 400.0,  "role": "helper","cmd": "..." }
+  ],
+  "notes": "manual-run measurement (idle) against commit 2a0e5f6. RSS from macOS ps(1) in KB /1024."
+}
+```
+
+| Field | Unit | Notes |
+|---|---|---|
+| `total_commander_rss_mb` | MB | Sum of all Commander process RSS values |
+| `rss_mb` (per process) | MB | Resident set size — physical RAM pages currently held |
+| `vsz_mb` (per process) | MB | Virtual address space — typically much larger, less meaningful |
+| `role` | string | Inferred from command line: `main`, `renderer`, `gpu`, `plugin`, `helper` |
+
+## How to update the W9 baseline
+
+Once you have three sets of JSON files (nine files total — three modes ×
+three runs), do the following:
+
+1. Compute the median `total_commander_rss_mb` for each mode across the
+   three runs.
+2. Edit `docs/proposals/W9-PERFORMANCE-BASELINE.md` §4.3: replace the
+   "300 MB provisional estimate" with your measured idle median.
+3. Add a table in §4.3.1 showing all three medians (idle / one-panel /
+   five-panels) and the delta between idle and five-panels.
+4. Cite the JSON filenames as the evidence artefacts.
+5. If the measured idle number exceeds 350 MB, escalate H-B5 to WEAKENED
+   (CRITICAL) and re-open the W8 §11.6 concurrency cap discussion.
+
+## Known limitations
+
+- **RSS is a rough proxy.** macOS `ps` reports resident set size, which
+  counts all pages currently in physical RAM for that process. It does not
+  account for memory shared between v8 isolates (e.g. read-only code pages
+  that the OS shares between renderer processes). Actual unique physical cost
+  per process may be lower than RSS suggests. For a sharper number, use
+  `vmmap -summary <pid>` and look at "TOTAL PRIVATE" — but that is outside
+  this harness's scope.
+- **macOS only.** Linux uses the same `ps -o rss` field name but returns
+  different values in some configurations; Windows has no `ps`. Porting is
+  deferred.
+- **GPU memory excluded.** The GPU process RSS reflects system RAM allocated
+  by the GPU driver, not VRAM. Metal/VRAM footprint is not captured.
+- **MCP server footprint excluded.** `mcp-orchestrator` and sibling servers
+  run as separate Node processes. They are not matched by the Commander
+  pgrep pattern and are tracked separately per W9 baseline §2.3.
+- **Single measurement is noisy.** App startup timing, background OS
+  activity, and JIT warm-up affect RSS. Take three runs and use the median.
+- **No automation.** The harness requires V>> to manually open panels
+  between runs. Automating panel open via Spectron or Playwright is a future
+  improvement once the raw numbers are established.
+
+## Falsification criterion
+
+If two consecutive idle measurements (same Commander session, no panels
+opened between them) differ by more than 20%, the methodology is too noisy
+and needs refinement before any baseline claim can be made. In that case,
+investigate background OS memory pressure (`memory_pressure` command) and
+re-run in a quieter system state.

--- a/scripts/measure-memory.sh
+++ b/scripts/measure-memory.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# measure-memory.sh — Commander runtime RSS snapshot (macOS only)
+# Usage: bash scripts/measure-memory.sh --idle | --one-panel | --five-panels
+# Output: docs/proposals/W9B-MEASUREMENT-<iso-date>.json + stdout summary
+#
+# macOS ps returns RSS in kilobytes. This script divides by 1024 for MB.
+# Linux is out of scope for now (ps field ordering differs).
+
+set -euo pipefail
+
+# ── argument handling ────────────────────────────────────────────────────────
+
+MODE=""
+case "${1:-}" in
+  --idle)       MODE="idle" ;;
+  --one-panel)  MODE="one-panel" ;;
+  --five-panels) MODE="five-panels" ;;
+  *)
+    echo "Usage: $0 --idle | --one-panel | --five-panels" >&2
+    exit 1
+    ;;
+esac
+
+# ── locate Commander processes ───────────────────────────────────────────────
+
+# Match Electron main process and all helpers/renderers spawned by Commander.
+# Exclude this script's own grep invocation via [E] anchor trick via pgrep -f.
+PIDS=$(pgrep -f "Electron|GRIP Commander|grip-commander|Commander Helper" 2>/dev/null || true)
+
+if [[ -z "$PIDS" ]]; then
+  echo "ERROR: No Commander process found. Launch Commander first, then re-run." >&2
+  exit 1
+fi
+
+# ── collect per-process stats ────────────────────────────────────────────────
+
+# ps -o rss,vsz,comm,pid returns KB on macOS.
+TOTAL_RSS_KB=0
+PROCESSES_JSON=""
+FIRST=1
+
+while IFS= read -r pid; do
+  [[ -z "$pid" ]] && continue
+
+  # Read rss(KB), vsz(KB), full command line for this pid.
+  STAT=$(ps -o rss=,vsz=,command= -p "$pid" 2>/dev/null || true)
+  [[ -z "$STAT" ]] && continue
+
+  RSS_KB=$(echo "$STAT" | awk '{print $1}')
+  VSZ_KB=$(echo "$STAT" | awk '{print $2}')
+  CMD=$(echo "$STAT" | awk '{for(i=3;i<=NF;i++) printf $i (i<NF?" ":""); print ""}')
+
+  RSS_MB=$(echo "scale=1; $RSS_KB / 1024" | bc)
+  VSZ_MB=$(echo "scale=1; $VSZ_KB / 1024" | bc)
+  TOTAL_RSS_KB=$((TOTAL_RSS_KB + RSS_KB))
+
+  # Infer role from command string.
+  ROLE="helper"
+  if echo "$CMD" | grep -qi "gpu"; then          ROLE="gpu"
+  elif echo "$CMD" | grep -qi "renderer";        then ROLE="renderer"
+  elif echo "$CMD" | grep -qi "plugin";          then ROLE="plugin"
+  elif echo "$CMD" | grep -qi "Helper";          then ROLE="helper"
+  elif echo "$CMD" | grep -qi "Electron$\|Electron "; then ROLE="main"
+  fi
+
+  # Escape double-quotes in CMD for valid JSON.
+  CMD_ESC="${CMD//\"/\\\"}"
+
+  [[ "$FIRST" -eq 0 ]] && PROCESSES_JSON+=","
+  PROCESSES_JSON+=$(printf '\n    {"pid":%s,"rss_mb":%s,"vsz_mb":%s,"role":"%s","cmd":"%s"}' \
+    "$pid" "$RSS_MB" "$VSZ_MB" "$ROLE" "$CMD_ESC")
+  FIRST=0
+done <<< "$PIDS"
+
+TOTAL_RSS_MB=$(echo "scale=1; $TOTAL_RSS_KB / 1024" | bc)
+
+# ── resolve commit sha ───────────────────────────────────────────────────────
+
+SHA=$(git -C "$(dirname "$0")/.." rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+# ── write JSON output ────────────────────────────────────────────────────────
+
+ISO_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+DATE_TAG=$(date -u +"%Y-%m-%d")
+OUT_FILE="docs/proposals/W9B-MEASUREMENT-${DATE_TAG}-${MODE}.json"
+
+mkdir -p "$(dirname "$OUT_FILE")"
+
+cat > "$OUT_FILE" <<JSON
+{
+  "timestamp": "${ISO_DATE}",
+  "mode": "${MODE}",
+  "host": "$(hostname)",
+  "host_total_ram_gb": 16,
+  "commit": "${SHA}",
+  "total_commander_rss_mb": ${TOTAL_RSS_MB},
+  "processes": [${PROCESSES_JSON}
+  ],
+  "notes": "manual-run measurement (${MODE}) against commit ${SHA}. RSS from macOS ps(1) in KB /1024."
+}
+JSON
+
+# ── stdout summary ───────────────────────────────────────────────────────────
+
+echo ""
+echo "Commander memory snapshot — mode: ${MODE}"
+echo "  Commit    : ${SHA}"
+echo "  Timestamp : ${ISO_DATE}"
+echo "  Total RSS : ${TOTAL_RSS_MB} MB (across $(echo "$PIDS" | wc -l | tr -d ' ') processes)"
+echo "  Output    : ${OUT_FILE}"
+echo ""


### PR DESCRIPTION
## Summary

- W9b deliverable per W8 §13.7. Ships docs+scripts only — no production code changes.
- `scripts/measure-memory.sh` captures Commander RSS at three lifecycle points (idle, one-panel, five-panels) via macOS `ps -o rss` and writes timestamped JSON to `docs/proposals/`.
- `docs/proposals/W9B-HARNESS.md` documents prerequisites, step-by-step usage, output format, known limitations, and falsification criterion.
- `docs/proposals/W9-PERFORMANCE-BASELINE.md` §4.3.1 appends a stub marking the harness as ready and H-B5 as still WEAKENED pending V>>'s manual run.

## Test plan

- [x] `bash -n scripts/measure-memory.sh` passes (syntax clean)
- [ ] V>> runs `--idle`, `--one-panel`, `--five-panels` against a live Commander instance on the 16 GB MacBook
- [ ] Three JSON output files written to `docs/proposals/W9B-MEASUREMENT-<date>-<mode>.json`
- [ ] §4.3 updated with measured numbers in a follow-up commit, citing the JSON artefacts

Unblocks H-B5 resolution once V>> runs the three-point measurement.
Risk: zero (docs+scripts, no runtime behaviour changes).
Pre-existing issues: none observed.