### PR TITLE
fix(hooks): deduplicate settings.json hook entries (closes #91)

### DIFF
--- a/__tests__/electron/providers/claude-provider.test.ts
+++ b/__tests__/electron/providers/claude-provider.test.ts
@@ -274,6 +274,67 @@ describe('ClaudeProvider', () => {
       expect(settings.hooks.PostToolUse).toBeUndefined();
       expect(settings.hooks.SessionStart).toBeUndefined();
     });
+
+    it('removes duplicate entries left by pre-posixQuote installer (issue #91)', async () => {
+      // Simulates a settings.json where the legacy installer appended a quoted
+      // entry alongside the original unquoted one instead of editing in place.
+      const provider = await getProvider();
+      const hooksDir = path.join(tmpDir, 'GRIP Commander.app', 'hooks');
+      fs.mkdirSync(hooksDir, { recursive: true });
+      fs.writeFileSync(path.join(hooksDir, 'on-stop.sh'), '#!/bin/sh\n');
+
+      const claudeDir = path.join(tmpDir, '.claude');
+      fs.mkdirSync(claudeDir, { recursive: true });
+
+      const rawPath = path.join(hooksDir, 'on-stop.sh');
+      const quotedPath = `'${rawPath}'`;
+
+      // Two duplicate entries: first unquoted (old), second quoted (partial fix)
+      fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify({
+        hooks: {
+          Stop: [
+            { hooks: [{ type: 'command', command: rawPath, timeout: 60000 }] },
+            { hooks: [{ type: 'command', command: quotedPath, timeout: 30 }] },
+          ],
+        },
+      }));
+
+      await provider.configureHooks(hooksDir);
+
+      const settings = JSON.parse(fs.readFileSync(path.join(claudeDir, 'settings.json'), 'utf-8'));
+      // After dedup: exactly one Stop entry, with correctly quoted path
+      expect(settings.hooks.Stop).toHaveLength(1);
+      expect(settings.hooks.Stop[0].hooks[0].command).toBe(quotedPath);
+    });
+
+    it('deduplicates multiple unquoted entries and re-quotes the survivor', async () => {
+      const provider = await getProvider();
+      const hooksDir = path.join(tmpDir, 'GRIP Commander.app', 'hooks');
+      fs.mkdirSync(hooksDir, { recursive: true });
+      fs.writeFileSync(path.join(hooksDir, 'session-start.sh'), '#!/bin/sh\n');
+
+      const claudeDir = path.join(tmpDir, '.claude');
+      fs.mkdirSync(claudeDir, { recursive: true });
+
+      const rawPath = path.join(hooksDir, 'session-start.sh');
+
+      // Two unquoted duplicates (pre-posixQuote installer ran twice)
+      fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify({
+        hooks: {
+          SessionStart: [
+            { matcher: '*', hooks: [{ type: 'command', command: rawPath, timeout: 30000 }] },
+            { matcher: '*', hooks: [{ type: 'command', command: rawPath, timeout: 30 }] },
+          ],
+        },
+      }));
+
+      await provider.configureHooks(hooksDir);
+
+      const settings = JSON.parse(fs.readFileSync(path.join(claudeDir, 'settings.json'), 'utf-8'));
+      expect(settings.hooks.SessionStart).toHaveLength(1);
+      const cmd = settings.hooks.SessionStart[0].hooks[0].command;
+      expect(cmd).toBe(`'${rawPath}'`);
+    });
   });
 
   describe('isMcpServerRegistered', () => {

--- a/electron/providers/claude-provider.ts
+++ b/electron/providers/claude-provider.ts
@@ -219,6 +219,26 @@ export class ClaudeProvider implements CLIProvider {
       }
     }
 
+    // Deduplication pass: pre-posixQuote installer versions appended new quoted
+    // entries instead of editing unquoted ones in place, leaving duplicates.
+    // Keep only the first entry per (event-type, script-file) pair.
+    for (const { type, file } of hookFiles) {
+      const entries: HookEntry[] = settings.hooks![type] || [];
+      if (entries.length <= 1) continue;
+
+      let seenThisFile = false;
+      const deduped = entries.filter((h: HookEntry) => {
+        const refersToFile = h.hooks?.some(
+          (hh: { command?: string }) => (hh.command ?? '').replace(/^'|'$/g, '').includes(file)
+        );
+        if (!refersToFile) return true;     // unrelated entry — always keep
+        if (seenThisFile) { updated = true; return false; } // duplicate — drop
+        seenThisFile = true;
+        return true;                         // first occurrence — keep
+      });
+      settings.hooks![type] = deduped;
+    }
+
     if (updated) {
       fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
       console.log('Claude hooks configured/updated in', settingsPath);


### PR DESCRIPTION
## Summary

- Pre-`posixQuote` installer versions appended a new quoted entry alongside the original unquoted one instead of editing in place
- `configureHooks()` only fixed the FIRST matching entry (`findIndex`), leaving any subsequent duplicates untouched — both entries kept firing, one broken
- Adds a deduplication pass after the main update loop: for each `(event-type, script-file)` pair, only the first matching entry in the array is kept

## What changed

- `electron/providers/claude-provider.ts` — dedup loop after the main `hookFiles` update loop
- `__tests__/electron/providers/claude-provider.test.ts` — two new regression tests (20 total, all pass)

## Test plan

- [ ] Install GRIP Commander into `/Applications/GRIP Commander.app`, launch Claude Code — no `Stop hook error` banner
- [ ] Inspect `~/.claude/settings.json` after first launch — each hook event type has exactly one entry per script, all paths single-quoted
- [ ] If settings.json already had duplicate entries (legacy install) — re-launching Commander removes the duplicates on the next `configureHooks()` call
- [ ] `npm test` → 20/20 claude-provider tests pass