### PR TITLE
fix(chat): prevent auto-scroll during tool output streaming

### DIFF
--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -124,8 +124,25 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
   const rafIdRef = useRef<number | null>(null);
   const pendingContentRef = useRef('');
   const scrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Tracks whether the user is within 200px of the bottom. True by default so
+  // new chats start pinned. Updated by the scroll handler below (via ref to
+  // avoid stale-closure issues inside the messages effect).
+  const isNearBottomRef = useRef(true);
+  // Tracks message count to distinguish "new message added" from "existing
+  // message content updated" (tool output streaming). Count increases are
+  // always scrolled; content-only updates only scroll when near the bottom.
+  const messageCountRef = useRef(0);
 
   useEffect(() => {
+    const newCount = messages.length;
+    const countIncreased = newCount > messageCountRef.current;
+    messageCountRef.current = newCount;
+
+    // Skip auto-scroll when tool output is streaming into an existing message
+    // and the user has scrolled up to read history. This eliminates the janky
+    // jump-to-bottom on every chunk. Always scroll when a new message appears.
+    if (!countIncreased && !isNearBottomRef.current) return;
+
     if (scrollTimerRef.current) clearTimeout(scrollTimerRef.current);
     scrollTimerRef.current = setTimeout(() => {
       messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -141,7 +158,9 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
     if (!container) return;
     const handleScroll = () => {
       const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
-      setShowScrollButton(distanceFromBottom > 200);
+      const nearBottom = distanceFromBottom <= 200;
+      isNearBottomRef.current = nearBottom;
+      setShowScrollButton(!nearBottom);
     };
     container.addEventListener('scroll', handleScroll, { passive: true });
     return () => container.removeEventListener('scroll', handleScroll);


### PR DESCRIPTION
## Summary

- Auto-scroll no longer fires on every tool output chunk, eliminating the janky jump-to-bottom while reading history
- Tracks message **count** via a ref: when count increases (new message), always scroll; when count is stable (streaming update to existing message), only scroll if user is already within 200px of the bottom
- The existing `isNearBottomRef` is now updated in the scroll handler and consulted in the effect, with no extra re-renders (all via refs, not state)

## Root cause

`useEffect([messages])` was firing on every `setMessages` call — including every `tool_use`, `tool_result`, and RAF text flush — and unconditionally calling `scrollIntoView` after 80ms. When a tool produces large output (file reads, web searches), this caused the viewport to jump back to the bottom on every chunk even if the user had scrolled up.

## Behaviour after fix

| Scenario | Before | After |
|---|---|---|
| User sends message | Scroll to bottom | Scroll to bottom |
| New assistant message starts | Scroll to bottom | Scroll to bottom |
| Tool output streaming, user at bottom | Scroll (ok) | Scroll (ok) |
| Tool output streaming, user scrolled up | **Jump back down** (bug) | No scroll (fixed) |
| User clicks scroll-to-bottom button | Scroll | Scroll |

## Test plan

- [ ] Send a prompt that triggers a multi-step tool use (e.g. file read + write)
- [ ] Scroll up mid-stream — viewport should stay put
- [ ] Verify the scroll-to-bottom button (↓) still appears when scrolled up
- [ ] Click the button — should scroll to bottom
- [ ] Send a new message — should scroll to bottom regardless of scroll position

🤖 Generated with [Claude Code](https://claude.com/claude-code)