### PR TITLE
feat(w8a-refactor): singleton-to-registry IPC broadcast refactor

### DIFF
--- a/__tests__/electron/broadcast.test.ts
+++ b/__tests__/electron/broadcast.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Helpers ────────────────────────────────────────────────────────────
+type ClosedListener = () => void;
+
+interface MockWindow {
+  _closedListeners: ClosedListener[];
+  _destroyed: boolean;
+  isDestroyed: ReturnType<typeof vi.fn>;
+  webContents: { send: ReturnType<typeof vi.fn> };
+  once: ReturnType<typeof vi.fn>;
+  /** Fire the 'closed' event on this mock window. */
+  simulateClose(): void;
+  /** Pretend Electron has destroyed this window's webContents. */
+  simulateDestroy(): void;
+}
+
+function makeMockWindow(): MockWindow {
+  const win: MockWindow = {
+    _closedListeners: [],
+    _destroyed: false,
+    isDestroyed: vi.fn(() => win._destroyed),
+    webContents: { send: vi.fn() },
+    once: vi.fn((event: string, listener: ClosedListener) => {
+      if (event === 'closed') win._closedListeners.push(listener);
+    }),
+    simulateClose() {
+      win._destroyed = true;
+      win._closedListeners.forEach((fn) => fn());
+    },
+    simulateDestroy() {
+      win._destroyed = true;
+    },
+  };
+  return win;
+}
+
+// ── Electron mock ──────────────────────────────────────────────────────
+vi.mock('electron', () => ({
+  BrowserWindow: class {},
+}));
+
+// ── Import SUT after mocks ─────────────────────────────────────────────
+import {
+  registerWorkspaceWindow,
+  deregisterWorkspaceWindow,
+  getAllWorkspaceIds,
+  getWindowForWorkspace,
+  broadcastToAllWorkspaces,
+} from '../../electron/core/broadcast';
+
+// ── Reset registry between tests ───────────────────────────────────────
+beforeEach(() => {
+  // Deregister any workspace registered by previous tests
+  for (const id of getAllWorkspaceIds()) {
+    deregisterWorkspaceWindow(id);
+  }
+  vi.clearAllMocks();
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────
+describe('broadcast — window registry', () => {
+  it('registers a window and returns it', () => {
+    const win = makeMockWindow();
+    registerWorkspaceWindow('ws-1', win as never);
+
+    expect(getWindowForWorkspace('ws-1')).toBe(win);
+    expect(getAllWorkspaceIds()).toContain('ws-1');
+  });
+
+  it('deregisters a window explicitly', () => {
+    const win = makeMockWindow();
+    registerWorkspaceWindow('ws-1', win as never);
+    deregisterWorkspaceWindow('ws-1');
+
+    expect(getWindowForWorkspace('ws-1')).toBeNull();
+    expect(getAllWorkspaceIds()).not.toContain('ws-1');
+  });
+
+  it('auto-deregisters when the window fires its closed event', () => {
+    const win = makeMockWindow();
+    registerWorkspaceWindow('ws-auto', win as never);
+
+    win.simulateClose();
+
+    expect(getWindowForWorkspace('ws-auto')).toBeNull();
+    expect(getAllWorkspaceIds()).not.toContain('ws-auto');
+  });
+
+  it('returns null for an unknown workspaceId', () => {
+    expect(getWindowForWorkspace('does-not-exist')).toBeNull();
+  });
+
+  it('returns null for a destroyed window', () => {
+    const win = makeMockWindow();
+    registerWorkspaceWindow('ws-dead', win as never);
+    win.simulateDestroy();
+
+    expect(getWindowForWorkspace('ws-dead')).toBeNull();
+  });
+});
+
+describe('broadcastToAllWorkspaces', () => {
+  it('sends to a single registered window', () => {
+    const win = makeMockWindow();
+    registerWorkspaceWindow('ws-1', win as never);
+
+    broadcastToAllWorkspaces('test:event', { foo: 'bar' });
+
+    expect(win.webContents.send).toHaveBeenCalledWith('test:event', { foo: 'bar' });
+  });
+
+  it('sends to all registered windows', () => {
+    const a = makeMockWindow();
+    const b = makeMockWindow();
+    registerWorkspaceWindow('ws-a', a as never);
+    registerWorkspaceWindow('ws-b', b as never);
+
+    broadcastToAllWorkspaces('multi:event', 42);
+
+    expect(a.webContents.send).toHaveBeenCalledWith('multi:event', 42);
+    expect(b.webContents.send).toHaveBeenCalledWith('multi:event', 42);
+  });
+
+  it('is a no-op when the registry is empty', () => {
+    // No windows registered — must not throw
+    expect(() => broadcastToAllWorkspaces('empty:event')).not.toThrow();
+  });
+
+  /**
+   * §14.4 regression anchor — LOAD-BEARING guard:
+   *
+   * If window A is destroyed (webContents gone), broadcasting must NOT throw
+   * and must still deliver the event to window B. Without the isDestroyed()
+   * guard in broadcastToAllWorkspaces(), an uncaught exception in the main
+   * process silently prevents every subsequent window in the loop from
+   * receiving the event.
+   */
+  it('§14.4 — skips destroyed window and still delivers to live window', () => {
+    const dead = makeMockWindow();
+    const live = makeMockWindow();
+    registerWorkspaceWindow('ws-dead', dead as never);
+    registerWorkspaceWindow('ws-live', live as never);
+
+    // Simulate the window being destroyed without firing 'closed'
+    // (e.g. the process crashed — registry not yet cleaned up)
+    dead.simulateDestroy();
+
+    broadcastToAllWorkspaces('app:update-available', { version: '2.0.0' });
+
+    expect(dead.webContents.send).not.toHaveBeenCalled();
+    expect(live.webContents.send).toHaveBeenCalledWith('app:update-available', { version: '2.0.0' });
+  });
+
+  it('§14.4 — removes destroyed window from registry during broadcast', () => {
+    const dead = makeMockWindow();
+    registerWorkspaceWindow('ws-dead', dead as never);
+    dead.simulateDestroy();
+
+    broadcastToAllWorkspaces('any:event');
+
+    // Destroyed window should have been evicted from registry
+    expect(getAllWorkspaceIds()).not.toContain('ws-dead');
+  });
+
+  it('passes undefined payload when called without second argument', () => {
+    const win = makeMockWindow();
+    registerWorkspaceWindow('ws-1', win as never);
+
+    broadcastToAllWorkspaces('app:update-downloaded');
+
+    expect(win.webContents.send).toHaveBeenCalledWith('app:update-downloaded', undefined);
+  });
+});

--- a/__tests__/electron/update-checker.test.ts
+++ b/__tests__/electron/update-checker.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ── Hoisted mocks (available inside vi.mock factories) ─────────────
-const { mockAutoUpdater, mockFetch } = vi.hoisted(() => ({
+const { mockAutoUpdater, mockFetch, mockBroadcast } = vi.hoisted(() => ({
   mockAutoUpdater: {
     autoDownload: true,
     autoInstallOnAppQuit: false,
@@ -12,6 +12,7 @@ const { mockAutoUpdater, mockFetch } = vi.hoisted(() => ({
     quitAndInstall: vi.fn(),
   },
   mockFetch: vi.fn(),
+  mockBroadcast: vi.fn(),
 }));
 
 vi.mock('electron-updater', () => ({
@@ -19,14 +20,18 @@ vi.mock('electron-updater', () => ({
 }));
 
 vi.mock('electron', () => ({
-  BrowserWindow: vi.fn(),
-  app: {
-    getVersion: () => '1.2.1',
-  },
+  app: { getVersion: () => '1.2.1' },
 }));
 
 vi.mock('../../electron/constants', () => ({
   GITHUB_REPO: 'Charlie85270/dorothy',
+}));
+
+// W8a: update-checker now calls broadcastToAllWorkspaces instead of
+// targeting a specific window. Mock the broadcast module so tests can
+// verify the correct channel and payload are emitted.
+vi.mock('../../electron/core/broadcast', () => ({
+  broadcastToAllWorkspaces: mockBroadcast,
 }));
 
 vi.stubGlobal('fetch', mockFetch);
@@ -37,7 +42,6 @@ import {
   checkForUpdates,
   downloadUpdate,
   quitAndInstall,
-  setMainWindowGetter,
 } from '../../electron/services/update-checker';
 
 // Helper: capture event handlers registered via autoUpdater.on()
@@ -46,26 +50,17 @@ function getEventHandler(eventName: string) {
   return call ? call[1] : undefined;
 }
 
-// Helper: make a mock BrowserWindow
-function makeMockWindow() {
-  return {
-    webContents: {
-      send: vi.fn(),
-    },
-  } as unknown as Electron.BrowserWindow;
-}
-
 beforeEach(() => {
   vi.clearAllMocks();
   mockAutoUpdater.currentVersion = { version: '1.2.1' };
   mockFetch.mockReset();
+  mockBroadcast.mockReset();
 });
 
 describe('update-checker', () => {
   describe('initAutoUpdater', () => {
     it('registers event handlers on autoUpdater', () => {
-      const win = makeMockWindow();
-      initAutoUpdater(() => win);
+      initAutoUpdater();
 
       const events = mockAutoUpdater.on.mock.calls.map((call) => call[0] as string);
       expect(events).toContain('update-available');
@@ -75,14 +70,13 @@ describe('update-checker', () => {
       expect(events).toContain('error');
     });
 
-    it('sends app:update-available IPC on update-available event', () => {
-      const win = makeMockWindow();
-      initAutoUpdater(() => win);
+    it('broadcasts app:update-available on update-available event', () => {
+      initAutoUpdater();
 
       const handler = getEventHandler('update-available');
       handler({ version: '2.0.0', releaseNotes: 'New features' });
 
-      expect(win.webContents.send).toHaveBeenCalledWith('app:update-available', {
+      expect(mockBroadcast).toHaveBeenCalledWith('app:update-available', {
         currentVersion: '1.2.1',
         latestVersion: '2.0.0',
         releaseNotes: 'New features',
@@ -91,38 +85,35 @@ describe('update-checker', () => {
     });
 
     it('handles releaseNotes that are not a string', () => {
-      const win = makeMockWindow();
-      initAutoUpdater(() => win);
+      initAutoUpdater();
 
       const handler = getEventHandler('update-available');
       handler({ version: '2.0.0', releaseNotes: [{ note: 'something' }] });
 
-      expect(win.webContents.send).toHaveBeenCalledWith('app:update-available', expect.objectContaining({
+      expect(mockBroadcast).toHaveBeenCalledWith('app:update-available', expect.objectContaining({
         releaseNotes: '',
       }));
     });
 
-    it('sends app:update-not-available IPC', () => {
-      const win = makeMockWindow();
-      initAutoUpdater(() => win);
+    it('broadcasts app:update-not-available', () => {
+      initAutoUpdater();
 
       const handler = getEventHandler('update-not-available');
       handler({ version: '1.2.1' });
 
-      expect(win.webContents.send).toHaveBeenCalledWith('app:update-not-available', {
+      expect(mockBroadcast).toHaveBeenCalledWith('app:update-not-available', {
         currentVersion: '1.2.1',
         latestVersion: '1.2.1',
       });
     });
 
-    it('sends app:update-progress IPC with progress data', () => {
-      const win = makeMockWindow();
-      initAutoUpdater(() => win);
+    it('broadcasts app:update-progress with progress data', () => {
+      initAutoUpdater();
 
       const handler = getEventHandler('download-progress');
       handler({ percent: 42, bytesPerSecond: 1024000, transferred: 5000000, total: 12000000 });
 
-      expect(win.webContents.send).toHaveBeenCalledWith('app:update-progress', {
+      expect(mockBroadcast).toHaveBeenCalledWith('app:update-progress', {
         percent: 42,
         bytesPerSecond: 1024000,
         transferred: 5000000,
@@ -130,22 +121,13 @@ describe('update-checker', () => {
       });
     });
 
-    it('sends app:update-downloaded IPC', () => {
-      const win = makeMockWindow();
-      initAutoUpdater(() => win);
+    it('broadcasts app:update-downloaded', () => {
+      initAutoUpdater();
 
       const handler = getEventHandler('update-downloaded');
       handler();
 
-      expect(win.webContents.send).toHaveBeenCalledWith('app:update-downloaded');
-    });
-
-    it('does not crash when mainWindow is null', () => {
-      initAutoUpdater(() => null);
-
-      const handler = getEventHandler('update-available');
-      // Should not throw
-      expect(() => handler({ version: '2.0.0', releaseNotes: '' })).not.toThrow();
+      expect(mockBroadcast).toHaveBeenCalledWith('app:update-downloaded');
     });
   });
 
@@ -166,9 +148,6 @@ describe('update-checker', () => {
 
     it('falls back to GitHub API when autoUpdater throws', async () => {
       mockAutoUpdater.checkForUpdates.mockRejectedValue(new Error('Cannot find latest-mac.yml'));
-
-      const win = makeMockWindow();
-      setMainWindowGetter(() => win);
 
       mockFetch.mockResolvedValue({
         ok: true,
@@ -194,11 +173,8 @@ describe('update-checker', () => {
       );
     });
 
-    it('sends update-available IPC via fallback when newer version exists', async () => {
+    it('broadcasts update-available via fallback when newer version exists', async () => {
       mockAutoUpdater.checkForUpdates.mockRejectedValue(new Error('No yml'));
-
-      const win = makeMockWindow();
-      setMainWindowGetter(() => win);
 
       mockFetch.mockResolvedValue({
         ok: true,
@@ -214,7 +190,7 @@ describe('update-checker', () => {
 
       await checkForUpdates();
 
-      expect(win.webContents.send).toHaveBeenCalledWith('app:update-available', expect.objectContaining({
+      expect(mockBroadcast).toHaveBeenCalledWith('app:update-available', expect.objectContaining({
         currentVersion: '1.2.1',
         latestVersion: '2.0.0',
         hasUpdate: true,
@@ -223,11 +199,8 @@ describe('update-checker', () => {
       }));
     });
 
-    it('sends update-not-available IPC via fallback when on latest', async () => {
+    it('broadcasts update-not-available via fallback when on latest', async () => {
       mockAutoUpdater.checkForUpdates.mockRejectedValue(new Error('No yml'));
-
-      const win = makeMockWindow();
-      setMainWindowGetter(() => win);
 
       mockFetch.mockResolvedValue({
         ok: true,
@@ -241,7 +214,7 @@ describe('update-checker', () => {
 
       await checkForUpdates();
 
-      expect(win.webContents.send).toHaveBeenCalledWith('app:update-not-available', {
+      expect(mockBroadcast).toHaveBeenCalledWith('app:update-not-available', {
         currentVersion: '1.2.1',
         latestVersion: '1.2.1',
       });
@@ -249,8 +222,6 @@ describe('update-checker', () => {
 
     it('returns error when both autoUpdater and GitHub API fail', async () => {
       mockAutoUpdater.checkForUpdates.mockRejectedValue(new Error('No yml'));
-
-      setMainWindowGetter(() => null);
       mockFetch.mockResolvedValue({ ok: false, status: 403 });
 
       const result = await checkForUpdates();
@@ -259,8 +230,6 @@ describe('update-checker', () => {
 
     it('returns error when GitHub API fetch throws', async () => {
       mockAutoUpdater.checkForUpdates.mockRejectedValue(new Error('No yml'));
-
-      setMainWindowGetter(() => null);
       mockFetch.mockRejectedValue(new Error('Network error'));
 
       const result = await checkForUpdates();
@@ -274,9 +243,6 @@ describe('update-checker', () => {
     });
 
     it('detects patch update (1.2.1 → 1.2.2)', async () => {
-      const win = makeMockWindow();
-      setMainWindowGetter(() => win);
-
       mockFetch.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -289,16 +255,13 @@ describe('update-checker', () => {
 
       await checkForUpdates();
 
-      expect(win.webContents.send).toHaveBeenCalledWith('app:update-available', expect.objectContaining({
+      expect(mockBroadcast).toHaveBeenCalledWith('app:update-available', expect.objectContaining({
         hasUpdate: true,
         latestVersion: '1.2.2',
       }));
     });
 
     it('detects minor update (1.2.1 → 1.3.0)', async () => {
-      const win = makeMockWindow();
-      setMainWindowGetter(() => win);
-
       mockFetch.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -311,15 +274,12 @@ describe('update-checker', () => {
 
       await checkForUpdates();
 
-      expect(win.webContents.send).toHaveBeenCalledWith('app:update-available', expect.objectContaining({
+      expect(mockBroadcast).toHaveBeenCalledWith('app:update-available', expect.objectContaining({
         hasUpdate: true,
       }));
     });
 
     it('does not flag downgrade as update (1.2.1 → 1.1.0)', async () => {
-      const win = makeMockWindow();
-      setMainWindowGetter(() => win);
-
       mockFetch.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -332,16 +292,13 @@ describe('update-checker', () => {
 
       await checkForUpdates();
 
-      expect(win.webContents.send).toHaveBeenCalledWith('app:update-not-available', expect.objectContaining({
+      expect(mockBroadcast).toHaveBeenCalledWith('app:update-not-available', expect.objectContaining({
         currentVersion: '1.2.1',
         latestVersion: '1.1.0',
       }));
     });
 
     it('strips v prefix from tag_name', async () => {
-      const win = makeMockWindow();
-      setMainWindowGetter(() => win);
-
       mockFetch.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -354,15 +311,12 @@ describe('update-checker', () => {
 
       await checkForUpdates();
 
-      expect(win.webContents.send).toHaveBeenCalledWith('app:update-available', expect.objectContaining({
+      expect(mockBroadcast).toHaveBeenCalledWith('app:update-available', expect.objectContaining({
         latestVersion: '3.0.0',
       }));
     });
 
     it('prefers DMG asset over ZIP for download URL', async () => {
-      const win = makeMockWindow();
-      setMainWindowGetter(() => win);
-
       mockFetch.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -378,15 +332,12 @@ describe('update-checker', () => {
 
       await checkForUpdates();
 
-      expect(win.webContents.send).toHaveBeenCalledWith('app:update-available', expect.objectContaining({
+      expect(mockBroadcast).toHaveBeenCalledWith('app:update-available', expect.objectContaining({
         downloadUrl: 'https://example.com/Dorothy-2.0.0.dmg',
       }));
     });
 
     it('falls back to ZIP when no DMG asset', async () => {
-      const win = makeMockWindow();
-      setMainWindowGetter(() => win);
-
       mockFetch.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -401,15 +352,12 @@ describe('update-checker', () => {
 
       await checkForUpdates();
 
-      expect(win.webContents.send).toHaveBeenCalledWith('app:update-available', expect.objectContaining({
+      expect(mockBroadcast).toHaveBeenCalledWith('app:update-available', expect.objectContaining({
         downloadUrl: 'https://example.com/Dorothy-2.0.0.zip',
       }));
     });
 
     it('falls back to html_url when no assets', async () => {
-      const win = makeMockWindow();
-      setMainWindowGetter(() => win);
-
       mockFetch.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -422,7 +370,7 @@ describe('update-checker', () => {
 
       await checkForUpdates();
 
-      expect(win.webContents.send).toHaveBeenCalledWith('app:update-available', expect.objectContaining({
+      expect(mockBroadcast).toHaveBeenCalledWith('app:update-available', expect.objectContaining({
         downloadUrl: 'https://github.com/releases/v2.0.0',
       }));
     });

--- a/electron/core/agent-manager.ts
+++ b/electron/core/agent-manager.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as pty from 'node-pty';
 import { v4 as uuidv4 } from 'uuid';
 import { BrowserWindow, Notification } from 'electron';
+import { broadcastToAllWorkspaces } from './broadcast';
 import { AgentStatus, AppSettings } from '../types';
 import { AGENTS_FILE, DATA_DIR } from '../constants';
 import { ensureDataDir, isSuperAgent } from '../utils';
@@ -208,6 +209,8 @@ export function loadAgents() {
 
       agent.status = 'idle';
       agent.ptyId = undefined;
+      // W8a migration: assign 'default' workspace to all pre-W8a agents.
+      if (!agent.workspaceId) agent.workspaceId = 'default';
 
       agents.set(agent.id, agent);
     }
@@ -319,7 +322,7 @@ export async function initAgentPty(
       }
     }
     if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send('agent:output', {
+      broadcastToAllWorkspaces('agent:output', {
         type: 'output',
         agentId: agent.id,
         ptyId,
@@ -341,7 +344,7 @@ export async function initAgentPty(
     }
     ptyProcesses.delete(ptyId);
     if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send('agent:complete', {
+      broadcastToAllWorkspaces('agent:complete', {
         type: 'complete',
         agentId: agent.id,
         ptyId,

--- a/electron/core/broadcast.ts
+++ b/electron/core/broadcast.ts
@@ -1,0 +1,87 @@
+/**
+ * broadcast.ts — §13.5 Hybrid IPC routing via workspace window registry
+ *
+ * Replaces 62 singleton `mainWindow.webContents.send(...)` call sites with
+ * three routing patterns:
+ *
+ *   Pattern 1 — Agent-initiated: route to the owning workspace window.
+ *     getWindowForWorkspace(agent.workspaceId ?? 'default')?.webContents.send(...)
+ *
+ *   Pattern 2 — User-initiated: resolved at IPC handler invocation time.
+ *     BrowserWindow.fromWebContents(event.sender)?.webContents.send(...)
+ *
+ *   Pattern 3 — Service-initiated: broadcast to all workspace windows.
+ *     broadcastToAllWorkspaces(channel, payload)
+ *
+ * W8a-refactor baseline: all agents carry workspaceId = 'default'; the
+ * registry holds exactly one window. All three patterns produce identical
+ * output to the old singleton pattern in the single-workspace case.
+ *
+ * The isDestroyed() guard in broadcastToAllWorkspaces is LOAD-BEARING
+ * (§14.4): sending to a destroyed webContents throws an uncaught exception
+ * in the main process, which silently prevents every subsequent window in
+ * the loop from receiving the event.
+ */
+
+import { BrowserWindow } from 'electron';
+
+/** Module-level registry: workspaceId → BrowserWindow. */
+const windowRegistry = new Map<string, BrowserWindow>();
+
+// ─── Registry management ───────────────────────────────────────────────────
+
+/**
+ * Register a workspace window. Call immediately after BrowserWindow creation
+ * so the registry is always current. Auto-deregisters the window on 'closed'.
+ */
+export function registerWorkspaceWindow(workspaceId: string, window: BrowserWindow): void {
+  windowRegistry.set(workspaceId, window);
+  window.once('closed', () => deregisterWorkspaceWindow(workspaceId));
+}
+
+/**
+ * Remove a workspace window from the registry.
+ * Auto-called on the 'closed' event; can also be called explicitly.
+ */
+export function deregisterWorkspaceWindow(workspaceId: string): void {
+  windowRegistry.delete(workspaceId);
+}
+
+/**
+ * Return all currently registered workspace IDs.
+ * Useful for diagnostics and the concurrency-cap check (soft warn at 6th window).
+ */
+export function getAllWorkspaceIds(): string[] {
+  return Array.from(windowRegistry.keys());
+}
+
+// ─── Pattern 1 — Agent-initiated routing ──────────────────────────────────
+
+/**
+ * Return the BrowserWindow for the given workspaceId, or null if not found.
+ * Usage: getWindowForWorkspace(agent.workspaceId ?? 'default')?.webContents.send(...)
+ */
+export function getWindowForWorkspace(workspaceId: string): BrowserWindow | null {
+  const win = windowRegistry.get(workspaceId);
+  if (!win || win.isDestroyed()) return null;
+  return win;
+}
+
+// ─── Pattern 3 — Service-initiated broadcast ──────────────────────────────
+
+/**
+ * Send `channel` with `payload` to every registered workspace window.
+ * Safe to call when the registry is empty (no-op).
+ *
+ * Used by update-checker, slack-bot, telegram-bot, scheduler-handlers,
+ * api-server, and any service that does not know which workspace is relevant.
+ */
+export function broadcastToAllWorkspaces(channel: string, payload?: unknown): void {
+  for (const [wsId, win] of windowRegistry) {
+    if (win.isDestroyed()) {
+      windowRegistry.delete(wsId);
+      continue;
+    }
+    win.webContents.send(channel, payload);
+  }
+}

--- a/electron/core/pty-manager.ts
+++ b/electron/core/pty-manager.ts
@@ -2,6 +2,7 @@ import * as pty from 'node-pty';
 import { v4 as uuidv4 } from 'uuid';
 import * as os from 'os';
 import { BrowserWindow } from 'electron';
+import { broadcastToAllWorkspaces } from './broadcast';
 
 export const ptyProcesses: Map<string, pty.IPty> = new Map();
 export const quickPtyProcesses: Map<string, pty.IPty> = new Map();
@@ -92,13 +93,13 @@ export function createQuickPty(
 
   ptyProcess.onData((data) => {
     if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send('shell:ptyOutput', { ptyId: id, data });
+      broadcastToAllWorkspaces('shell:ptyOutput', { ptyId: id, data });
     }
   });
 
   ptyProcess.onExit(({ exitCode }) => {
     if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send('shell:ptyExit', { ptyId: id, exitCode });
+      broadcastToAllWorkspaces('shell:ptyExit', { ptyId: id, exitCode });
     }
     quickPtyProcesses.delete(id);
   });

--- a/electron/core/window-manager.ts
+++ b/electron/core/window-manager.ts
@@ -3,25 +3,33 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { getAppBasePath } from '../utils';
 import { MIME_TYPES } from '../constants';
+import { registerWorkspaceWindow, getWindowForWorkspace } from './broadcast';
 
 // Allowed origins for in-app navigation
 const ALLOWED_ORIGINS = ['http://localhost', 'app://-'];
 
-// Global reference to the main window
-let mainWindow: BrowserWindow | null = null;
+/**
+ * The workspace ID used for the initial window in the single-workspace baseline.
+ * All pre-W8a-ui agents are assigned this workspaceId on load.
+ */
+export const DEFAULT_WORKSPACE_ID = 'default';
 
 /**
- * Get the main window instance
+ * Get the main window instance.
+ * Backwards-compatible alias — returns the 'default' workspace window.
  */
 export function getMainWindow(): BrowserWindow | null {
-  return mainWindow;
+  return getWindowForWorkspace(DEFAULT_WORKSPACE_ID);
 }
 
 /**
- * Set the main window instance
+ * Set the main window instance.
+ * Kept for backwards-compatible call sites; registers the window in the
+ * broadcast registry under the 'default' workspace ID.
+ * Passing null is a no-op — deregistration happens automatically on 'closed'.
  */
 export function setMainWindow(window: BrowserWindow | null) {
-  mainWindow = window;
+  if (window) registerWorkspaceWindow(DEFAULT_WORKSPACE_ID, window);
 }
 
 /**
@@ -30,7 +38,7 @@ export function setMainWindow(window: BrowserWindow | null) {
 export function createWindow() {
   const isDarkMode = nativeTheme.shouldUseDarkColors;
 
-  mainWindow = new BrowserWindow({
+  const win = new BrowserWindow({
     width: 1600,
     height: 1000,
     minWidth: 1200,
@@ -48,8 +56,21 @@ export function createWindow() {
       preload: path.join(__dirname, '..', 'preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
+      // §13.3: inject workspace ID into renderer process.argv so
+      // workspace-context.ts can read it synchronously at import time.
+      // W8a-ui will pass the real workspace UUID here; for now 'default'
+      // establishes the single-workspace baseline.
+      additionalArguments: [`--grip-ws=${DEFAULT_WORKSPACE_ID}`],
     },
   });
+
+  // Register in the broadcast registry under the default workspace ID.
+  // This is the only registration site; setMainWindow() also calls
+  // registerWorkspaceWindow() but createWindow() always runs first.
+  registerWorkspaceWindow(DEFAULT_WORKSPACE_ID, win);
+
+  // Keep local variable for the rest of createWindow()'s setup code.
+  const mainWindow = win;
 
   // Show window with fade-in once content is ready (prevents white flash)
   mainWindow.once('ready-to-show', () => {
@@ -70,9 +91,8 @@ export function createWindow() {
     mainWindow.loadURL('app://-/index.html');
   }
 
-  mainWindow.on('closed', () => {
-    mainWindow = null;
-  });
+  // Deregistration from the broadcast registry happens automatically via the
+  // 'closed' listener registered in registerWorkspaceWindow(). No manual cleanup needed.
 
   // Navigation guards — prevent external URLs loading in the Electron window
   mainWindow.webContents.on('will-navigate', (event, url) => {
@@ -108,8 +128,9 @@ export function createWindow() {
  * Called from renderer via IPC to keep Electron window bg in sync with CSS theme.
  */
 export function updateWindowBackground(isDark: boolean): void {
-  if (!mainWindow) return;
-  mainWindow.setBackgroundColor(isDark ? '#0a0a0a' : '#EAEAEA');
+  const win = getWindowForWorkspace(DEFAULT_WORKSPACE_ID);
+  if (!win) return;
+  win.setBackgroundColor(isDark ? '#0a0a0a' : '#EAEAEA');
 }
 
 /**

--- a/electron/handlers/ipc-handlers.ts
+++ b/electron/handlers/ipc-handlers.ts
@@ -17,6 +17,7 @@ import { buildFullPath } from '../utils/path-builder';
 import { decodeProjectPath } from '../utils/decode-project-path';
 import { getProvider, getAllProviders } from '../providers';
 import { writeProgrammaticInput } from '../core/pty-manager';
+import { broadcastToAllWorkspaces } from '../core/broadcast';
 
 // Dependencies interface for dependency injection
 export interface IpcHandlerDependencies {
@@ -106,12 +107,12 @@ function registerPtyHandlers(deps: IpcHandlerDependencies): void {
 
     // Send data from PTY to renderer
     ptyProcess.onData((data) => {
-      getMainWindow()?.webContents.send('pty:data', { id, data });
+      broadcastToAllWorkspaces('pty:data', { id, data });
     });
 
     // Handle PTY exit
     ptyProcess.onExit(({ exitCode }) => {
-      getMainWindow()?.webContents.send('pty:exit', { id, exitCode });
+      broadcastToAllWorkspaces('pty:exit', { id, exitCode });
       ptyProcesses.delete(id);
     });
 
@@ -343,7 +344,7 @@ function registerAgentHandlers(deps: IpcHandlerDependencies): void {
         }
       }
 
-      getMainWindow()?.webContents.send('agent:output', {
+      broadcastToAllWorkspaces('agent:output', {
         type: 'output',
         agentId: id,
         ptyId,
@@ -361,7 +362,7 @@ function registerAgentHandlers(deps: IpcHandlerDependencies): void {
         agent.status = newStatus;
         agent.lastActivity = new Date().toISOString();
         handleStatusChangeNotification(agent, newStatus);
-        getMainWindow()?.webContents.send('agent:complete', {
+        broadcastToAllWorkspaces('agent:complete', {
           type: 'complete',
           agentId: id,
           ptyId,
@@ -479,7 +480,7 @@ function registerAgentHandlers(deps: IpcHandlerDependencies): void {
             }
           }
         }
-        getMainWindow()?.webContents.send('agent:output', {
+        broadcastToAllWorkspaces('agent:output', {
           type: 'output',
           agentId: id,
           ptyId: newPtyId,
@@ -498,7 +499,7 @@ function registerAgentHandlers(deps: IpcHandlerDependencies): void {
           handleStatusChangeNotification(agentData, newStatus);
         }
         ptyProcesses.delete(newPtyId);
-        getMainWindow()?.webContents.send('agent:complete', {
+        broadcastToAllWorkspaces('agent:complete', {
           type: 'complete',
           agentId: id,
           ptyId: newPtyId,
@@ -667,7 +668,7 @@ function registerAgentHandlers(deps: IpcHandlerDependencies): void {
       saveAgents();
 
       // Send status change notification to frontend immediately
-      getMainWindow()?.webContents.send('agent:status', {
+      broadcastToAllWorkspaces('agent:status', {
         type: 'status',
         agentId: id,
         status: 'idle',
@@ -807,12 +808,12 @@ function registerSkillHandlers(deps: IpcHandlerDependencies): void {
 
     // Forward PTY output to renderer
     ptyProcess.onData((data) => {
-      getMainWindow()?.webContents.send('skill:pty-data', { id, data });
+      broadcastToAllWorkspaces('skill:pty-data', { id, data });
     });
 
     // Handle PTY exit
     ptyProcess.onExit(({ exitCode }) => {
-      getMainWindow()?.webContents.send('skill:pty-exit', { id, exitCode });
+      broadcastToAllWorkspaces('skill:pty-exit', { id, exitCode });
       skillPtyProcesses.delete(id);
     });
 
@@ -968,12 +969,12 @@ function registerPluginHandlers(deps: IpcHandlerDependencies): void {
 
     // Forward PTY output to renderer
     ptyProcess.onData((data) => {
-      getMainWindow()?.webContents.send('plugin:pty-data', { id, data });
+      broadcastToAllWorkspaces('plugin:pty-data', { id, data });
     });
 
     // Handle PTY exit
     ptyProcess.onExit(({ exitCode }) => {
-      getMainWindow()?.webContents.send('plugin:pty-exit', { id, exitCode });
+      broadcastToAllWorkspaces('plugin:pty-exit', { id, exitCode });
       pluginPtyProcesses.delete(id);
     });
 
@@ -1256,7 +1257,7 @@ function registerAppSettingsHandlers(deps: IpcHandlerDependencies): void {
 
     // Notify frontend of settings change
     const mainWindow = getMainWindow();
-    mainWindow?.webContents.send('settings:updated', appSettings);
+    broadcastToAllWorkspaces('settings:updated', appSettings);
 
     return { success: true };
   });
@@ -1835,12 +1836,12 @@ function registerShellHandlers(deps: IpcHandlerDependencies): void {
 
     // Forward PTY output to renderer
     ptyProcess.onData((data) => {
-      getMainWindow()?.webContents.send('shell:ptyOutput', { ptyId: id, data });
+      broadcastToAllWorkspaces('shell:ptyOutput', { ptyId: id, data });
     });
 
     // Handle PTY exit
     ptyProcess.onExit(({ exitCode }) => {
-      getMainWindow()?.webContents.send('shell:ptyExit', { ptyId: id, exitCode });
+      broadcastToAllWorkspaces('shell:ptyExit', { ptyId: id, exitCode });
       quickPtyProcesses.delete(id);
     });
 

--- a/electron/handlers/kanban-handlers.ts
+++ b/electron/handlers/kanban-handlers.ts
@@ -1,4 +1,5 @@
 import { ipcMain, BrowserWindow } from 'electron';
+import { broadcastToAllWorkspaces } from '../core/broadcast';
 import * as fs from 'fs';
 import * as path from 'path';
 import { v4 as uuidv4 } from 'uuid';
@@ -101,7 +102,7 @@ function saveTasks(tasks: KanbanTask[]): void {
 }
 
 function emitTaskEvent(eventName: string, task: KanbanTask): void {
-  deps?.getMainWindow()?.webContents.send(eventName, task);
+  deps?.broadcastToAllWorkspaces(eventName, task);
 }
 
 /**
@@ -380,7 +381,7 @@ export function registerKanbanHandlers(dependencies: KanbanHandlerDependencies):
 
       saveTasks(tasks);
 
-      deps?.getMainWindow()?.webContents.send('kanban:task-deleted', { id });
+      deps?.broadcastToAllWorkspaces('kanban:task-deleted', { id });
 
       return { success: true };
     } catch (err) {

--- a/electron/handlers/scheduler-handlers.ts
+++ b/electron/handlers/scheduler-handlers.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 import { spawn } from 'child_process';
 import { v4 as uuidv4 } from 'uuid';
 import { getMainWindow } from '../core/window-manager';
+import { broadcastToAllWorkspaces } from '../core/broadcast';
 import { getProvider } from '../providers';
 import type { AgentProvider, AgentStatus, AppSettings } from '../types';
 import { posixQuote } from '../utils/shell';
@@ -1306,7 +1307,7 @@ export function registerSchedulerHandlers(deps: SchedulerDeps): void {
           const data = buffer.toString('utf-8');
           const mainWindow = getMainWindow();
           if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send('scheduler:log-data', { taskId, data });
+            broadcastToAllWorkspaces('scheduler:log-data', { taskId, data });
           }
         } catch {
           // File may have been deleted or rotated

--- a/electron/handlers/vault-handlers.ts
+++ b/electron/handlers/vault-handlers.ts
@@ -1,9 +1,10 @@
-import { ipcMain, BrowserWindow } from 'electron';
+import { ipcMain } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { getVaultDb } from '../services/vault-db';
 import { VAULT_DIR } from '../constants';
+import { broadcastToAllWorkspaces } from '../core/broadcast';
 
 // Types
 export interface VaultFolder {
@@ -42,7 +43,7 @@ export interface VaultHandlerDependencies {
 
 function emitVaultEvent(mainWindow: BrowserWindow | null, event: string, data: unknown) {
   if (mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.webContents.send(event, data);
+    broadcastToAllWorkspaces(event, data);
   }
 }
 

--- a/electron/handlers/world-handlers.ts
+++ b/electron/handlers/world-handlers.ts
@@ -1,4 +1,5 @@
 import { ipcMain, BrowserWindow, dialog, app } from 'electron';
+import { broadcastToAllWorkspaces } from '../core/broadcast';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -47,6 +47,7 @@ import {
   setupProtocolHandler,
   getMainWindow,
 } from './core/window-manager';
+import { broadcastToAllWorkspaces } from './core/broadcast';
 
 import {
   agents,
@@ -288,7 +289,6 @@ function createIpcDependencies(): IpcHandlerDependencies {
 
 function initApiServer() {
   startApiServer(
-    getMainWindow(),
     appSettings,
     getTelegramBot,
     getSlackApp,
@@ -374,7 +374,7 @@ app.whenReady().then(async () => {
         agent.lastActivity = new Date().toISOString();
         saveAgents();
 
-        getMainWindow()?.webContents.send('agent:status', {
+        broadcastToAllWorkspaces('agent:status', {
           type: 'status',
           agentId,
           status: 'idle',
@@ -473,7 +473,7 @@ app.whenReady().then(async () => {
           agent.output.push(data);
           agent.lastActivity = new Date().toISOString();
         }
-        getMainWindow()?.webContents.send('agent:output', {
+        broadcastToAllWorkspaces('agent:output', {
           type: 'output',
           agentId: id,
           ptyId,
@@ -492,13 +492,13 @@ app.whenReady().then(async () => {
         }
         ptyProcesses.delete(ptyId);
         // Emit status event so kanban sync can detect completion
-        getMainWindow()?.webContents.send('agent:status', {
+        broadcastToAllWorkspaces('agent:status', {
           type: 'status',
           agentId: id,
           status: exitCode === 0 ? 'completed' : 'error',
           timestamp: new Date().toISOString(),
         });
-        getMainWindow()?.webContents.send('agent:complete', {
+        broadcastToAllWorkspaces('agent:complete', {
           type: 'complete',
           agentId: id,
           ptyId,

--- a/electron/services/api-server.ts
+++ b/electron/services/api-server.ts
@@ -3,7 +3,8 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as crypto from 'crypto';
 import * as pty from 'node-pty';
-import { app, BrowserWindow } from 'electron';
+import { app } from 'electron';
+import { broadcastToAllWorkspaces } from '../core/broadcast';
 import { v4 as uuidv4 } from 'uuid';
 import TelegramBot from 'node-telegram-bot-api';
 import { App as SlackApp } from '@slack/bolt';
@@ -83,7 +84,6 @@ export function getApiToken(): string {
 }
 
 export function startApiServer(
-  mainWindow: BrowserWindow | null,
   appSettings: AppSettings,
   getTelegramBot: () => TelegramBot | null,
   getSlackApp: () => SlackApp | null,
@@ -320,10 +320,8 @@ export function startApiServer(
             agent.output = agent.output.slice(-5000);
           }
           agent.lastActivity = new Date().toISOString();
+            broadcastToAllWorkspaces('agent:output', { agentId: agent.id, data });
 
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send('agent:output', { agentId: agent.id, data });
-          }
         });
 
         ptyProcess.onExit(({ exitCode }) => {
@@ -641,14 +639,12 @@ export function startApiServer(
 
         if (oldStatus !== agent.status) {
           handleStatusChangeNotificationCallback(agent, agent.status);
-
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send('agent:status', {
+            broadcastToAllWorkspaces('agent:status', {
               agentId: agent.id,
               status: agent.status,
               waitingReason: waiting_reason
             });
-          }
+
         }
 
         sendJson({ success: true, agent: { id: agent.id, status: agent.status } });
@@ -699,15 +695,13 @@ export function startApiServer(
             );
           }
         }
-
-        if (mainWindow && !mainWindow.isDestroyed()) {
-          mainWindow.webContents.send('agent:notification', {
+          broadcastToAllWorkspaces('agent:notification', {
             agentId: agent?.id,
             type,
             title,
             message
           });
-        }
+
 
         sendJson({ success: true });
         return;
@@ -751,9 +745,8 @@ export function startApiServer(
           fs.writeFileSync(metadataPath, JSON.stringify(metadata, null, 2));
 
           // Emit to frontend
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send('scheduler:task-status', { taskId: task_id, status, summary });
-          }
+            broadcastToAllWorkspaces('scheduler:task-status', { taskId: task_id, status, summary });
+
 
           sendJson({ success: true });
         } catch (err) {
@@ -848,9 +841,8 @@ export function startApiServer(
           saveTasks(tasks);
 
           // Emit event to frontend
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send('kanban:task-updated', task);
-          }
+            broadcastToAllWorkspaces('kanban:task-updated', task);
+
 
           console.log(`[Kanban] Task "${task.title}" marked as complete via hook`);
           sendJson({ success: true, task });
@@ -925,9 +917,8 @@ export function startApiServer(
           const document = db.prepare('SELECT * FROM documents WHERE id = ?').get(id);
 
           // Emit event to frontend
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send('vault:document-created', document);
-          }
+            broadcastToAllWorkspaces('vault:document-created', document);
+
 
           sendJson({ success: true, document });
         } catch (err) {
@@ -982,10 +973,8 @@ export function startApiServer(
           db.prepare(`UPDATE documents SET ${updates.join(', ')} WHERE id = ?`).run(...values);
 
           const document = db.prepare('SELECT * FROM documents WHERE id = ?').get(docId);
+            broadcastToAllWorkspaces('vault:document-updated', document);
 
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send('vault:document-updated', document);
-          }
 
           sendJson({ success: true, document });
         } catch (err) {
@@ -1007,10 +996,8 @@ export function startApiServer(
           }
 
           db.prepare('DELETE FROM documents WHERE id = ?').run(docId);
+            broadcastToAllWorkspaces('vault:document-deleted', { id: docId });
 
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send('vault:document-deleted', { id: docId });
-          }
 
           sendJson({ success: true });
         } catch (err) {

--- a/electron/services/slack-bot.ts
+++ b/electron/services/slack-bot.ts
@@ -7,8 +7,8 @@ import { formatSlackAgentStatus, isSuperAgent, getSuperAgent, getSuperAgentInstr
 import { posixQuote } from '../utils/shell';
 import { agents, saveAgents, initAgentPty } from '../core/agent-manager';
 import { ptyProcesses, writeProgrammaticInput } from '../core/pty-manager';
-import { getMainWindow } from '../core/window-manager';
 import { app } from 'electron';
+import { broadcastToAllWorkspaces } from '../core/broadcast';
 
 // Slack bot state
 let slackApp: SlackApp | null = null;
@@ -140,7 +140,7 @@ export function initSlackBot(
       if (appSettings.slackChannelId !== event.channel) {
         appSettings.slackChannelId = event.channel;
         onSettingsChanged(appSettings);
-        mainWindow?.webContents.send('settings:updated', appSettings);
+        broadcastToAllWorkspaces('settings:updated', appSettings);
       }
 
       await handleSlackCommand(text, event.channel, say, appSettings, mainWindow);
@@ -173,7 +173,7 @@ export function initSlackBot(
       if (appSettings.slackChannelId !== channel) {
         appSettings.slackChannelId = channel;
         onSettingsChanged(appSettings);
-        mainWindow?.webContents.send('settings:updated', appSettings);
+        broadcastToAllWorkspaces('settings:updated', appSettings);
       }
 
       await sendToSuperAgentFromSlack(channel, msg.text, say, appSettings, mainWindow);

--- a/electron/services/telegram-bot.ts
+++ b/electron/services/telegram-bot.ts
@@ -10,6 +10,7 @@ import { isSuperAgent, formatAgentStatus, getSuperAgentInstructions, getTelegram
 import { posixQuote } from '../utils/shell';
 import { getProvider } from '../providers';
 import { writeProgrammaticInput } from '../core/pty-manager';
+import { broadcastToAllWorkspaces } from '../core/broadcast';
 
 // ============== Telegram Bot State ==============
 let telegramBot: TelegramBot | null = null;
@@ -437,7 +438,7 @@ export function initTelegramBot() {
           // Also update legacy field for backwards compatibility
           appSettings.telegramChatId = chatId;
           saveAppSettings(appSettings);
-          mainWindow?.webContents.send('settings:updated', appSettings);
+          broadcastToAllWorkspaces('settings:updated', appSettings);
         }
 
         telegramBot?.sendMessage(chatId,

--- a/electron/services/update-checker.ts
+++ b/electron/services/update-checker.ts
@@ -1,15 +1,16 @@
 import { autoUpdater, UpdateInfo } from 'electron-updater';
-import { BrowserWindow, app } from 'electron';
+import { app } from 'electron';
 import { GITHUB_REPO } from '../constants';
+import { broadcastToAllWorkspaces } from '../core/broadcast';
 
 // Don't download until user clicks "Download"
 autoUpdater.autoDownload = false;
 // Install on next quit after download completes
 autoUpdater.autoInstallOnAppQuit = true;
 
-export function initAutoUpdater(getMainWindow: () => BrowserWindow | null) {
+export function initAutoUpdater() {
   autoUpdater.on('update-available', (info: UpdateInfo) => {
-    getMainWindow()?.webContents.send('app:update-available', {
+    broadcastToAllWorkspaces('app:update-available', {
       currentVersion: autoUpdater.currentVersion.version,
       latestVersion: info.version,
       releaseNotes: typeof info.releaseNotes === 'string' ? info.releaseNotes : '',
@@ -18,14 +19,14 @@ export function initAutoUpdater(getMainWindow: () => BrowserWindow | null) {
   });
 
   autoUpdater.on('update-not-available', (info: UpdateInfo) => {
-    getMainWindow()?.webContents.send('app:update-not-available', {
+    broadcastToAllWorkspaces('app:update-not-available', {
       currentVersion: autoUpdater.currentVersion.version,
       latestVersion: info.version,
     });
   });
 
   autoUpdater.on('download-progress', (progress) => {
-    getMainWindow()?.webContents.send('app:update-progress', {
+    broadcastToAllWorkspaces('app:update-progress', {
       percent: progress.percent,
       bytesPerSecond: progress.bytesPerSecond,
       transferred: progress.transferred,
@@ -34,7 +35,7 @@ export function initAutoUpdater(getMainWindow: () => BrowserWindow | null) {
   });
 
   autoUpdater.on('update-downloaded', () => {
-    getMainWindow()?.webContents.send('app:update-downloaded');
+    broadcastToAllWorkspaces('app:update-downloaded');
   });
 
   autoUpdater.on('error', (err) => {
@@ -48,7 +49,7 @@ export function initAutoUpdater(getMainWindow: () => BrowserWindow | null) {
  * Fallback: check GitHub releases API directly (same as pre-electron-updater).
  * Used when autoUpdater fails (e.g. missing latest-mac.yml on older releases).
  */
-async function checkGitHubRelease(mainWindow: BrowserWindow | null) {
+async function checkGitHubRelease() {
   const currentVersion = app.getVersion();
   const url = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
   const response = await fetch(url, {
@@ -92,22 +93,12 @@ async function checkGitHubRelease(mainWindow: BrowserWindow | null) {
   };
 
   if (hasUpdate) {
-    mainWindow?.webContents.send('app:update-available', info);
+    broadcastToAllWorkspaces('app:update-available', info);
   } else {
-    mainWindow?.webContents.send('app:update-not-available', {
-      currentVersion,
-      latestVersion,
-    });
+    broadcastToAllWorkspaces('app:update-not-available', { currentVersion, latestVersion });
   }
 
   return info;
-}
-
-// Store a reference so the fallback can access mainWindow
-let _getMainWindow: (() => BrowserWindow | null) | null = null;
-
-export function setMainWindowGetter(fn: () => BrowserWindow | null) {
-  _getMainWindow = fn;
 }
 
 export async function checkForUpdates() {
@@ -123,8 +114,7 @@ export async function checkForUpdates() {
     // Fall back to direct GitHub API check.
     console.warn('autoUpdater failed, falling back to GitHub API:', (err as Error).message);
     try {
-      const mainWindow = _getMainWindow?.() ?? null;
-      const info = await checkGitHubRelease(mainWindow);
+      const info = await checkGitHubRelease();
       if (!info) {
         return { error: true };
       }

--- a/electron/types/index.ts
+++ b/electron/types/index.ts
@@ -29,6 +29,7 @@ export interface AgentStatus {
   provider?: AgentProvider;   // 'claude' (default) or 'local' (Tasmania)
   localModel?: string;        // Tasmania model name when provider is 'local'
   obsidianVaultPaths?: string[]; // Obsidian vault paths to mount via --add-dir (read-only)
+  workspaceId?: string;       // W8a: owning workspace window ID; 'default' for single-window baseline
 }
 
 export interface CLIPaths {

--- a/electron/utils/index.ts
+++ b/electron/utils/index.ts
@@ -1,15 +1,17 @@
-import { app, Notification, BrowserWindow } from 'electron';
+import { app, Notification } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 import { AgentStatus } from '../types';
 import { TG_CHARACTER_FACES, SLACK_CHARACTER_FACES, DATA_DIR, OLD_DATA_DIR, LEGACY_DATA_DIR } from '../constants';
+import { broadcastToAllWorkspaces, getWindowForWorkspace } from '../core/broadcast';
 
-let mainWindow: BrowserWindow | null = null;
-
-export function setMainWindow(window: BrowserWindow | null) {
-  mainWindow = window;
-}
+/**
+ * Kept for backwards compatibility — main.ts calls setUtilsMainWindow(getMainWindow()).
+ * No longer needed now that sendNotification uses getWindowForWorkspace('default')
+ * directly. Safe to remove in W8a-ui when main.ts is fully updated.
+ */
+export function setMainWindow(_window: unknown) { /* no-op */ }
 
 export function getAppBasePath(): string {
   let appPath = app.getAppPath();
@@ -337,11 +339,12 @@ export function sendNotification(
   });
 
   notification.on('click', () => {
-    if (mainWindow) {
-      if (mainWindow.isMinimized()) mainWindow.restore();
-      mainWindow.focus();
+    const win = getWindowForWorkspace('default');
+    if (win) {
+      if (win.isMinimized()) win.restore();
+      win.focus();
       if (agentId) {
-        mainWindow.webContents.send('agent:focus', { agentId });
+        broadcastToAllWorkspaces('agent:focus', { agentId });
       }
     }
   });

--- a/src/lib/workspace-context.ts
+++ b/src/lib/workspace-context.ts
@@ -1,0 +1,39 @@
+/**
+ * workspace-context.ts — §13.3 Workspace ID transport via additionalArguments
+ *
+ * The Electron main process injects `--grip-ws=<uuid>` into the BrowserWindow
+ * via `webPreferences.additionalArguments`. Electron merges these into the
+ * renderer's `process.argv` before any renderer code runs, so this module
+ * resolves the workspace ID synchronously at import time — no async, no race.
+ *
+ * The custom `app://` protocol handler (window-manager.ts) strips query strings,
+ * so `?ws=<uuid>` would silently drop. `additionalArguments` survives because it
+ * is injected at the Chromium layer, not the URL layer (§13.3 of W8-MULTI-SESSION.md).
+ *
+ * CRITICAL — RSC footgun (§14.2): this file reads `process.argv` which is only
+ * populated by Electron in the RENDERER process. React Server Components run in
+ * a separate Node.js process where `additionalArguments` is absent. If an RSC
+ * imports WORKSPACE_ID directly, it silently resolves to 'default' with no error.
+ *
+ * Rule: this file MUST only be imported from Client Components ('use client').
+ * The WorkspaceProvider in W8a-ui will wrap the app root and distribute the
+ * value via React context so Server Components never need to import this directly.
+ *
+ * Null case: if the flag is absent (dev mode without workspace support, unit
+ * tests), WORKSPACE_ID falls back to 'default'. Callers must treat 'default'
+ * as a valid workspace ID, not an error.
+ */
+
+'use client';
+
+const FLAG_PREFIX = '--grip-ws=';
+
+const arg = typeof process !== 'undefined'
+  ? process.argv?.find((a) => a.startsWith(FLAG_PREFIX))
+  : undefined;
+
+/**
+ * The workspace ID for this BrowserWindow, resolved from additionalArguments.
+ * Guaranteed to be a non-empty string; 'default' when no flag is present.
+ */
+export const WORKSPACE_ID: string = arg?.slice(FLAG_PREFIX.length) ?? 'default';


### PR DESCRIPTION
## Summary

- Replaces 62 `mainWindow.webContents.send()` call sites with a workspace window registry (`electron/core/broadcast.ts`) and `broadcastToAllWorkspaces()` helper per W8-MULTI-SESSION.md §13.5
- Adds `src/lib/workspace-context.ts` for client-side workspace ID resolution via `additionalArguments`
- Removes `setMainWindowGetter` pattern from `update-checker`; removes `mainWindow` parameter from `startApiServer()`; keeps `getMainWindow`/`setMainWindow` as backwards-compatible aliases
- No UI changes, no behaviour changes — single-workspace baseline: all agents carry `workspaceId='default'`, registry holds exactly one window

## Test plan

- [x] `broadcast.test.ts` (NEW, 11 tests): registry lifecycle + §14.4 regression anchor — destroyed window skipped, live window still receives event
- [x] `update-checker.test.ts` (REWRITTEN, 22 tests): now mocks `broadcastToAllWorkspaces` instead of `window.webContents.send`
- [x] All 33 tests pass locally

## Notes

The `isDestroyed()` guard in `broadcastToAllWorkspaces` is **load-bearing** (§14.4): sending to a destroyed `webContents` throws an uncaught exception in the main process that silently prevents every subsequent window in the loop from receiving the event. The regression test explicitly covers this case.

This is PR 1/3 in the W8a sequence: W8a-refactor → W8a-ui → W8a-modes.