### PR TITLE
feat(engine): concurrent chat tabs — multiple sessions open simultaneously

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import GripStatusBar from '@/components/Engine/GripStatusBar';
 import FocusMode from '@/components/Engine/FocusMode';
 import WelcomeAnimation from '@/components/Engine/WelcomeAnimation';
 import MobileToolbar from '@/components/Engine/MobileToolbar';
+import ChatTabBar from '@/components/Engine/ChatTabBar';
 import { useState, useCallback, useEffect } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useStore } from '@/store';
@@ -15,10 +16,12 @@ import {
   getChatSessions,
   getActiveChatId,
   createChatSession,
-  getChatMessages,
   migrateStorageIfNeeded,
-  type ChatSession,
+  getOpenTabIds,
+  setOpenTabIds,
 } from '@/lib/chat-storage';
+
+const MAX_TABS = 8;
 
 interface HealthData {
   skillCount: number;
@@ -30,8 +33,8 @@ export default function EnginePage() {
   const [showWelcome, setShowWelcome] = useState(true);
   const [focusMode, setFocusMode] = useState(false);
   const [model, setModel] = useState('sonnet');
-  const [activeChatId, setActiveChatId] = useState<string | null>(null);
-  const [chatKey, setChatKey] = useState(0); // Force re-mount ChatInterface on session switch
+  const [openTabIds, setOpenTabIdsState] = useState<string[]>([]);
+  const [activeTabId, setActiveTabId] = useState<string | null>(null);
   const [health, setHealth] = useState<HealthData>({ skillCount: 5, generation: 33, fitness: 0.467 });
   const { rightPanelCollapsed, toggleRightPanel } = useStore();
 
@@ -56,37 +59,112 @@ export default function EnginePage() {
     return () => clearInterval(interval);
   }, []);
 
-  // Initialise: migrate storage, load or create active chat
+  // Initialise: migrate, restore or create tabs
   useEffect(() => {
     migrateStorageIfNeeded();
 
-    const existingId = getActiveChatId();
-    if (existingId) {
-      setActiveChatId(existingId);
-    } else {
-      const sessions = getChatSessions();
-      if (sessions.length > 0) {
-        setActiveChatId(sessions[0].id);
-      }
-      // Don't auto-create — let ChatInterface create on first message
+    const sessions = getChatSessions();
+    const sessionIds = new Set(sessions.map(s => s.id));
+
+    // Restore persisted open tabs, filtering out deleted sessions
+    const persisted = getOpenTabIds().filter(id => sessionIds.has(id));
+    if (persisted.length > 0) {
+      setOpenTabIdsState(persisted);
+      setActiveTabId(persisted[0]);
+      return;
     }
+
+    // Fall back to the stored active chat or the first available session
+    const activeId = getActiveChatId();
+    if (activeId && sessionIds.has(activeId)) {
+      setOpenTabIdsState([activeId]);
+      setActiveTabId(activeId);
+      setOpenTabIds([activeId]);
+      return;
+    }
+
+    if (sessions.length > 0) {
+      const firstId = sessions[0].id;
+      setOpenTabIdsState([firstId]);
+      setActiveTabId(firstId);
+      setOpenTabIds([firstId]);
+      return;
+    }
+
+    // No sessions yet — create one so there is always an initial tab
+    const fresh = createChatSession('sonnet');
+    setOpenTabIdsState([fresh.id]);
+    setActiveTabId(fresh.id);
+    setOpenTabIds([fresh.id]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Persist open tabs whenever the list changes
+  useEffect(() => {
+    if (openTabIds.length > 0) setOpenTabIds(openTabIds);
+  }, [openTabIds]);
 
   const handleWelcomeComplete = useCallback(() => setShowWelcome(false), []);
-  const handleFocusToggle = useCallback((focused: boolean) => {
-    setFocusMode(focused);
-  }, []);
+  const handleFocusToggle = useCallback((focused: boolean) => setFocusMode(focused), []);
 
+  // Called from ChatHistory when the user clicks a past session —
+  // opens it as a new tab, or switches to an already-open tab.
   const handleSessionChange = useCallback((chatId: string) => {
-    setActiveChatId(chatId);
-    setChatKey(prev => prev + 1); // Force ChatInterface to re-mount with new session data
+    setOpenTabIdsState(prev => {
+      if (prev.includes(chatId)) {
+        setActiveTabId(chatId);
+        return prev;
+      }
+      const next = prev.length >= MAX_TABS ? prev : [...prev, chatId];
+      setActiveTabId(chatId);
+      return next;
+    });
   }, []);
 
-  const handleNewChat = useCallback(() => {
-    const session = createChatSession(model);
-    setActiveChatId(session.id);
-    setChatKey(prev => prev + 1);
+  const handleNewTab = useCallback(() => {
+    setOpenTabIdsState(prev => {
+      if (prev.length >= MAX_TABS) return prev;
+      const session = createChatSession(model);
+      setActiveTabId(session.id);
+      return [...prev, session.id];
+    });
   }, [model]);
+
+  // ChatHistory's onNewChat — same as opening a new tab
+  const handleNewChat = useCallback(() => handleNewTab(), [handleNewTab]);
+
+  const handleTabClose = useCallback((id: string) => {
+    setOpenTabIdsState(prev => {
+      const next = prev.filter(t => t !== id);
+      if (id === activeTabId) {
+        const idx = prev.indexOf(id);
+        setActiveTabId(next[idx - 1] ?? next[idx] ?? null);
+      }
+      return next;
+    });
+  }, [activeTabId]);
+
+  const handleTabSelect = useCallback((id: string) => setActiveTabId(id), []);
+
+  // Keyboard shortcuts: ⌘T = new tab, ⌘W = close tab, ⌘1-9 = switch
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (!e.metaKey && !e.ctrlKey) return;
+      if (e.key === 't' || e.key === 'T') {
+        if (openTabIds.length < MAX_TABS) { e.preventDefault(); handleNewTab(); }
+      } else if (e.key === 'w' || e.key === 'W') {
+        if (openTabIds.length > 1 && activeTabId) { e.preventDefault(); handleTabClose(activeTabId); }
+      } else {
+        const num = parseInt(e.key, 10);
+        if (num >= 1 && num <= 9) {
+          const target = openTabIds[num - 1];
+          if (target) { e.preventDefault(); setActiveTabId(target); }
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [openTabIds, activeTabId, handleNewTab, handleTabClose]);
 
   return (
     <>
@@ -94,23 +172,53 @@ export default function EnginePage() {
 
       <div className="h-[calc(100vh-64px)] lg:h-screen flex flex-col pb-6">
         <div className="flex-1 flex min-h-0">
-          {/* Chat Interface — left (main content) */}
-          <div className="flex-1 min-w-0">
-            <FocusMode onToggle={handleFocusToggle}>
-              <ChatInterface
-                key={chatKey}
-                chatId={activeChatId}
-                onModelChange={setModel}
+
+          {/* Chat area — left / main column */}
+          <div className="flex-1 min-w-0 flex flex-col min-h-0">
+
+            {/* Tab bar — only rendered when multiple tabs are open */}
+            {openTabIds.length > 1 && !focusMode && (
+              <ChatTabBar
+                openTabIds={openTabIds}
+                activeTabId={activeTabId}
+                onTabSelect={handleTabSelect}
+                onTabClose={handleTabClose}
+                onNewTab={handleNewTab}
+                maxTabs={MAX_TABS}
               />
-            </FocusMode>
+            )}
+
+            {/* Chat instances — all mounted; inactive ones are CSS-hidden to preserve state */}
+            <div className="flex-1 min-h-0">
+              <FocusMode onToggle={handleFocusToggle}>
+                <div className="h-full">
+                  {openTabIds.map(tabId => (
+                    <div
+                      key={tabId}
+                      className={tabId === activeTabId ? 'block h-full' : 'hidden'}
+                    >
+                      <ChatInterface
+                        key={tabId}
+                        chatId={tabId}
+                        onModelChange={setModel}
+                      />
+                    </div>
+                  ))}
+                  {/* Fallback: show blank ChatInterface if tabs haven't loaded yet */}
+                  {openTabIds.length === 0 && (
+                    <ChatInterface onModelChange={setModel} />
+                  )}
+                </div>
+              </FocusMode>
+            </div>
           </div>
 
-          {/* Right Panel — sticky, collapsible, mirrors left sidebar behaviour */}
+          {/* Right Panel — sticky, collapsible, mirrors left sidebar */}
           {!focusMode && (
             <div
               className={`hidden lg:flex shrink-0 flex-col border-l border-[var(--border)] bg-[var(--card)] sticky top-0 h-screen self-start transition-[width] duration-200 ease-in-out ${rightPanelCollapsed ? 'w-8' : 'w-[280px]'}`}
             >
-              {/* Collapse / expand toggle — always visible */}
+              {/* Collapse / expand toggle */}
               <button
                 onClick={toggleRightPanel}
                 title={rightPanelCollapsed ? 'Expand context panel (\u2318\u21E7B)' : 'Collapse context panel (\u2318\u21E7B)'}
@@ -121,15 +229,11 @@ export default function EnginePage() {
                   : <ChevronRight className="w-3 h-3" strokeWidth={1.5} />}
               </button>
 
-              {/* Panel content — hidden when collapsed */}
               {!rightPanelCollapsed && (
                 <>
-                  {/* Context Panel — fills remaining height */}
                   <div className="flex-1 min-h-0 overflow-y-auto">
                     <ContextPanel />
                   </div>
-
-                  {/* Chat History — pinned to bottom */}
                   <div className="h-[240px] shrink-0 border-t border-[var(--border)] p-3 overflow-hidden">
                     <span className="grip-label block mb-2">HISTORY</span>
                     <div className="h-[calc(100%-24px)]">
@@ -149,7 +253,7 @@ export default function EnginePage() {
         {!focusMode && <GripStatusBar skillCount={health.skillCount} />}
       </div>
 
-      {/* Mobile bottom toolbar — visible on small screens only */}
+      {/* Mobile bottom toolbar */}
       {!focusMode && <MobileToolbar />}
     </>
   );

--- a/src/components/Engine/ChatTabBar.tsx
+++ b/src/components/Engine/ChatTabBar.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { Plus, X, MessageSquare } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { getChatSessions, type ChatSession } from '@/lib/chat-storage';
+
+interface ChatTabBarProps {
+  openTabIds: string[];
+  activeTabId: string | null;
+  onTabSelect: (id: string) => void;
+  onTabClose: (id: string) => void;
+  onNewTab: () => void;
+  maxTabs?: number;
+}
+
+/**
+ * Tab bar for switching between concurrent chat sessions.
+ * Shown only when more than one tab is open.
+ * Swiss Nihilism: monospace labels, sharp borders, no decoration.
+ */
+export default function ChatTabBar({
+  openTabIds,
+  activeTabId,
+  onTabSelect,
+  onTabClose,
+  onNewTab,
+  maxTabs = 8,
+}: ChatTabBarProps) {
+  const [sessionMap, setSessionMap] = useState<Record<string, ChatSession>>({});
+
+  // Refresh session titles whenever the tab list changes
+  useEffect(() => {
+    const all = getChatSessions();
+    const map: Record<string, ChatSession> = {};
+    for (const s of all) map[s.id] = s;
+    setSessionMap(map);
+  }, [openTabIds]);
+
+  return (
+    <div className="flex items-stretch border-b border-[var(--border)] bg-[var(--card)] overflow-x-auto shrink-0 min-h-[32px]">
+      {openTabIds.map((id) => {
+        const session = sessionMap[id];
+        const title = session?.title ?? 'New Chat';
+        const isActive = id === activeTabId;
+
+        return (
+          <div
+            key={id}
+            role="tab"
+            tabIndex={0}
+            aria-selected={isActive}
+            onClick={() => onTabSelect(id)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onTabSelect(id); }
+            }}
+            className={`flex items-center gap-1.5 px-3 shrink-0 cursor-pointer border-r border-[var(--border)] transition-colors select-none group max-w-[160px] min-w-[80px] ${
+              isActive
+                ? 'bg-[var(--background)] text-[var(--foreground)] border-b-2 border-b-[var(--primary)] -mb-px'
+                : 'text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--secondary)]'
+            }`}
+          >
+            <MessageSquare className="w-3 h-3 shrink-0 opacity-40" strokeWidth={1.5} />
+            <span className="font-mono text-[10px] tracking-wider truncate flex-1 py-2">
+              {title.toUpperCase().slice(0, 20)}
+            </span>
+            {openTabIds.length > 1 && (
+              <button
+                onClick={(e) => { e.stopPropagation(); onTabClose(id); }}
+                className="shrink-0 opacity-0 group-hover:opacity-60 hover:!opacity-100 transition-opacity p-0.5 -mr-1 hover:text-[var(--danger)]"
+                aria-label={`Close tab: ${title}`}
+              >
+                <X className="w-2.5 h-2.5" strokeWidth={2} />
+              </button>
+            )}
+          </div>
+        );
+      })}
+
+      {/* New tab button — hidden when at max */}
+      {openTabIds.length < maxTabs && (
+        <button
+          onClick={onNewTab}
+          title="New chat tab (⌘T)"
+          aria-label="New chat tab"
+          className="flex items-center justify-center w-8 shrink-0 text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--secondary)] transition-colors border-r border-[var(--border)]"
+        >
+          <Plus className="w-3.5 h-3.5" strokeWidth={1.5} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/lib/chat-storage.ts
+++ b/src/lib/chat-storage.ts
@@ -25,6 +25,7 @@ export interface ChatSession {
 const CHATS_KEY = 'grip-chats';
 const ACTIVE_KEY = 'grip-active-chat';
 const CHAT_PREFIX = 'grip-chat-';
+const TABS_KEY = 'grip-open-tabs';
 const VERSION_KEY = 'grip-storage-version';
 const CURRENT_STORAGE_VERSION = 4;
 const MAX_CHATS = 50;
@@ -227,6 +228,25 @@ export function updateSessionId(chatId: string, sessionId: string): void {
     sessions[idx].sessionId = sessionId;
     localStorage.setItem(CHATS_KEY, JSON.stringify(sessions));
   }
+}
+
+/**
+ * Get the list of currently open tab IDs (persisted across reloads).
+ */
+export function getOpenTabIds(): string[] {
+  try {
+    const raw = localStorage.getItem(TABS_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Persist the open tab list.
+ */
+export function setOpenTabIds(ids: string[]): void {
+  localStorage.setItem(TABS_KEY, JSON.stringify(ids));
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a tab bar above the chat area, allowing up to 8 concurrent chat sessions open at once
- Each tab mounts its own `ChatInterface` instance; inactive tabs are CSS-hidden (not unmounted), so streaming state and in-progress input are preserved when switching
- Tab bar is hidden when only one tab is open — zero visual change for the default single-session workflow

## Changes

| File | Change |
|------|--------|
| `src/lib/chat-storage.ts` | `getOpenTabIds()` / `setOpenTabIds()` — persists open tab list across reloads |
| `src/components/Engine/ChatTabBar.tsx` | New tab strip component: open tabs, close button, new-tab (+) button |
| `src/app/page.tsx` | Replaces `activeChatId` + `chatKey` with `openTabIds[]` + `activeTabId`; single `FocusMode` wrapper; keyboard shortcuts |

## Keyboard shortcuts

| Shortcut | Action |
|----------|--------|
| `⌘T` | Open new tab |
| `⌘W` | Close active tab |
| `⌘1`–`⌘9` | Switch to tab N |

## Test plan

- [ ] Open second tab with `⌘T` — new empty chat appears, tab bar becomes visible
- [ ] Type in tab 1, switch to tab 2, switch back — input text preserved
- [ ] Start a stream in tab 1, switch to tab 2 — tab 1 stream continues in background
- [ ] Close tab with `⌘W` or `×` button — adjacent tab becomes active
- [ ] Reload page — open tabs are restored from localStorage
- [ ] Single-tab: tab bar is not rendered
- [ ] ChatHistory session click opens session as new tab
- [ ] `⌘Shift+B` right panel collapse still works
- [ ] Focus mode (`⌘Shift+F`) hides tab bar and right panel as expected