### PR TITLE
docs: first-launch instructions for unsigned builds (mac/win/linux)

### DIFF
--- a/.github/RELEASE_FOOTER.md
+++ b/.github/RELEASE_FOOTER.md
@@ -1,0 +1,61 @@
+---
+
+## First-time launch
+
+GRIP Commander is distributed as an unsigned build (no Apple Developer certificate, no Microsoft Authenticode signature). Your OS will quarantine the download and refuse to open it until you explicitly allow it. Pick the path for your platform.
+
+### macOS (Apple Silicon or Intel)
+
+When you double-click the app the first time you will see:
+
+> **"GRIP Commander" is damaged and can't be opened. You should move it to the Trash.**
+
+The app is not damaged — macOS Gatekeeper is blocking an unsigned download. Two ways to unblock:
+
+**Option A — Terminal (fastest)**
+
+```bash
+xattr -cr "/Applications/GRIP Commander.app"
+```
+
+Then re-launch. This strips the `com.apple.quarantine` flag so Gatekeeper stops blocking.
+
+**Option B — System Settings (no Terminal)**
+
+1. Double-click the app — it will fail with the "damaged" message.
+2. Open **System Settings → Privacy & Security**.
+3. Scroll to the bottom. You will see a line: *"GRIP Commander was blocked from use because it is not from an identified developer."*
+4. Click **Open Anyway** and confirm.
+5. The next launch will prompt once more, then work from then on.
+
+### Windows
+
+When you run `GRIP-Commander-<version>-x64-setup.exe`, SmartScreen will show:
+
+> **Windows protected your PC** — Microsoft Defender SmartScreen prevented an unrecognised app from starting.
+
+Click **More info** → **Run anyway**. This happens once per version.
+
+### Linux
+
+The AppImage needs to be made executable before the first run:
+
+```bash
+chmod +x GRIP-Commander-<version>-x86_64.AppImage
+./GRIP-Commander-<version>-x86_64.AppImage
+```
+
+Some distributions also require `libfuse2` to be installed for AppImages to run:
+
+```bash
+sudo apt install libfuse2         # Ubuntu/Debian
+sudo dnf install fuse-libs        # Fedora/RHEL
+```
+
+---
+
+### Why unsigned?
+
+Code signing requires paid developer accounts on each platform (Apple Developer Program $99/year, Microsoft Authenticode cert ~$300+/year). We will move to signed + notarised builds before the 1.0 release. Until then, the steps above are the one-time friction.
+
+If you are uncomfortable with unsigned builds, you can verify the artefacts yourself: every release is built in GitHub Actions from the `v<version>` tag. The workflow run linked from each release page shows the full build log, a pre-publish verifier step that inspects every native binary for correct architecture, and the exact commit SHA that was packaged.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,10 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
+      # Checkout needed so we can read .github/RELEASE_FOOTER.md (first-launch
+      # instructions appended to every release body).
+      - uses: actions/checkout@v4
+
       - name: Download all artefacts
         uses: actions/download-artifact@v4
         with:
@@ -145,3 +149,5 @@ jobs:
             artefacts/**/*.zip
           fail_on_unmatched_files: false
           generate_release_notes: true
+          body_path: .github/RELEASE_FOOTER.md
+          append_body: true

--- a/README.md
+++ b/README.md
@@ -12,11 +12,74 @@ Cross-domain knowledge work engine. Run, orchestrate, and automate Claude Code a
 
 ## Download
 
-| Platform | Architecture | Link |
-|----------|-------------|------|
-| macOS | ARM64 (Apple Silicon) | [Download DMG](https://github.com/CodeTonight-SA/GRIP-GUI/releases/download/v0.1.0-alpha.1/GRIP-Commander-0.1.0-arm64.dmg) |
+Latest release: [**github.com/CodeTonight-SA/GRIP-GUI/releases/latest**](https://github.com/CodeTonight-SA/GRIP-GUI/releases/latest)
 
-> **Unsigned alpha.** After installing: `xattr -cr /Applications/GRIP\ Commander.app`
+| Platform | Architecture | File |
+|----------|-------------|------|
+| macOS | ARM64 (Apple Silicon) | `GRIP-Commander-<version>-arm64.dmg` |
+| macOS | x64 (Intel) | `GRIP-Commander-<version>-x64.dmg` |
+| Windows | x64 | `GRIP-Commander-<version>-x64-setup.exe` |
+| Linux | x64 | `GRIP-Commander-<version>-x86_64.AppImage` |
+
+> **Unsigned build.** First launch needs one manual step to get past OS security. See [First-time launch](#first-time-launch) below.
+
+---
+
+## First-time launch
+
+GRIP Commander is distributed unsigned (no Apple Developer certificate, no Microsoft Authenticode signature). Your OS will block the first launch until you explicitly allow it. Pick the path for your platform.
+
+### macOS (Apple Silicon or Intel)
+
+When you double-click the app the first time you'll see:
+
+> **"GRIP Commander" is damaged and can't be opened. You should move it to the Trash.**
+
+The app isn't damaged — macOS Gatekeeper is blocking an unsigned download. Two ways to unblock:
+
+**Option A — Terminal (fastest)**
+
+```bash
+xattr -cr "/Applications/GRIP Commander.app"
+```
+
+Then re-launch. Strips the `com.apple.quarantine` flag so Gatekeeper stops blocking.
+
+**Option B — System Settings (no Terminal)**
+
+1. Double-click the app — it fails with the "damaged" message.
+2. Open **System Settings → Privacy & Security**.
+3. Scroll to the bottom. You'll see *"GRIP Commander was blocked from use because it is not from an identified developer."*
+4. Click **Open Anyway** and confirm.
+5. The next launch prompts once more, then it works from then on.
+
+### Windows
+
+Running `GRIP-Commander-<version>-x64-setup.exe` will show a SmartScreen warning:
+
+> **Windows protected your PC** — Microsoft Defender SmartScreen prevented an unrecognised app from starting.
+
+Click **More info** → **Run anyway**. This happens once per version.
+
+### Linux
+
+Make the AppImage executable, then run it:
+
+```bash
+chmod +x GRIP-Commander-<version>-x86_64.AppImage
+./GRIP-Commander-<version>-x86_64.AppImage
+```
+
+Some distros need `libfuse2` installed for AppImages:
+
+```bash
+sudo apt install libfuse2         # Ubuntu/Debian
+sudo dnf install fuse-libs        # Fedora/RHEL
+```
+
+### Why unsigned?
+
+Code signing requires paid developer accounts on each platform (Apple Developer Program $99/year, Microsoft Authenticode cert ~$300+/year). We'll move to signed + notarised builds before the 1.0 release. Until then, the steps above are the one-time friction per version.
 
 ---
 
@@ -184,12 +247,11 @@ GRIP Commander bundles MCP servers for programmatic control:
 - **Claude Code CLI**: `npm install -g @anthropic-ai/claude-code`
 - **Claude login**: `claude login` (each user authenticates with their own Anthropic account)
 
-### Install from DMG
+### Install (any platform)
 
-1. [Download the DMG](https://github.com/CodeTonight-SA/GRIP-GUI/releases/download/v0.1.0-alpha.1/GRIP-Commander-0.1.0-arm64.dmg)
-2. Drag to Applications
-3. Run `xattr -cr /Applications/GRIP\ Commander.app`
-4. Launch GRIP Commander
+1. Grab the matching artefact for your OS from the [latest release](https://github.com/CodeTonight-SA/GRIP-GUI/releases/latest)
+2. Install per your platform's convention (drag DMG to Applications, run NSIS setup, chmod the AppImage)
+3. Follow the [First-time launch](#first-time-launch) steps above — this is the one-time OS-security unblock
 
 ### Build from Source
 


### PR DESCRIPTION
## Summary

Unsigned builds hit platform security on first launch with no hint of what to do:
- macOS: "GRIP Commander is damaged and can't be opened"
- Windows: SmartScreen block
- Linux: AppImage not executable / missing libfuse2

README had a dead v0.1.0-alpha.1 link and only covered macOS arm64. Every release body was auto-generated "What's Changed" — no install help at all.

## Changes

- **README.md** — replaces stale hardcoded download link with [\`/releases/latest\`](https://github.com/CodeTonight-SA/GRIP-GUI/releases/latest), expands to all 4 platforms, adds a *First-time launch* section per-platform (macOS Terminal + Settings UI fallback, Windows SmartScreen, Linux chmod + libfuse2), adds a \`Why unsigned?\` note pointing at the eventual notarisation path.
- **.github/RELEASE_FOOTER.md** — shared first-launch block written once, appended to every release body going forward.
- **.github/workflows/build.yml** — release job now checks out the repo and passes \`body_path: .github/RELEASE_FOOTER.md\` + \`append_body: true\` to \`softprops/action-gh-release\`. Auto-generated "What's Changed" notes stay at the top; the footer gets appended under them.

## Test plan

- [x] README markdown renders correctly on GitHub preview
- [ ] Merge + tag \`v0.4.4\` (or whenever the next version ships) → expect the release body to contain both \"What's Changed\" and the First-time launch section
- [ ] For v0.4.3 (already published), edit the release body directly via \`gh release edit\` to append the footer — not part of this PR, done in parallel