### PR TITLE
fix(hooks): deduplicate settings.json hook entries, fixes #91

### DIFF
--- a/__tests__/electron/providers/claude-provider.test.ts
+++ b/__tests__/electron/providers/claude-provider.test.ts
@@ -274,6 +274,67 @@ describe('ClaudeProvider', () => {
       expect(settings.hooks.PostToolUse).toBeUndefined();
       expect(settings.hooks.SessionStart).toBeUndefined();
     });
+
+    it('removes duplicate entries left by pre-posixQuote installer (issue #91)', async () => {
+      // Simulates a settings.json where the legacy installer appended a quoted
+      // entry alongside the original unquoted one instead of editing in place.
+      const provider = await getProvider();
+      const hooksDir = path.join(tmpDir, 'GRIP Commander.app', 'hooks');
+      fs.mkdirSync(hooksDir, { recursive: true });
+      fs.writeFileSync(path.join(hooksDir, 'on-stop.sh'), '#!/bin/sh\n');
+
+      const claudeDir = path.join(tmpDir, '.claude');
+      fs.mkdirSync(claudeDir, { recursive: true });
+
+      const rawPath = path.join(hooksDir, 'on-stop.sh');
+      const quotedPath = `'${rawPath}'`;
+
+      // Two duplicate entries: first unquoted (old), second quoted (partial fix)
+      fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify({
+        hooks: {
+          Stop: [
+            { hooks: [{ type: 'command', command: rawPath, timeout: 60000 }] },
+            { hooks: [{ type: 'command', command: quotedPath, timeout: 30 }] },
+          ],
+        },
+      }));
+
+      await provider.configureHooks(hooksDir);
+
+      const settings = JSON.parse(fs.readFileSync(path.join(claudeDir, 'settings.json'), 'utf-8'));
+      // After dedup: exactly one Stop entry, with correctly quoted path
+      expect(settings.hooks.Stop).toHaveLength(1);
+      expect(settings.hooks.Stop[0].hooks[0].command).toBe(quotedPath);
+    });
+
+    it('deduplicates multiple unquoted entries and re-quotes the survivor', async () => {
+      const provider = await getProvider();
+      const hooksDir = path.join(tmpDir, 'GRIP Commander.app', 'hooks');
+      fs.mkdirSync(hooksDir, { recursive: true });
+      fs.writeFileSync(path.join(hooksDir, 'session-start.sh'), '#!/bin/sh\n');
+
+      const claudeDir = path.join(tmpDir, '.claude');
+      fs.mkdirSync(claudeDir, { recursive: true });
+
+      const rawPath = path.join(hooksDir, 'session-start.sh');
+
+      // Two unquoted duplicates (pre-posixQuote installer ran twice)
+      fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify({
+        hooks: {
+          SessionStart: [
+            { matcher: '*', hooks: [{ type: 'command', command: rawPath, timeout: 30000 }] },
+            { matcher: '*', hooks: [{ type: 'command', command: rawPath, timeout: 30 }] },
+          ],
+        },
+      }));
+
+      await provider.configureHooks(hooksDir);
+
+      const settings = JSON.parse(fs.readFileSync(path.join(claudeDir, 'settings.json'), 'utf-8'));
+      expect(settings.hooks.SessionStart).toHaveLength(1);
+      const cmd = settings.hooks.SessionStart[0].hooks[0].command;
+      expect(cmd).toBe(`'${rawPath}'`);
+    });
   });
 
   describe('isMcpServerRegistered', () => {

--- a/electron/providers/claude-provider.ts
+++ b/electron/providers/claude-provider.ts
@@ -219,6 +219,26 @@ export class ClaudeProvider implements CLIProvider {
       }
     }
 
+    // Deduplication pass: pre-posixQuote installer versions appended new quoted
+    // entries instead of editing unquoted ones in place, leaving duplicates.
+    // Keep only the first entry per (event-type, script-file) pair.
+    for (const { type, file } of hookFiles) {
+      const entries: HookEntry[] = settings.hooks![type] || [];
+      if (entries.length <= 1) continue;
+
+      let seenThisFile = false;
+      const deduped = entries.filter((h: HookEntry) => {
+        const refersToFile = h.hooks?.some(
+          (hh: { command?: string }) => (hh.command ?? '').replace(/^'|'$/g, '').includes(file)
+        );
+        if (!refersToFile) return true;     // unrelated entry — always keep
+        if (seenThisFile) { updated = true; return false; } // duplicate — drop
+        seenThisFile = true;
+        return true;                         // first occurrence — keep
+      });
+      settings.hooks![type] = deduped;
+    }
+
     if (updated) {
       fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
       console.log('Claude hooks configured/updated in', settingsPath);


### PR DESCRIPTION
## Summary

- Pre-`posixQuote` installer versions appended new quoted entries instead of editing existing unquoted ones in place, leaving duplicate hook entries in `~/.claude/settings.json`
- `configureHooks()` `findIndex` only fixed the *first* matching entry, leaving duplicates with stale/unquoted paths still firing
- Adds a deduplication pass after the main update loop: for each `(event-type, script-file)` pair, filters the array down to the **first** occurrence, dropping all subsequent duplicates

## Test plan

- [x] `npm test -- claude-provider` — 20/20 passing (2 new regression tests added)
- [ ] Install GRIP Commander, inspect `~/.claude/settings.json` — each hook type has exactly one entry, with a single-quoted path
- [ ] Verify `Stop hook error` banner no longer appears in Claude Code sessions after re-launch

Closes #91.