### PR TITLE
chore: bump to 0.4.3; exclude @next/swc-* and @img/sharp-* from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grip-knowledge-engine",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "description": "GRIP Knowledge Work Engine",
   "author": {
@@ -52,7 +52,10 @@
       "!node_modules/@next/eslint-plugin-next",
       "skills/**/*",
       "hooks/**/*",
-      "grip-starter/**/*"
+      "grip-starter/**/*",
+      "!node_modules/@next/swc-*/**",
+      "!node_modules/@img/sharp-*/**",
+      "!node_modules/@img/sharp-libvips-*/**"
     ],
     "asarUnpack": [
       "out/**/*",


### PR DESCRIPTION
## Summary

v0.4.2 mac x64 CI caught two arm64-only native modules leaking into the x64 DMG during cross-compile on macos-14 arm64 runners:

- `node_modules/@next/swc-darwin-arm64/next-swc.darwin-arm64.node`
- `node_modules/@img/sharp-darwin-arm64/lib/sharp-darwin-arm64.node`

These are arch-specific npm packages selected by npm based on **host** arch during `npm ci`. On an arm64 runner, npm installs the arm64 variants; electron-builder packages them under `node_modules/**/*` despite the target being x64.

Fix: exclude `@next/swc-*`, `@img/sharp-*`, and `@img/sharp-libvips-*` from the electron-builder `files` list. Neither is needed at runtime — SWC is the Next.js compiler (used during `next build`, not at runtime) and Sharp is for build-time image optimisation. Removing them also shrinks every DMG/NSIS/AppImage artefact.

## Test plan

- [x] Verifier mechanically catches the issue (that's what flagged v0.4.2)
- [ ] Merge + tag `v0.4.3` → expect all 4 matrix entries green
- [ ] Download `GRIP-Commander-0.4.3-x64.dmg` and confirm it launches on Intel Mac
- [ ] Spot-check DMG size drop (these two packages are ~50MB combined)

## Falsification

Wrong if either package is required at runtime. Evidence it isn't:
- `@next/swc` — Next.js SWC compiler; `next build` produces output that runs without it
- `@img/sharp` — used during build for image optimisation; renderer imports compiled output