### PR TITLE
fix(chat): only show pending spinner on last streaming tool block

### DIFF
--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -589,13 +589,17 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
                                 : `\u25B8 +${hiddenCount} earlier tool call${hiddenCount === 1 ? '' : 's'}`}
                             </button>
                           )}
-                          {visibleToolUses.map((tu, i) => (
-                            <ToolUseBlock
-                              key={tu.toolId || i}
-                              toolUse={tu}
-                              result={msg.toolResults?.find(r => r.toolId === tu.toolId)}
-                            />
-                          ))}
+                          {visibleToolUses.map((tu, i) => {
+                            const isLastTool = msg.toolUses!.indexOf(tu) === msg.toolUses!.length - 1;
+                            return (
+                              <ToolUseBlock
+                                key={tu.toolId || i}
+                                toolUse={tu}
+                                result={msg.toolResults?.find(r => r.toolId === tu.toolId)}
+                                streaming={msg.streaming && isLastTool}
+                              />
+                            );
+                          })}
                         </div>
                       );
                     })()}

--- a/src/components/Engine/ToolUseBlock.tsx
+++ b/src/components/Engine/ToolUseBlock.tsx
@@ -6,6 +6,7 @@ import type { ToolUseEvent, ToolResultEvent } from '@/lib/grip-session';
 interface ToolUseBlockProps {
   toolUse: ToolUseEvent;
   result?: ToolResultEvent;
+  streaming?: boolean;
 }
 
 const TOOL_ICONS: Record<string, string> = {
@@ -44,11 +45,11 @@ function formatToolInput(input: Record<string, unknown>): string {
   return keys.slice(0, 3).join(', ');
 }
 
-export default function ToolUseBlock({ toolUse, result }: ToolUseBlockProps) {
+export default function ToolUseBlock({ toolUse, result, streaming }: ToolUseBlockProps) {
   const [expanded, setExpanded] = useState(false);
   const category = getToolCategory(toolUse.toolName);
   const summary = formatToolInput(toolUse.input);
-  const isPending = !result;
+  const isPending = !result && streaming === true;
   const isError = result?.isError;
 
   const categoryColors: Record<string, string> = {


### PR DESCRIPTION
## Summary

- `ToolUseBlock.isPending` was `!result`, causing every tool block without a result to show a loading spinner — including completed blocks after streaming finished
- Adds `streaming?: boolean` prop to `ToolUseBlock`; `isPending` is now `!result && streaming === true`
- `ChatInterface` computes `isLastTool` and passes `streaming={msg.streaming && isLastTool}` so only the currently-active (last) tool in a live stream shows the spinner

## Test plan

- [ ] Start a chat and trigger a multi-tool response — confirm only the last tool shows the spinner while streaming
- [ ] After streaming completes — confirm all tool blocks without explicit results no longer show the spinner
- [ ] Single-tool responses — spinner shows during stream, clears on completion
- [ ] TypeScript: `npx tsc --noEmit` exits 0