### PR TITLE
ci: cross-platform build hardening + native-arch verifier (fixes v0.4.0 DMG)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,15 @@
 name: Build Release
 
+# Cross-platform DMG / NSIS / AppImage + deb build.
+#
+# Each matrix entry runs on a dedicated fresh runner with its own node_modules,
+# so native modules (better-sqlite3, node-pty) can never contaminate across
+# architectures. scripts/verify-native-arch.mjs runs after packaging and fails
+# the job if any .node file inside the artefact doesn't match the target.
+#
+# Triggered by: tag push (v*) -> publishes release artefacts, or manual dispatch
+# -> uploads per-job artefacts for download without publishing.
+
 on:
   push:
     tags:
@@ -7,105 +17,125 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag (e.g. v0.4.0)'
+        description: 'Version tag (e.g. v0.4.1) — informational only, artefacts use package.json version'
         required: false
 
 permissions:
   contents: write
 
 jobs:
-  build-mac:
-    name: Mac (arm64 + x64)
-    runs-on: macos-latest
+  build:
+    name: ${{ matrix.platform }} ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      # Do not cancel sibling jobs when one arch fails — we want to know which
+      # platform+arch combinations break so we can fix them in one PR cycle.
+      fail-fast: false
+      matrix:
+        include:
+          - platform: mac
+            arch: arm64
+            runner: macos-14          # arm64 runner (Apple Silicon)
+            target: dmg
+          - platform: mac
+            arch: x64
+            runner: macos-13          # x64 runner (Intel) — must be Intel for native x64 rebuild
+            target: dmg
+          - platform: win
+            arch: x64
+            runner: windows-latest
+            target: nsis
+          - platform: linux
+            arch: x64
+            runner: ubuntu-latest
+            target: appimage
+
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
-      - run: npm ci
-      - run: npm run build
 
-      - name: Build Mac DMG (arm64)
-        run: npx electron-builder --mac dmg --arm64
+      # --------------------------------------------------------------------
+      # Linux-only: electron-builder needs a handful of native deps for
+      # AppImage / deb + some sandbox libraries that don't ship with ubuntu-latest.
+      # --------------------------------------------------------------------
+      - name: Install Linux build deps
+        if: matrix.platform == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libopenjp2-tools fakeroot rpm dpkg \
+            libnss3 libatk-bridge2.0-0 libgtk-3-0 libasound2t64 || \
+          sudo apt-get install -y --no-install-recommends \
+            libopenjp2-tools fakeroot rpm dpkg \
+            libnss3 libatk-bridge2.0-0 libgtk-3-0 libasound2
+
+      - name: Clean install
+        run: npm ci --no-audit --no-fund
+
+      # --------------------------------------------------------------------
+      # Build via the extracted script (Bash is available on all 3 OSes
+      # via actions/setup-node's shell defaults — Windows uses Git Bash).
+      # --------------------------------------------------------------------
+      - name: Build ${{ matrix.platform }} ${{ matrix.arch }} (${{ matrix.target }})
+        shell: bash
         env:
           SKIP_NOTARIZE: '1'
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+        run: |
+          chmod +x scripts/build-electron.sh
+          scripts/build-electron.sh ${{ matrix.platform }} ${{ matrix.arch }} ${{ matrix.target }}
 
-      - name: Build Mac DMG (x64)
-        run: npx electron-builder --mac dmg --x64
-        env:
-          SKIP_NOTARIZE: '1'
+      # --------------------------------------------------------------------
+      # Independent verifier step — even if build-electron.sh's internal
+      # verify step is skipped (SKIP_VERIFY=1), this job-level step will
+      # catch arch mismatches and fail the release.
+      # --------------------------------------------------------------------
+      - name: Verify native module architecture
+        shell: bash
+        run: node scripts/verify-native-arch.mjs --platform ${{ matrix.platform }} --arch ${{ matrix.arch }} --dir release
 
-      - name: Upload Mac artifacts
+      - name: Upload ${{ matrix.platform }}-${{ matrix.arch }} artefacts
         uses: actions/upload-artifact@v4
         with:
-          name: mac-builds
+          name: ${{ matrix.platform }}-${{ matrix.arch }}
           path: |
             release/*.dmg
             release/*.dmg.blockmap
-
-  build-linux:
-    name: Linux (x64)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run build
-
-      - name: Build Linux deb + AppImage
-        run: npx electron-builder --linux deb AppImage --x64
-
-      - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: linux-builds
-          path: |
-            release/*.deb
-            release/*.AppImage
-
-  build-windows:
-    name: Windows (x64)
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run build
-
-      - name: Build Windows NSIS installer
-        run: npx electron-builder --win nsis --x64
-
-      - name: Upload Windows artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-builds
-          path: |
             release/*.exe
             release/*.exe.blockmap
+            release/*.AppImage
+            release/*.deb
+            release/*.zip
+          if-no-files-found: error
 
   release:
     name: Upload to GitHub Release
-    needs: [build-mac, build-linux, build-windows]
+    needs: [build]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - name: Download all artifacts
+      - name: Download all artefacts
         uses: actions/download-artifact@v4
         with:
-          path: artifacts
+          path: artefacts
 
-      - name: Upload to release
+      - name: List downloaded artefacts
+        run: find artefacts -type f | sort
+
+      - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            artifacts/mac-builds/*
-            artifacts/linux-builds/*
-            artifacts/windows-builds/*
+            artefacts/**/*.dmg
+            artefacts/**/*.dmg.blockmap
+            artefacts/**/*.exe
+            artefacts/**/*.exe.blockmap
+            artefacts/**/*.AppImage
+            artefacts/**/*.deb
+            artefacts/**/*.zip
           fail_on_unmatched_files: false
+          generate_release_notes: true

--- a/__tests__/electron/handlers/vault-handlers.test.ts
+++ b/__tests__/electron/handlers/vault-handlers.test.ts
@@ -45,6 +45,14 @@ vi.mock('../../../electron/constants', () => ({
   VAULT_DIR: '/mock/vault',
 }));
 
+// After the multi-session refactor (commit 26b56c6), vault events are emitted
+// via broadcastToAllWorkspaces instead of mainWindow.webContents.send directly.
+// Mock the broadcast function so tests can assert event emission.
+const mockBroadcastToAllWorkspaces = vi.fn();
+vi.mock('../../../electron/core/broadcast', () => ({
+  broadcastToAllWorkspaces: mockBroadcastToAllWorkspaces,
+}));
+
 function invokeHandler(channel: string, ...args: unknown[]): Promise<unknown> {
   const fn = handlers.get(channel);
   if (!fn) throw new Error(`No handler for "${channel}"`);
@@ -170,7 +178,7 @@ describe('vault-handlers', () => {
 
       expect(result.success).toBe(true);
       expect(result.document).toEqual(createdDoc);
-      expect(mockMainWindow.webContents.send).toHaveBeenCalledWith('vault:document-created', createdDoc);
+      expect(mockBroadcastToAllWorkspaces).toHaveBeenCalledWith('vault:document-created', createdDoc);
     });
 
     it('returns error on failure', async () => {
@@ -204,7 +212,7 @@ describe('vault-handlers', () => {
 
       expect(result.success).toBe(true);
       expect(result.document).toEqual(updated);
-      expect(mockMainWindow.webContents.send).toHaveBeenCalledWith('vault:document-updated', updated);
+      expect(mockBroadcastToAllWorkspaces).toHaveBeenCalledWith('vault:document-updated', updated);
     });
 
     it('returns error for non-existent document', async () => {
@@ -229,7 +237,7 @@ describe('vault-handlers', () => {
       const result = await invokeHandler('vault:deleteDocument', 'del-1') as { success: boolean };
 
       expect(result.success).toBe(true);
-      expect(mockMainWindow.webContents.send).toHaveBeenCalledWith('vault:document-deleted', { id: 'del-1' });
+      expect(mockBroadcastToAllWorkspaces).toHaveBeenCalledWith('vault:document-deleted', { id: 'del-1' });
     });
   });
 

--- a/__tests__/scripts/verify-native-arch.test.ts
+++ b/__tests__/scripts/verify-native-arch.test.ts
@@ -14,7 +14,7 @@ import { tmpdir } from 'node:os';
 // The verifier is an ES module (.mjs). Vitest's esbuild transform handles the
 // cross-extension import transparently.
 // @ts-expect-error - .mjs import without declaration file
-import { detectNativeArch, walkNativeModules } from '../../scripts/verify-native-arch.mjs';
+import { detectNativeArch, walkNativeModules, isPrebuildPath } from '../../scripts/verify-native-arch.mjs';
 
 // ---------------------------------------------------------------------------
 // Header builders — minimum valid bytes for each format we care about.
@@ -184,6 +184,28 @@ describe('walkNativeModules', () => {
     const nonexistent = join(tmpRoot, 'does-not-exist');
     const found = [...walkNativeModules(nonexistent)];
     expect(found).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isPrebuildPath — node-pty-style multi-platform prebuild bundles
+// ---------------------------------------------------------------------------
+
+describe('isPrebuildPath', () => {
+  it('recognises node-pty prebuilds/<platform-arch>/ paths', () => {
+    expect(isPrebuildPath('release/mac-arm64/app.asar.unpacked/node_modules/node-pty/prebuilds/win32-x64/pty.node')).toBe(true);
+    expect(isPrebuildPath('release/mac-arm64/app.asar.unpacked/node_modules/node-pty/prebuilds/darwin-arm64/pty.node')).toBe(true);
+    expect(isPrebuildPath('release/mac-arm64/app.asar.unpacked/node_modules/node-pty/prebuilds/linux-x64/conpty.node')).toBe(true);
+  });
+
+  it('does NOT match active native module paths', () => {
+    expect(isPrebuildPath('release/mac-arm64/app.asar.unpacked/node_modules/better-sqlite3/build/Release/better_sqlite3.node')).toBe(false);
+    expect(isPrebuildPath('release/mac-arm64/app.asar.unpacked/node_modules/node-pty/build/Release/pty.node')).toBe(false);
+    expect(isPrebuildPath('release/mac-arm64/app.asar.unpacked/node_modules/node-pty/bin/darwin-arm64-130/node-pty.node')).toBe(false);
+  });
+
+  it('handles Windows-style path separators', () => {
+    expect(isPrebuildPath('release\\mac-arm64\\node_modules\\node-pty\\prebuilds\\win32-x64\\pty.node')).toBe(true);
   });
 });
 

--- a/__tests__/scripts/verify-native-arch.test.ts
+++ b/__tests__/scripts/verify-native-arch.test.ts
@@ -1,0 +1,208 @@
+// Tests for scripts/verify-native-arch.mjs — the post-build guard that would
+// have caught the v0.4.0 DMG regression (Windows PE32+ better_sqlite3.node
+// shipped inside an arm64 macOS DMG).
+//
+// Strategy: write minimal valid native-module headers to temp files and assert
+// the detector returns the right (platform, arch) tuple. Also covers the
+// cross-platform mismatch case that is the actual bug we're protecting against.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// The verifier is an ES module (.mjs). Vitest's esbuild transform handles the
+// cross-extension import transparently.
+// @ts-expect-error - .mjs import without declaration file
+import { detectNativeArch, walkNativeModules } from '../../scripts/verify-native-arch.mjs';
+
+// ---------------------------------------------------------------------------
+// Header builders — minimum valid bytes for each format we care about.
+// ---------------------------------------------------------------------------
+
+function machoArm64(): Buffer {
+  // MH_MAGIC_64 = 0xFEEDFACF. Header layout: magic, cputype, cpusubtype, filetype, ncmds, sizeofcmds, flags, reserved.
+  const buf = Buffer.alloc(32);
+  buf.writeUInt32LE(0xFEEDFACF, 0);      // magic (little-endian encoding)
+  buf.writeInt32LE(0x0100000C, 4);       // CPU_TYPE_ARM64
+  return buf;
+}
+
+function machoX64(): Buffer {
+  const buf = Buffer.alloc(32);
+  buf.writeUInt32LE(0xFEEDFACF, 0);
+  buf.writeInt32LE(0x01000007, 4);       // CPU_TYPE_X86_64
+  return buf;
+}
+
+function machoUniversal(): Buffer {
+  // Fat header: magic (BE), nfat_arch, then N × fat_arch_64 entries (20 bytes each).
+  const buf = Buffer.alloc(8 + 20 * 2);
+  buf.writeUInt32BE(0xCAFEBABE, 0);      // MACHO_FAT magic
+  buf.writeUInt32BE(2, 4);               // 2 sub-architectures
+  buf.writeInt32BE(0x01000007, 8);       // arch 0: x86_64
+  buf.writeInt32BE(0x0100000C, 28);      // arch 1: arm64
+  return buf;
+}
+
+function peX64(): Buffer {
+  // Minimum PE: MZ header at 0, PE offset at 0x3C, PE signature + machine type.
+  const buf = Buffer.alloc(0x80);
+  buf[0] = 0x4D; buf[1] = 0x5A;          // 'MZ'
+  buf.writeUInt32LE(0x40, 0x3C);         // PE header offset
+  buf.writeUInt32LE(0x00004550, 0x40);   // 'PE\0\0'
+  buf.writeUInt16LE(0x8664, 0x44);       // IMAGE_FILE_MACHINE_AMD64
+  return buf;
+}
+
+function peArm64(): Buffer {
+  const buf = Buffer.alloc(0x80);
+  buf[0] = 0x4D; buf[1] = 0x5A;
+  buf.writeUInt32LE(0x40, 0x3C);
+  buf.writeUInt32LE(0x00004550, 0x40);
+  buf.writeUInt16LE(0xAA64, 0x44);       // IMAGE_FILE_MACHINE_ARM64
+  return buf;
+}
+
+function elfX64(): Buffer {
+  // ELF header: \x7fELF, class, data, ..., machine at offset 18.
+  const buf = Buffer.alloc(64);
+  buf[0] = 0x7F; buf[1] = 0x45; buf[2] = 0x4C; buf[3] = 0x46;
+  buf[4] = 0x02;                          // EI_CLASS = 64-bit
+  buf[5] = 0x01;                          // EI_DATA = little-endian
+  buf.writeUInt16LE(0x3E, 18);           // EM_X86_64
+  return buf;
+}
+
+function elfArm64(): Buffer {
+  const buf = Buffer.alloc(64);
+  buf[0] = 0x7F; buf[1] = 0x45; buf[2] = 0x4C; buf[3] = 0x46;
+  buf[4] = 0x02; buf[5] = 0x01;
+  buf.writeUInt16LE(0xB7, 18);           // EM_AARCH64
+  return buf;
+}
+
+// ---------------------------------------------------------------------------
+// Temp fixture
+// ---------------------------------------------------------------------------
+
+let tmpRoot: string;
+beforeAll(() => { tmpRoot = mkdtempSync(join(tmpdir(), 'verify-arch-')); });
+afterAll(() => { rmSync(tmpRoot, { recursive: true, force: true }); });
+
+function writeTemp(name: string, data: Buffer): string {
+  const p = join(tmpRoot, name);
+  mkdirSync(join(p, '..'), { recursive: true });
+  writeFileSync(p, data);
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// detectNativeArch
+// ---------------------------------------------------------------------------
+
+describe('detectNativeArch', () => {
+  it('identifies Mach-O arm64', () => {
+    const p = writeTemp('macho-arm64.node', machoArm64());
+    expect(detectNativeArch(p)).toMatchObject({ format: 'macho', platform: 'darwin', arch: 'arm64' });
+  });
+
+  it('identifies Mach-O x86_64', () => {
+    const p = writeTemp('macho-x64.node', machoX64());
+    expect(detectNativeArch(p)).toMatchObject({ format: 'macho', platform: 'darwin', arch: 'x64' });
+  });
+
+  it('identifies Mach-O universal binary and enumerates contained arches', () => {
+    const p = writeTemp('macho-universal.node', machoUniversal());
+    const r = detectNativeArch(p);
+    expect(r.format).toBe('macho');
+    expect(r.platform).toBe('darwin');
+    expect(r.arch).toBe('universal');
+    expect(r.universal).toEqual(expect.arrayContaining(['x64', 'arm64']));
+  });
+
+  it('identifies PE32+ x64 (the v0.4.0 regression case)', () => {
+    const p = writeTemp('win32-x64.node', peX64());
+    expect(detectNativeArch(p)).toMatchObject({ format: 'pe', platform: 'win32', arch: 'x64' });
+  });
+
+  it('identifies PE arm64', () => {
+    const p = writeTemp('win32-arm64.node', peArm64());
+    expect(detectNativeArch(p)).toMatchObject({ format: 'pe', platform: 'win32', arch: 'arm64' });
+  });
+
+  it('identifies ELF x86_64', () => {
+    const p = writeTemp('elf-x64.node', elfX64());
+    expect(detectNativeArch(p)).toMatchObject({ format: 'elf', platform: 'linux', arch: 'x64' });
+  });
+
+  it('identifies ELF aarch64', () => {
+    const p = writeTemp('elf-arm64.node', elfArm64());
+    expect(detectNativeArch(p)).toMatchObject({ format: 'elf', platform: 'linux', arch: 'arm64' });
+  });
+
+  it('returns unknown for files that are not native modules', () => {
+    const p = writeTemp('garbage.node', Buffer.from('hello world, not a binary'));
+    expect(detectNativeArch(p)).toMatchObject({ format: 'unknown', arch: 'unknown' });
+  });
+
+  it('returns unknown for truncated files without crashing', () => {
+    const p = writeTemp('tiny.node', Buffer.from([0x7F, 0x45])); // 2 bytes
+    const r = detectNativeArch(p);
+    expect(r.format).toBe('unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// walkNativeModules
+// ---------------------------------------------------------------------------
+
+describe('walkNativeModules', () => {
+  it('finds all .node files recursively under a release-like tree', () => {
+    // Simulate: release/mac-arm64/GRIP Commander.app/Contents/.../better-sqlite3.node
+    //          release/mac-arm64/GRIP Commander.app/Contents/.../node-pty.node
+    //          release/ignored.txt (should be ignored)
+    const base = join(tmpRoot, 'walk-fixture');
+    const deep = join(base, 'mac-arm64', 'app', 'Contents', 'Resources', 'app.asar.unpacked',
+                      'node_modules', 'better-sqlite3', 'build', 'Release');
+    mkdirSync(deep, { recursive: true });
+    writeFileSync(join(deep, 'better_sqlite3.node'), machoArm64());
+
+    const ptyDir = join(base, 'mac-arm64', 'app', 'Contents', 'Resources', 'app.asar.unpacked',
+                        'node_modules', 'node-pty', 'build', 'Release');
+    mkdirSync(ptyDir, { recursive: true });
+    writeFileSync(join(ptyDir, 'pty.node'), machoArm64());
+
+    writeFileSync(join(base, 'ignored.txt'), 'not a native module');
+
+    const found = [...walkNativeModules(base)];
+    expect(found).toHaveLength(2);
+    expect(found.every(p => p.endsWith('.node'))).toBe(true);
+  });
+
+  it('yields nothing when the root directory does not exist', () => {
+    const nonexistent = join(tmpRoot, 'does-not-exist');
+    const found = [...walkNativeModules(nonexistent)];
+    expect(found).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: the bug that motivated this file
+// ---------------------------------------------------------------------------
+
+describe('v0.4.0 regression: Windows DLL in macOS DMG', () => {
+  it('flags a Windows PE32+ binary as NOT matching darwin-arm64', () => {
+    const p = writeTemp('regression-better-sqlite3.node', peX64());
+    const det = detectNativeArch(p);
+
+    // The exact state we saw in the field: native module detected as win32-x64,
+    // expected darwin-arm64. This is the failure mode the verifier exists to catch.
+    expect(det.platform).toBe('win32');
+    expect(det.arch).toBe('x64');
+
+    // Cross-platform mismatch — verifier must fail the build.
+    const matchesTarget = (det.platform === 'darwin' && det.arch === 'arm64');
+    expect(matchesTarget).toBe(false);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -19,11 +19,17 @@
     "test:coverage": "vitest run --coverage",
     "electron:dev": "concurrently \"npm run dev\" \"npm run electron:start\"",
     "electron:start": "wait-on http://localhost:3000 && tsc -p electron/tsconfig.json && NODE_ENV=development electron .",
-    "electron:build": "bash -c 'set -e; mv src/app/api src/app/_api_backup; mv src/app/icon.tsx src/app/_icon_backup.tsx 2>/dev/null || true; trap \"mv src/app/_api_backup src/app/api 2>/dev/null; mv src/app/_icon_backup.tsx src/app/icon.tsx 2>/dev/null\" EXIT; ELECTRON_BUILD=1 next build; tsc -p electron/tsconfig.json; cd mcp-orchestrator && npm install && npm run build && cd ..; cd mcp-telegram && npm install && npm run build && cd ..; cd mcp-kanban && npm install && npm run build && cd ..; cd mcp-vault && npm install && npm run build && cd ..; cd mcp-socialdata && npm install && npm run build && cd ..; cd mcp-x && npm install && npm run build && cd ..; cd mcp-world && npm install && npm run build && cd ..; electron-builder --mac'",
-    "electron:pack": "tsc -p electron/tsconfig.json && cd mcp-orchestrator && npm install && npm run build && cd .. && cd mcp-telegram && npm install && npm run build && cd .. && cd mcp-kanban && npm install && npm run build && cd .. && cd mcp-vault && npm install && npm run build && cd .. && cd mcp-socialdata && npm install && npm run build && cd .. && cd mcp-x && npm install && npm run build && cd .. && cd mcp-world && npm install && npm run build && cd .. && electron-builder --dir --mac",
+    "electron:build": "bash scripts/build-electron.sh mac arm64 dmg",
+    "electron:pack": "bash scripts/build-electron.sh mac arm64 dir",
     "commander:dev": "concurrently \"npm run dev\" \"npm run electron:start\"",
-    "commander:pack": "SKIP_NOTARIZE=1 CSC_IDENTITY_AUTO_DISCOVERY=false bash -c 'set -e; mv src/app/api src/app/_api_backup; mv src/app/icon.tsx src/app/_icon_backup.tsx 2>/dev/null || true; trap \"mv src/app/_api_backup src/app/api 2>/dev/null; mv src/app/_icon_backup.tsx src/app/icon.tsx 2>/dev/null\" EXIT; ELECTRON_BUILD=1 next build; tsc -p electron/tsconfig.json; cd mcp-orchestrator && npm install && npm run build && cd ..; cd mcp-telegram && npm install && npm run build && cd ..; cd mcp-kanban && npm install && npm run build && cd ..; cd mcp-vault && npm install && npm run build && cd ..; cd mcp-socialdata && npm install && npm run build && cd ..; cd mcp-x && npm install && npm run build && cd ..; cd mcp-world && npm install && npm run build && cd ..; electron-builder --mac --dir'",
-    "commander:dmg": "SKIP_NOTARIZE=1 CSC_IDENTITY_AUTO_DISCOVERY=false bash -c 'set -e; mv src/app/api src/app/_api_backup; mv src/app/icon.tsx src/app/_icon_backup.tsx 2>/dev/null || true; trap \"mv src/app/_api_backup src/app/api 2>/dev/null; mv src/app/_icon_backup.tsx src/app/icon.tsx 2>/dev/null\" EXIT; ELECTRON_BUILD=1 next build; tsc -p electron/tsconfig.json; cd mcp-orchestrator && npm install && npm run build && cd ..; cd mcp-telegram && npm install && npm run build && cd ..; cd mcp-kanban && npm install && npm run build && cd ..; cd mcp-vault && npm install && npm run build && cd ..; cd mcp-socialdata && npm install && npm run build && cd ..; cd mcp-x && npm install && npm run build && cd ..; cd mcp-world && npm install && npm run build && cd ..; electron-builder --mac dmg'"
+    "commander:pack": "bash scripts/build-electron.sh mac arm64 dir",
+    "commander:dmg": "bash scripts/build-electron.sh mac arm64 dmg",
+    "commander:dmg:x64": "bash scripts/build-electron.sh mac x64 dmg",
+    "build:electron:mac:arm64": "bash scripts/build-electron.sh mac arm64 dmg",
+    "build:electron:mac:x64": "bash scripts/build-electron.sh mac x64 dmg",
+    "build:electron:win:x64": "bash scripts/build-electron.sh win x64 nsis",
+    "build:electron:linux:x64": "bash scripts/build-electron.sh linux x64 appimage",
+    "verify:native-arch": "node scripts/verify-native-arch.mjs"
   },
   "build": {
     "appId": "co.codetonight.grip",

--- a/plans/xplat-ci-native-arch-hardening.md
+++ b/plans/xplat-ci-native-arch-hardening.md
@@ -1,0 +1,110 @@
+# GRIP Commander Cross-Platform CI + Native-Arch Hardening
+
+## Context
+
+v0.4.0 DMG shipped a **Windows PE32+ DLL** as `better_sqlite3.node` on arm64
+macOS. Runtime impact: `ERR_DLOPEN_FAILED` at startup → `registerIpcHandlers`
+cascade fails → every `grip:*` / `vault:*` IPC channel reports "No handler
+registered". Symptom the user sees: "GRIP Error: Electron IPC error: Error
+invoking remote method 'grip:prompt': Error: No handler registered for
+'grip:prompt'".
+
+Root cause: v0.4.0 was built locally via `commander:dmg` from a dev tree whose
+root `node_modules/better-sqlite3/build/Release/` had been contaminated by a
+prior Windows build. `commander:dmg` does not clean `node_modules`, does not
+run `@electron/rebuild`, and has no post-build arch verification.
+
+The freshly-added `.github/workflows/build.yml` (commit fbd4071) was intended
+to fix this but has three distinct defects that would produce broken DMGs if
+anyone tagged `v0.4.1` today:
+
+1. **Missing electron main compilation.** The CI step runs `npm run build`,
+   which is `next build` — it does NOT run `tsc -p electron/tsconfig.json`
+   (main process) or build the 7 MCP submodules. Packaged DMGs would be
+   missing `electron/dist/**` entirely.
+2. **No native rebuild step.** electron-builder relies on its implicit
+   `install-app-deps`, but there is no explicit guarantee that native
+   modules are rebuilt for the target platform/arch — and no failure signal
+   if they are not.
+3. **Sequential arm64/x64 in one job.** `npx electron-builder --mac dmg --arm64`
+   followed by `--x64` share a single `node_modules`. The second run
+   overwrites `better_sqlite3.node` with x64 artefacts; if it fails silently,
+   the "x64" DMG ships arm64 binaries.
+
+## Hypotheses
+
+| ID | Claim | Metric | Prediction | Verification |
+|----|-------|--------|------------|--------------|
+| H-XP1 | The current `build.yml` would produce a non-launching DMG because `electron/dist/` would be empty | packaged app has electron main | absent on `v0.4.1` CI run | Fixed before any tag is pushed |
+| H-XP2 | Per-arch matrix jobs with explicit `@electron/rebuild` produce DMGs where every `.node` inside `app.asar.unpacked/node_modules/**/build/Release/` matches the target arch | verifier exit code | 0 for all 4 platforms (darwin-arm64, darwin-x64, win32-x64, linux-x64) | `scripts/verify-native-arch.mjs` as CI step |
+| H-XP3 | Refactoring the 20-line bash one-liner in `commander:dmg` into `scripts/build-electron.sh` reduces the chance of silent step-failure and makes the build reproducible | set -euo pipefail + individual step exit | any failing step aborts the build, surfaces in stderr | Test locally on arm64 |
+| H-XP4 | The verifier, if it had existed at v0.4.0, would have caught the Windows DLL before release | test case: Windows PE32+ in darwin-arm64 build | test fails with non-zero exit | Unit test in Vitest |
+
+## Fibonacci Waves
+
+### W1 — FAST (depth=1): CI workflow rewrite (`.github/workflows/build.yml`)
+
+Target: a workflow that actually produces working, arch-correct DMGs.
+
+- Use per-platform, per-arch matrix jobs instead of sequential steps within one job.
+- Each job: fresh checkout → `npm ci` → `bash scripts/build-electron.sh <platform> <arch>` (which handles tsc + mcp submodules + electron-rebuild) → `npx electron-builder --$platform --$arch` → `node scripts/verify-native-arch.mjs` → upload artefact.
+- Tag-triggered release job gated on all matrix entries succeeding + verifier passing.
+
+### W2 — FAST (depth=1): Build script extraction (`scripts/build-electron.sh`)
+
+Target: single source of truth for local and CI builds.
+
+- Replace the bash one-liner embedded in `commander:dmg` / `commander:pack` / `electron:build` with `scripts/build-electron.sh`.
+- Script accepts `--platform` and `--arch` flags; defaults to host.
+- `set -euo pipefail`. Each step (next build / tsc / mcp submodules / electron-rebuild / electron-builder) is its own function with explicit error handling.
+- New npm scripts `build:electron:mac`, `build:electron:win`, `build:electron:linux` wrap it.
+
+### W3 — CAREFUL (depth=2): Native-arch verifier (`scripts/verify-native-arch.mjs`)
+
+Target: catch any wrong-arch native module before shipping.
+
+- Walks every `.node` file in `release/**/app.asar.unpacked/node_modules/**/build/Release/` after electron-builder packages the app.
+- For each, computes arch via Mach-O magic bytes (darwin) / PE32 signature (win32) / ELF header (linux) — pure JS, no native deps, works on any CI runner.
+- Compares against the expected target (read from package.json build config or CLI args).
+- Exits non-zero with a readable diff if any file is wrong-arch.
+- Covered by Vitest unit tests in `scripts/__tests__/verify-native-arch.test.mjs`.
+
+### W4 — SHIP (commit → PR → merge → tag)
+
+- Commits granular per wave so bisect works.
+- PR to `main` with this plan linked.
+- Admin merge (protected branch pattern consistent with other CodeTonight repos).
+- User decides when to tag `v0.4.1` — the new CI will produce the correct artefacts.
+
+## Local unblock (for the user right now, not part of CI fix)
+
+Two options to get v0.4.0 working on the user's installed copy while the CI
+fix is pending:
+
+**A. In-place native rebuild** (fast, fragile if /Applications is locked):
+
+```bash
+cd "/Applications/GRIP Commander.app/Contents/Resources/app.asar.unpacked/node_modules/better-sqlite3"
+sudo npx @electron/rebuild -v 35.7.5 -m . -t prod -w better-sqlite3
+file build/Release/better_sqlite3.node  # expect: Mach-O 64-bit bundle arm64
+```
+
+**B. Local clean rebuild + DMG** (matches what v0.4.1 CI will produce):
+
+```bash
+cd ~/CodeTonight/GRIP-GUI
+rm -rf node_modules package-lock.json
+npm install
+npx @electron/rebuild
+npm run commander:dmg
+open release/*.dmg
+```
+
+## Falsification criteria
+
+This plan is wrong if:
+
+- The verifier misidentifies the arch of a valid prebuild (false positive blocks a correct release).
+- `@electron/rebuild` fails on CI runners for one of the 4 targets (platform-specific breakage we didn't anticipate).
+- The matrix spread inflates CI minute cost beyond what CodeTonight is willing to spend per release.
+- electron-builder already handles everything correctly and the v0.4.0 contamination was entirely a local-build issue that won't recur in CI. (If so: the verifier is still cheap insurance.)

--- a/scripts/build-electron.sh
+++ b/scripts/build-electron.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# build-electron.sh — single source of truth for GRIP Commander packaging.
+#
+# Runs the full electron-builder pipeline: stash Next.js API/icon routes, build
+# renderer + main process + MCP submodules, rebuild native modules for the
+# target platform/arch, then package via electron-builder.
+#
+# Usage:
+#   scripts/build-electron.sh <platform> <arch> [mode]
+#
+#     platform := mac | win | linux          (required)
+#     arch     := arm64 | x64                (required)
+#     mode     := dmg | nsis | deb | appimage | dir
+#                 (default: platform-native primary target)
+#
+# Examples:
+#   scripts/build-electron.sh mac arm64 dmg
+#   scripts/build-electron.sh win x64 nsis
+#   scripts/build-electron.sh linux x64 appimage
+#   scripts/build-electron.sh mac arm64 dir        # unpacked, faster for iteration
+#
+# Environment:
+#   SKIP_NOTARIZE=1   Skip macOS notarisation (default in CI)
+#   SKIP_VERIFY=1     Skip post-build native-arch verifier (not recommended)
+#   GRIP_DEBUG=1      Enable set -x
+#
+# Exit codes: 0 success, non-zero = failing step (set -euo pipefail aborts).
+
+set -euo pipefail
+
+if [[ "${GRIP_DEBUG:-0}" == "1" ]]; then
+  set -x
+fi
+
+PLATFORM="${1:-}"
+ARCH="${2:-}"
+MODE="${3:-}"
+
+if [[ -z "$PLATFORM" || -z "$ARCH" ]]; then
+  echo "usage: $0 <mac|win|linux> <arm64|x64> [mode]" >&2
+  exit 2
+fi
+
+case "$PLATFORM" in
+  mac|win|linux) ;;
+  *) echo "unknown platform: $PLATFORM" >&2; exit 2 ;;
+esac
+
+case "$ARCH" in
+  arm64|x64) ;;
+  *) echo "unknown arch: $ARCH" >&2; exit 2 ;;
+esac
+
+# Default target per platform.
+if [[ -z "$MODE" ]]; then
+  case "$PLATFORM" in
+    mac)   MODE="dmg" ;;
+    win)   MODE="nsis" ;;
+    linux) MODE="appimage" ;;
+  esac
+fi
+
+# Resolve repo root so the script works regardless of cwd.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+MCP_SUBMODULES=(mcp-orchestrator mcp-telegram mcp-kanban mcp-vault mcp-socialdata mcp-x mcp-world)
+
+# -----------------------------------------------------------------------------
+# API route / icon.tsx stash: Next.js API routes and the React icon route are
+# incompatible with electron's static export. Move them aside for the build
+# and restore on exit regardless of outcome.
+# -----------------------------------------------------------------------------
+
+stash_incompatible_routes() {
+  [[ -d src/app/api ]] && mv src/app/api src/app/_api_backup
+  [[ -f src/app/icon.tsx ]] && mv src/app/icon.tsx src/app/_icon_backup.tsx
+  return 0
+}
+
+restore_incompatible_routes() {
+  [[ -d src/app/_api_backup ]] && mv src/app/_api_backup src/app/api
+  [[ -f src/app/_icon_backup.tsx ]] && mv src/app/_icon_backup.tsx src/app/icon.tsx
+  return 0
+}
+
+trap restore_incompatible_routes EXIT
+
+# -----------------------------------------------------------------------------
+# Build pipeline steps. Each is its own function so the failing step surfaces
+# clearly in CI logs instead of being hidden inside a multiline bash string.
+# -----------------------------------------------------------------------------
+
+step_next_build() {
+  echo "==> [1/5] Next.js renderer build"
+  ELECTRON_BUILD=1 npx next build
+}
+
+step_tsc_main() {
+  echo "==> [2/5] TypeScript compile — electron main process"
+  npx tsc -p electron/tsconfig.json
+}
+
+step_mcp_submodules() {
+  echo "==> [3/5] Build MCP submodules (${#MCP_SUBMODULES[@]})"
+  for sub in "${MCP_SUBMODULES[@]}"; do
+    if [[ ! -d "$sub" ]]; then
+      echo "  ! skipping $sub (directory missing)" >&2
+      continue
+    fi
+    echo "  --> $sub"
+    (cd "$sub" && npm install --no-audit --no-fund && npm run build)
+  done
+}
+
+step_rebuild_natives() {
+  echo "==> [4/5] @electron/rebuild native modules for $PLATFORM-$ARCH"
+  # Map our platform token to electron's platform token.
+  local ep_platform
+  case "$PLATFORM" in
+    mac)   ep_platform="darwin" ;;
+    win)   ep_platform="win32" ;;
+    linux) ep_platform="linux" ;;
+  esac
+  npx @electron/rebuild \
+    --arch "$ARCH" \
+    --platform "$ep_platform" \
+    --force
+}
+
+step_electron_builder() {
+  echo "==> [5/5] electron-builder $PLATFORM $MODE --$ARCH"
+  local flag
+  case "$PLATFORM" in
+    mac)   flag="--mac" ;;
+    win)   flag="--win" ;;
+    linux) flag="--linux" ;;
+  esac
+  # --publish never: publishing is a separate concern, gated on verifier success.
+  npx electron-builder "$flag" "$MODE" "--$ARCH" --publish never
+}
+
+step_verify_arch() {
+  if [[ "${SKIP_VERIFY:-0}" == "1" ]]; then
+    echo "==> Skipping native-arch verifier (SKIP_VERIFY=1)"
+    return 0
+  fi
+  echo "==> Post-build: verify native modules match $PLATFORM-$ARCH"
+  node scripts/verify-native-arch.mjs --platform "$PLATFORM" --arch "$ARCH"
+}
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+
+echo "==================================================================="
+echo "GRIP Commander build: platform=$PLATFORM arch=$ARCH mode=$MODE"
+echo "==================================================================="
+
+stash_incompatible_routes
+step_next_build
+step_tsc_main
+step_mcp_submodules
+step_rebuild_natives
+step_electron_builder
+step_verify_arch
+
+echo "==================================================================="
+echo "Build complete. Artefacts in release/"
+ls -lh release/ 2>/dev/null || true
+echo "==================================================================="

--- a/scripts/verify-native-arch.mjs
+++ b/scripts/verify-native-arch.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+// verify-native-arch.mjs — post-build guard against wrong-arch native modules.
+//
+// Walks the packaged release/ directory and inspects every `.node` file
+// inside `app.asar.unpacked/node_modules/**`. Compares the detected arch
+// against the expected (target) arch and exits non-zero if any mismatch.
+//
+// This would have caught the v0.4.0 DMG regression where
+// `better_sqlite3.node` shipped as a Windows PE32+ x64 DLL inside an
+// arm64 macOS DMG, causing ERR_DLOPEN_FAILED at startup and the
+// ipcMain.handle cascade to abort silently.
+//
+// Usage:
+//   node scripts/verify-native-arch.mjs --platform mac --arch arm64
+//   node scripts/verify-native-arch.mjs --platform win --arch x64 --dir release
+//
+// Exits 0 on success, 1 on mismatch, 2 on usage error.
+//
+// No native deps; works on any Node 18+ runner.
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const out = { platform: null, arch: null, dir: 'release', strict: true };
+  for (let i = 2; i < argv.length; i++) {
+    const k = argv[i];
+    const v = argv[i + 1];
+    switch (k) {
+      case '--platform': out.platform = v; i++; break;
+      case '--arch':     out.arch = v; i++; break;
+      case '--dir':      out.dir = v; i++; break;
+      case '--no-strict': out.strict = false; break;
+      case '-h':
+      case '--help':
+        console.log('usage: verify-native-arch.mjs --platform <mac|win|linux> --arch <arm64|x64> [--dir release]');
+        process.exit(0);
+      default:
+        if (k.startsWith('--')) {
+          console.error(`unknown flag: ${k}`);
+          process.exit(2);
+        }
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Header detection
+// ---------------------------------------------------------------------------
+
+// Mach-O magic constants
+const MACHO_MAGIC_64 = 0xFEEDFACF;
+const MACHO_CIGAM_64 = 0xCFFAEDFE;        // little-endian reversed
+const MACHO_MAGIC_32 = 0xFEEDFACE;
+const MACHO_CIGAM_32 = 0xCEFAEDFE;
+const MACHO_FAT      = 0xCAFEBABE;        // universal binary
+const MACHO_FAT_REV  = 0xBEBAFECA;
+
+// Mach-O CPU types (per <mach/machine.h>)
+const CPU_TYPE_X86_64 = 0x01000007;
+const CPU_TYPE_ARM64  = 0x0100000C;
+
+// ELF machine types
+const EM_X86_64 = 0x3E;
+const EM_AARCH64 = 0xB7;
+
+// PE machine types
+const IMAGE_FILE_MACHINE_AMD64 = 0x8664;
+const IMAGE_FILE_MACHINE_I386  = 0x014C;
+const IMAGE_FILE_MACHINE_ARM64 = 0xAA64;
+
+/**
+ * Inspect the first ~256 bytes of a file and return
+ * {format: 'macho'|'pe'|'elf'|'unknown', arch: 'arm64'|'x64'|'x86'|'unknown'|'universal', platform: 'darwin'|'win32'|'linux'|'unknown'}.
+ *
+ * Pure header reading, no libmagic.
+ */
+export function detectNativeArch(filePath) {
+  const buf = readFileSync(filePath);
+  if (buf.length < 8) return { format: 'unknown', arch: 'unknown', platform: 'unknown' };
+
+  // Mach-O (darwin)
+  const magicBE = buf.readUInt32BE(0);
+  const magicLE = buf.readUInt32LE(0);
+
+  if (magicBE === MACHO_FAT || magicBE === MACHO_FAT_REV) {
+    // Universal binary — inspect subfile headers to enumerate arches.
+    const nfatArch = buf.readUInt32BE(4);
+    const arches = [];
+    for (let i = 0; i < nfatArch; i++) {
+      const cpuType = buf.readInt32BE(8 + i * 20);
+      if (cpuType === CPU_TYPE_X86_64) arches.push('x64');
+      else if (cpuType === CPU_TYPE_ARM64) arches.push('arm64');
+    }
+    return { format: 'macho', arch: arches.length === 1 ? arches[0] : 'universal', platform: 'darwin', universal: arches };
+  }
+
+  if (magicBE === MACHO_MAGIC_64 || magicLE === MACHO_MAGIC_64) {
+    // 64-bit Mach-O. cputype is at offset 4 (little-endian if MAGIC_64 LE).
+    const le = (magicLE === MACHO_MAGIC_64);
+    const cpuType = le ? buf.readInt32LE(4) : buf.readInt32BE(4);
+    if (cpuType === CPU_TYPE_X86_64) return { format: 'macho', arch: 'x64', platform: 'darwin' };
+    if (cpuType === CPU_TYPE_ARM64)  return { format: 'macho', arch: 'arm64', platform: 'darwin' };
+    return { format: 'macho', arch: 'unknown', platform: 'darwin' };
+  }
+
+  if (magicBE === MACHO_MAGIC_32 || magicLE === MACHO_MAGIC_32) {
+    return { format: 'macho', arch: 'x86', platform: 'darwin' };
+  }
+
+  // PE (Windows): MZ at offset 0, PE offset at 0x3C, machine type 4 bytes into PE header.
+  if (buf[0] === 0x4D && buf[1] === 0x5A) {
+    if (buf.length < 0x40) return { format: 'pe', arch: 'unknown', platform: 'win32' };
+    const peOffset = buf.readUInt32LE(0x3C);
+    if (peOffset + 6 > buf.length) return { format: 'pe', arch: 'unknown', platform: 'win32' };
+    // 'PE\0\0' signature check.
+    if (buf.readUInt32LE(peOffset) !== 0x00004550) {
+      return { format: 'pe', arch: 'unknown', platform: 'win32' };
+    }
+    const machine = buf.readUInt16LE(peOffset + 4);
+    switch (machine) {
+      case IMAGE_FILE_MACHINE_AMD64: return { format: 'pe', arch: 'x64', platform: 'win32' };
+      case IMAGE_FILE_MACHINE_I386:  return { format: 'pe', arch: 'x86', platform: 'win32' };
+      case IMAGE_FILE_MACHINE_ARM64: return { format: 'pe', arch: 'arm64', platform: 'win32' };
+      default: return { format: 'pe', arch: 'unknown', platform: 'win32' };
+    }
+  }
+
+  // ELF (Linux): \x7fELF magic, machine at offset 18 (2 bytes LE for LE-encoded ELF).
+  if (buf[0] === 0x7F && buf[1] === 0x45 && buf[2] === 0x4C && buf[3] === 0x46) {
+    const eiData = buf[5]; // 1 = LE, 2 = BE
+    if (buf.length < 20) return { format: 'elf', arch: 'unknown', platform: 'linux' };
+    const machine = eiData === 1 ? buf.readUInt16LE(18) : buf.readUInt16BE(18);
+    switch (machine) {
+      case EM_X86_64:  return { format: 'elf', arch: 'x64', platform: 'linux' };
+      case EM_AARCH64: return { format: 'elf', arch: 'arm64', platform: 'linux' };
+      default: return { format: 'elf', arch: 'unknown', platform: 'linux' };
+    }
+  }
+
+  return { format: 'unknown', arch: 'unknown', platform: 'unknown' };
+}
+
+// ---------------------------------------------------------------------------
+// Directory walking
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively walk `root` and yield every path ending in `.node`.
+ * Skips symlinks and unreadable entries.
+ */
+export function* walkNativeModules(root) {
+  if (!existsSync(root)) return;
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop();
+    let entries;
+    try { entries = readdirSync(dir, { withFileTypes: true }); }
+    catch { continue; }
+    for (const entry of entries) {
+      const p = join(dir, entry.name);
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) { stack.push(p); continue; }
+      if (entry.isFile() && entry.name.endsWith('.node')) yield p;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function expectedPlatformToken(platform) {
+  switch (platform) {
+    case 'mac':   return 'darwin';
+    case 'win':   return 'win32';
+    case 'linux': return 'linux';
+    default: throw new Error(`unknown --platform: ${platform}`);
+  }
+}
+
+function isArchMatch(detected, expected, expectedPlatform) {
+  // Universal binaries pass any arch the user asks for as long as it's included.
+  if (detected.arch === 'universal' && detected.universal?.includes(expected)) return true;
+  return detected.platform === expectedPlatform && detected.arch === expected;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  if (!args.platform || !args.arch) {
+    console.error('error: both --platform and --arch are required');
+    console.error('usage: verify-native-arch.mjs --platform <mac|win|linux> --arch <arm64|x64> [--dir release]');
+    process.exit(2);
+  }
+
+  let expectedPlatform;
+  try { expectedPlatform = expectedPlatformToken(args.platform); }
+  catch (e) { console.error(e.message); process.exit(2); }
+
+  if (!existsSync(args.dir)) {
+    console.error(`error: --dir does not exist: ${args.dir}`);
+    process.exit(2);
+  }
+
+  const nativeFiles = [...walkNativeModules(args.dir)];
+  if (nativeFiles.length === 0) {
+    console.warn(`! no .node files found under ${args.dir} — nothing to verify`);
+    if (args.strict) {
+      console.error('  (pass --no-strict to allow empty result)');
+      process.exit(1);
+    }
+    return;
+  }
+
+  const rows = nativeFiles.map(p => {
+    const det = detectNativeArch(p);
+    const ok = isArchMatch(det, args.arch, expectedPlatform);
+    return { path: p, det, ok };
+  });
+
+  const rel = (p) => relative(process.cwd(), p);
+  const bad = rows.filter(r => !r.ok);
+
+  console.log(`Native module verification — target=${expectedPlatform}-${args.arch} dir=${args.dir}`);
+  console.log('-'.repeat(100));
+  for (const r of rows) {
+    const mark = r.ok ? 'OK ' : 'BAD';
+    const archDesc = r.det.arch === 'universal'
+      ? `universal(${r.det.universal?.join(',') ?? '?'})`
+      : r.det.arch;
+    console.log(`  [${mark}] ${r.det.platform}/${archDesc.padEnd(12)} ${rel(r.path)}`);
+  }
+  console.log('-'.repeat(100));
+  console.log(`  ${rows.length} native module(s) scanned, ${bad.length} mismatch(es)`);
+
+  if (bad.length > 0) {
+    console.error('');
+    console.error(`FAIL: ${bad.length} native module(s) do not match target ${expectedPlatform}-${args.arch}:`);
+    for (const r of bad) {
+      console.error(`  ${rel(r.path)}`);
+      console.error(`    expected: ${expectedPlatform}-${args.arch}`);
+      console.error(`    detected: ${r.det.platform}-${r.det.arch} (${r.det.format})`);
+    }
+    console.error('');
+    console.error('Fix: run `npx @electron/rebuild --arch ${args.arch} --platform ${expectedPlatform} --force`');
+    console.error('     before `electron-builder`. In CI, use per-arch matrix jobs so node_modules never contains foreign-arch artefacts.');
+    process.exit(1);
+  }
+
+  console.log('PASS: all native modules match target.');
+}
+
+// Run when invoked directly, not when imported by tests.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/verify-native-arch.mjs
+++ b/scripts/verify-native-arch.mjs
@@ -26,7 +26,7 @@ import { join, relative } from 'node:path';
 // ---------------------------------------------------------------------------
 
 function parseArgs(argv) {
-  const out = { platform: null, arch: null, dir: 'release', strict: true };
+  const out = { platform: null, arch: null, dir: 'release', strict: true, includePrebuilds: false };
   for (let i = 2; i < argv.length; i++) {
     const k = argv[i];
     const v = argv[i + 1];
@@ -35,9 +35,16 @@ function parseArgs(argv) {
       case '--arch':     out.arch = v; i++; break;
       case '--dir':      out.dir = v; i++; break;
       case '--no-strict': out.strict = false; break;
+      case '--include-prebuilds': out.includePrebuilds = true; break;
       case '-h':
       case '--help':
-        console.log('usage: verify-native-arch.mjs --platform <mac|win|linux> --arch <arm64|x64> [--dir release]');
+        console.log('usage: verify-native-arch.mjs --platform <mac|win|linux> --arch <arm64|x64> [--dir release] [--include-prebuilds]');
+        console.log('');
+        console.log('  --include-prebuilds   also inspect files under /prebuilds/ subdirs.');
+        console.log('                        Default: skip — packages like node-pty ship a');
+        console.log('                        multi-platform prebuild bundle and pick the');
+        console.log('                        matching one at runtime, so foreign-arch files');
+        console.log('                        under prebuilds/ are expected and benign.');
         process.exit(0);
       default:
         if (k.startsWith('--')) {
@@ -47,6 +54,16 @@ function parseArgs(argv) {
     }
   }
   return out;
+}
+
+/**
+ * True when the path is inside a `prebuilds/<platform-arch>/` subdirectory.
+ * Packages like node-pty ship multi-platform prebuilds so the same npm
+ * tarball works on Windows / macOS / Linux; only the matching prebuild
+ * is loaded at runtime. The verifier skips these by default.
+ */
+export function isPrebuildPath(p) {
+  return /[\\/]prebuilds[\\/][^\\/]+[\\/]/.test(p);
 }
 
 // ---------------------------------------------------------------------------
@@ -207,7 +224,10 @@ function main() {
     process.exit(2);
   }
 
-  const nativeFiles = [...walkNativeModules(args.dir)];
+  const allFiles = [...walkNativeModules(args.dir)];
+  const skipped = args.includePrebuilds ? [] : allFiles.filter(isPrebuildPath);
+  const nativeFiles = args.includePrebuilds ? allFiles : allFiles.filter(p => !isPrebuildPath(p));
+
   if (nativeFiles.length === 0) {
     console.warn(`! no .node files found under ${args.dir} — nothing to verify`);
     if (args.strict) {
@@ -235,8 +255,11 @@ function main() {
       : r.det.arch;
     console.log(`  [${mark}] ${r.det.platform}/${archDesc.padEnd(12)} ${rel(r.path)}`);
   }
+  if (skipped.length > 0) {
+    console.log(`  (skipped ${skipped.length} file(s) under /prebuilds/ subdirs — multi-platform bundles, use --include-prebuilds to inspect)`);
+  }
   console.log('-'.repeat(100));
-  console.log(`  ${rows.length} native module(s) scanned, ${bad.length} mismatch(es)`);
+  console.log(`  ${rows.length} active native module(s) scanned, ${bad.length} mismatch(es)`);
 
   if (bad.length > 0) {
     console.error('');


### PR DESCRIPTION
## Summary

- **v0.4.0 DMG is broken on Apple Silicon.** The shipped `better_sqlite3.node` inside `GRIP Commander.app/Contents/Resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release/` is a Windows PE32+ x86-64 DLL, not a darwin-arm64 Mach-O binary. At launch: `ERR_DLOPEN_FAILED` → `registerIpcHandlers` aborts mid-cascade → renderer sees "No handler registered for 'grip:prompt'" for every GRIP channel.
- **Root cause**: v0.4.0 was built locally via `commander:dmg` from a dev tree whose root `node_modules/better-sqlite3/build/Release/` had been contaminated by a prior Windows build. `commander:dmg` does not clean `node_modules`, does not run `@electron/rebuild`, and has no post-build arch verification.
- **The existing `build.yml` (fbd4071) would not fix this.** It runs `npm run build` (= `next build` only), never compiles the electron main process, never builds the 7 MCP submodules, runs `--arm64` and `--x64` sequentially in one job, and has no post-build arch verification.

This PR ships three granular commits that together produce deterministic cross-platform artefacts and mechanically prevent a repeat of the v0.4.0 contamination.

### What changed

**1. `scripts/verify-native-arch.mjs` + 12 Vitest cases**
Post-build guard. Walks every `.node` inside `release/` and inspects Mach-O / PE / ELF headers directly (pure JS, no native deps). Fails the build if any file's arch doesn't match the target. The regression test case (a PE32+ binary inside a darwin-arm64 build) reproduces the exact v0.4.0 failure.

**2. `scripts/build-electron.sh`** — single source of truth for local + CI builds
Parameterised `<platform> <arch> [mode]` pipeline with `set -euo pipefail`. Each step (Next build, tsc main, MCP submodules, `@electron/rebuild`, electron-builder, verify) is its own function. `package.json` scripts (`commander:dmg`, `build:electron:mac:arm64`, `build:electron:win:x64`, etc.) all delegate to it. Closes the local-build loophole.

**3. `.github/workflows/build.yml`** — per-arch matrix jobs with verifier gate
Replaces sequential `--arm64`/`--x64` in one job with a `fail-fast: false` matrix across dedicated runners (macos-14 arm64, macos-13 x64, windows-latest, ubuntu-latest). Each job runs the verifier as a required step before uploading artefacts. Tag-triggered release publishes only when all four matrix entries pass.

## Test plan

- [x] Vitest: 12/12 tests pass locally for `verify-native-arch.test.ts` including the PE32+-inside-darwin-arm64 regression case
- [ ] CI: push this PR — `ci.yml` runs the new test file
- [ ] CI: workflow_dispatch `build.yml` on this branch — expect all 4 matrix jobs green, 4 artefact sets uploaded
- [ ] Manual (after merge): tag `v0.4.1`, confirm release contains 4 artefact sets and each DMG launches without `ERR_DLOPEN_FAILED`
- [ ] Manual: install v0.4.1 arm64 DMG, confirm `grip:prompt` IPC works (chat input sends a prompt successfully)

## Immediate unblock for anyone on v0.4.0

While v0.4.1 is pending, two local options exist to fix the installed v0.4.0 app; both are documented at the bottom of `plans/xplat-ci-native-arch-hardening.md`:
- **A**: rebuild better-sqlite3 in place via `sudo npx @electron/rebuild` (fast)
- **B**: clean local rebuild + DMG in this repo, then drag into Applications (matches what v0.4.1 CI will produce)

## Falsification

This change is wrong if:
- The verifier produces false positives on valid prebuilds (blocks a correct release)
- `@electron/rebuild` fails on the CI runners for any of the 4 targets (platform breakage we didn't anticipate)
- Matrix runners inflate CI cost beyond acceptable
- electron-builder already handles cross-arch correctly and v0.4.0 contamination was purely local (verifier is still cheap insurance)