### PR TITLE
feat(layout): sticky right panel with collapse toggle (Cmd+Shift+B)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,8 @@ import FocusMode from '@/components/Engine/FocusMode';
 import WelcomeAnimation from '@/components/Engine/WelcomeAnimation';
 import MobileToolbar from '@/components/Engine/MobileToolbar';
 import { useState, useCallback, useEffect } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useStore } from '@/store';
 import { isElectronEnv } from '@/lib/grip-session';
 import {
   getChatSessions,
@@ -31,6 +33,7 @@ export default function EnginePage() {
   const [activeChatId, setActiveChatId] = useState<string | null>(null);
   const [chatKey, setChatKey] = useState(0); // Force re-mount ChatInterface on session switch
   const [health, setHealth] = useState<HealthData>({ skillCount: 5, generation: 33, fitness: 0.467 });
+  const { rightPanelCollapsed, toggleRightPanel } = useStore();
 
   // Fetch GRIP health data for live status bar
   useEffect(() => {
@@ -102,25 +105,43 @@ export default function EnginePage() {
             </FocusMode>
           </div>
 
-          {/* Right Panel — Context + Chat History, hidden in focus mode */}
+          {/* Right Panel — sticky, collapsible, mirrors left sidebar behaviour */}
           {!focusMode && (
-            <div className="hidden lg:flex w-[280px] shrink-0 flex-col border-l border-[var(--border)] bg-[var(--card)]">
-              {/* Context Panel — top half */}
-              <div className="flex-1 min-h-0 overflow-y-auto">
-                <ContextPanel />
-              </div>
+            <div
+              className={`hidden lg:flex shrink-0 flex-col border-l border-[var(--border)] bg-[var(--card)] sticky top-0 h-screen self-start transition-[width] duration-200 ease-in-out ${rightPanelCollapsed ? 'w-8' : 'w-[280px]'}`}
+            >
+              {/* Collapse / expand toggle — always visible */}
+              <button
+                onClick={toggleRightPanel}
+                title={rightPanelCollapsed ? 'Expand context panel (\u2318\u21E7B)' : 'Collapse context panel (\u2318\u21E7B)'}
+                className="flex items-center justify-center h-8 w-full shrink-0 text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--secondary)] border-b border-[var(--border)] transition-colors"
+              >
+                {rightPanelCollapsed
+                  ? <ChevronLeft className="w-3 h-3" strokeWidth={1.5} />
+                  : <ChevronRight className="w-3 h-3" strokeWidth={1.5} />}
+              </button>
 
-              {/* Chat History — bottom section */}
-              <div className="h-[240px] shrink-0 border-t border-[var(--border)] p-3 overflow-hidden">
-                <span className="grip-label block mb-2">HISTORY</span>
-                <div className="h-[calc(100%-24px)]">
-                  <ChatHistory
-                    onSessionChange={handleSessionChange}
-                    onNewChat={handleNewChat}
-                    currentModel={model}
-                  />
-                </div>
-              </div>
+              {/* Panel content — hidden when collapsed */}
+              {!rightPanelCollapsed && (
+                <>
+                  {/* Context Panel — fills remaining height */}
+                  <div className="flex-1 min-h-0 overflow-y-auto">
+                    <ContextPanel />
+                  </div>
+
+                  {/* Chat History — pinned to bottom */}
+                  <div className="h-[240px] shrink-0 border-t border-[var(--border)] p-3 overflow-hidden">
+                    <span className="grip-label block mb-2">HISTORY</span>
+                    <div className="h-[calc(100%-24px)]">
+                      <ChatHistory
+                        onSessionChange={handleSessionChange}
+                        onNewChat={handleNewChat}
+                        currentModel={model}
+                      />
+                    </div>
+                  </div>
+                </>
+              )}
             </div>
           )}
         </div>

--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -217,6 +217,32 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
     return unsub;
   }, []);
 
+  // Persist rightPanelCollapsed to localStorage (same pattern as sidebarCollapsed above).
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = window.localStorage.getItem('grip.rightPanelCollapsed');
+      if (stored !== null) {
+        const parsed = stored === 'true';
+        if (parsed !== useStore.getState().rightPanelCollapsed) {
+          useStore.setState({ rightPanelCollapsed: parsed });
+        }
+      }
+    } catch {
+      // localStorage unavailable — ignore, use in-memory default
+    }
+    const unsub = useStore.subscribe((state, prev) => {
+      if (state.rightPanelCollapsed !== prev.rightPanelCollapsed) {
+        try {
+          window.localStorage.setItem('grip.rightPanelCollapsed', String(state.rightPanelCollapsed));
+        } catch {
+          // ignore write failures
+        }
+      }
+    });
+    return unsub;
+  }, []);
+
   const mainMarginLeft = isMobile ? 0 : (sidebarCollapsed ? 72 : 240);
 
   // Page transitions
@@ -246,6 +272,15 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
         e.preventDefault();
         router.push('/settings');
         showKeyboardToast('\u2318,', 'SETTINGS');
+        return;
+      }
+
+      // Cmd+Shift+B = toggle right context panel — checked before Cmd+B to avoid shadowing
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === 'b' || e.key === 'B')) {
+        e.preventDefault();
+        useStore.getState().toggleRightPanel();
+        const collapsed = useStore.getState().rightPanelCollapsed;
+        showKeyboardToast('\u2318\u21E7B', collapsed ? 'CONTEXT COLLAPSED' : 'CONTEXT EXPANDED');
         return;
       }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -219,6 +219,7 @@ interface AppState {
   selectedAgent: string | null;
   selectedChat: string | null;
   sidebarCollapsed: boolean;
+  rightPanelCollapsed: boolean;
   mobileMenuOpen: boolean;
   darkMode: boolean; // computed from theme — backward compat
   theme: string;
@@ -251,6 +252,7 @@ interface AppState {
   setSelectedAgent: (id: string | null) => void;
   setSelectedChat: (id: string | null) => void;
   toggleSidebar: () => void;
+  toggleRightPanel: () => void;
   setMobileMenuOpen: (open: boolean) => void;
   toggleMobileMenu: () => void;
   setDarkMode: (dark: boolean) => void;
@@ -280,6 +282,7 @@ export const useStore = create<AppState>((set, get) => ({
   selectedAgent: null,
   selectedChat: null,
   sidebarCollapsed: false,
+  rightPanelCollapsed: false,
   mobileMenuOpen: false,
   darkMode: true, // computed default — matches DEFAULT_THEME (swiss-nihilism-dark)
   theme: DEFAULT_THEME,
@@ -409,6 +412,7 @@ export const useStore = create<AppState>((set, get) => ({
   setSelectedAgent: (id) => set({ selectedAgent: id }),
   setSelectedChat: (id) => set({ selectedChat: id }),
   toggleSidebar: () => set((state) => ({ sidebarCollapsed: !state.sidebarCollapsed })),
+  toggleRightPanel: () => set((state) => ({ rightPanelCollapsed: !state.rightPanelCollapsed })),
   setMobileMenuOpen: (open) => set({ mobileMenuOpen: open }),
   toggleMobileMenu: () => set((state) => ({ mobileMenuOpen: !state.mobileMenuOpen })),
   setDarkMode: (dark) => set({ darkMode: dark, theme: dark ? 'swiss-nihilism-dark' : 'swiss-nihilism-light' }),


### PR DESCRIPTION
## Summary

- Right panel (Context + Chat History) was in normal document flow — it scrolled out of view as chat content grew
- Now uses `sticky top-0 h-screen self-start` so it stays pinned to the viewport exactly like the left sidebar
- Adds a collapse toggle button at the top of the panel (ChevronRight to collapse, ChevronLeft to expand)
- Collapsed state: `w-8` strip (just the toggle button); expanded: `w-[280px]`
- `Cmd+Shift+B` keyboard shortcut toggles the right panel (added before `Cmd+B` check to prevent key shadowing)
- State persists to `localStorage` under `grip.rightPanelCollapsed` via the same pattern as `grip.sidebarCollapsed`

## Files changed

- `src/store/index.ts` — adds `rightPanelCollapsed` state + `toggleRightPanel` action
- `src/app/page.tsx` — sticky panel + collapse UI
- `src/components/ClientLayout.tsx` — `Cmd+Shift+B` shortcut + localStorage sync

## Test plan

- [ ] Open Engine page — right panel is visible at `w-[280px]`, does NOT scroll away when chat grows tall
- [ ] Click the `>` button — panel collapses to an `w-8` strip; `<` button shown
- [ ] Click the `<` button — panel re-expands to `w-[280px]`
- [ ] Press `Cmd+Shift+B` — panel toggles; keyboard toast shows CONTEXT COLLAPSED / EXPANDED
- [ ] Press `Cmd+B` — left sidebar still toggles (not right panel)
- [ ] Reload app — panel remembers its collapsed/expanded state
- [ ] `npx tsc --noEmit` exits 0