### PR TITLE
feat(sidebar): mode-stack chip (S3 / Phase 2 W1)

### DIFF
--- a/__tests__/renderer/ModeStackChip.test.tsx
+++ b/__tests__/renderer/ModeStackChip.test.tsx
@@ -1,0 +1,252 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import ModeStackChip from '../../src/components/ModeStackChip';
+
+// next/navigation — stub usePathname so we can drive route-change re-fetches
+let currentPathname = '/';
+vi.mock('next/navigation', () => ({
+  usePathname: () => currentPathname,
+}));
+
+// Environment-agnostic localStorage stub (matches ChatStorage.test.tsx pattern).
+let lsStore: Record<string, string> = {};
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => lsStore[key] ?? null,
+  setItem: (key: string, value: string) => {
+    lsStore[key] = String(value);
+  },
+  removeItem: (key: string) => {
+    delete lsStore[key];
+  },
+  clear: () => {
+    lsStore = {};
+  },
+  get length() {
+    return Object.keys(lsStore).length;
+  },
+  key: (i: number) => Object.keys(lsStore)[i] ?? null,
+});
+
+function mockFetchResponse(body: unknown, init: { ok?: boolean; status?: number } = {}) {
+  const ok = init.ok ?? true;
+  const status = init.status ?? 200;
+  return vi.fn(() =>
+    Promise.resolve({
+      ok,
+      status,
+      json: () => Promise.resolve(body),
+    } as Response),
+  );
+}
+
+beforeEach(() => {
+  currentPathname = '/';
+  lsStore = {};
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ModeStackChip', () => {
+  describe('rendering', () => {
+    it('renders the active mode list uppercase joined by " · "', async () => {
+      globalThis.fetch = mockFetchResponse({ modes: ['code', 'architect'] });
+
+      render(<ModeStackChip showLabels />);
+
+      await waitFor(() =>
+        expect(screen.getByTestId('mode-stack-chip')).toHaveTextContent('CODE · ARCHITECT'),
+      );
+    });
+
+    it('renders "NO MODES" when the stack is empty', async () => {
+      globalThis.fetch = mockFetchResponse({ modes: [] });
+
+      render(<ModeStackChip showLabels />);
+
+      await waitFor(() =>
+        expect(screen.getByTestId('mode-stack-chip')).toHaveTextContent('NO MODES'),
+      );
+    });
+
+    it('renders an honest "MODES —" placeholder when the fetch fails', async () => {
+      globalThis.fetch = vi.fn(() => Promise.reject(new Error('network down')));
+
+      render(<ModeStackChip showLabels />);
+
+      await waitFor(() =>
+        expect(screen.getByTestId('mode-stack-chip')).toHaveTextContent('MODES —'),
+      );
+    });
+
+    it('renders the honest placeholder on non-OK HTTP status (500)', async () => {
+      globalThis.fetch = mockFetchResponse({ error: 'boom' }, { ok: false, status: 500 });
+
+      render(<ModeStackChip showLabels />);
+
+      await waitFor(() =>
+        expect(screen.getByTestId('mode-stack-chip')).toHaveTextContent('MODES —'),
+      );
+    });
+
+    it('ignores malformed payloads (modes not an array) and shows empty state', async () => {
+      globalThis.fetch = mockFetchResponse({ modes: 'not-an-array' });
+
+      render(<ModeStackChip showLabels />);
+
+      await waitFor(() =>
+        expect(screen.getByTestId('mode-stack-chip')).toHaveTextContent('NO MODES'),
+      );
+    });
+
+    it('filters non-string entries out of the modes array', async () => {
+      globalThis.fetch = mockFetchResponse({ modes: ['code', 42, null, 'architect', { a: 1 }] });
+
+      render(<ModeStackChip showLabels />);
+
+      await waitFor(() =>
+        expect(screen.getByTestId('mode-stack-chip')).toHaveTextContent('CODE · ARCHITECT'),
+      );
+    });
+  });
+
+  describe('collapsed sidebar', () => {
+    it('hides the label and shortcut hint when showLabels=false', async () => {
+      globalThis.fetch = mockFetchResponse({ modes: ['code'] });
+
+      render(<ModeStackChip showLabels={false} />);
+      const chip = screen.getByTestId('mode-stack-chip');
+
+      // Label is in the tooltip (hidden until hover), not in the main row.
+      // The shortcut hint "⌘⇧M" must NOT render at all in collapsed mode.
+      expect(chip).not.toHaveTextContent('⌘⇧M');
+    });
+
+    it('does not show the shortcut hint on mobile even when expanded', async () => {
+      globalThis.fetch = mockFetchResponse({ modes: ['code'] });
+
+      render(<ModeStackChip showLabels isMobile />);
+      const chip = screen.getByTestId('mode-stack-chip');
+
+      expect(chip).not.toHaveTextContent('⌘⇧M');
+    });
+  });
+
+  describe('interaction', () => {
+    it('dispatches grip:open-palette with presetFilter=MODES on click', async () => {
+      globalThis.fetch = mockFetchResponse({ modes: ['code'] });
+      const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+
+      render(<ModeStackChip showLabels />);
+      await waitFor(() => screen.getByTestId('mode-stack-chip'));
+
+      fireEvent.click(screen.getByTestId('mode-stack-chip'));
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'grip:open-palette',
+        }),
+      );
+      const event = dispatchSpy.mock.calls[0][0] as CustomEvent;
+      expect(event.detail).toEqual({ presetFilter: 'MODES' });
+    });
+
+    it('dispatches the palette event even when the fetch errored', async () => {
+      globalThis.fetch = vi.fn(() => Promise.reject(new Error('offline')));
+      const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+
+      render(<ModeStackChip showLabels />);
+      await waitFor(() =>
+        expect(screen.getByTestId('mode-stack-chip')).toHaveTextContent('MODES —'),
+      );
+
+      fireEvent.click(screen.getByTestId('mode-stack-chip'));
+      // The button must stay functional — the whole point is that the chip
+      // can recover the user to the palette even when the backend is down.
+      expect(dispatchSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('route changes', () => {
+    it('re-fetches modes when the pathname changes (council rider: no cached state)', async () => {
+      const fetchSpy = mockFetchResponse({ modes: ['code'] });
+      globalThis.fetch = fetchSpy;
+
+      const { rerender } = render(<ModeStackChip showLabels />);
+      await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+
+      currentPathname = '/agents';
+      rerender(<ModeStackChip showLabels />);
+
+      await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+    });
+  });
+
+  describe('feature flag', () => {
+    it('returns null when sidebarShowModeChip === "false"', () => {
+      localStorage.setItem('sidebarShowModeChip', 'false');
+      globalThis.fetch = mockFetchResponse({ modes: ['code'] });
+
+      const { container } = render(<ModeStackChip showLabels />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders when the flag is unset', async () => {
+      globalThis.fetch = mockFetchResponse({ modes: ['code'] });
+
+      render(<ModeStackChip showLabels />);
+
+      await waitFor(() => expect(screen.getByTestId('mode-stack-chip')).toBeInTheDocument());
+    });
+
+    it('renders when the flag is any other value', async () => {
+      localStorage.setItem('sidebarShowModeChip', 'true');
+      globalThis.fetch = mockFetchResponse({ modes: ['code'] });
+
+      render(<ModeStackChip showLabels />);
+
+      await waitFor(() => expect(screen.getByTestId('mode-stack-chip')).toBeInTheDocument());
+    });
+  });
+
+  describe('accessibility', () => {
+    it('exposes an aria-label describing the active-stack state', async () => {
+      globalThis.fetch = mockFetchResponse({ modes: ['code', 'architect'] });
+
+      render(<ModeStackChip showLabels />);
+      const chip = await waitFor(() => screen.getByTestId('mode-stack-chip'));
+
+      expect(chip).toHaveAttribute(
+        'aria-label',
+        '2 modes active: code, architect. Click to manage.',
+      );
+    });
+
+    it('exposes a singular aria-label when only one mode is active', async () => {
+      globalThis.fetch = mockFetchResponse({ modes: ['code'] });
+
+      render(<ModeStackChip showLabels />);
+      const chip = await waitFor(() => screen.getByTestId('mode-stack-chip'));
+
+      expect(chip).toHaveAttribute(
+        'aria-label',
+        '1 mode active: code. Click to manage.',
+      );
+    });
+
+    it('uses the no-modes aria-label when the stack is empty', async () => {
+      globalThis.fetch = mockFetchResponse({ modes: [] });
+
+      render(<ModeStackChip showLabels />);
+      const chip = await waitFor(() => screen.getByTestId('mode-stack-chip'));
+
+      expect(chip).toHaveAttribute(
+        'aria-label',
+        'No modes active. Click to stack modes.',
+      );
+    });
+  });
+});

--- a/src/components/ModeStackChip.tsx
+++ b/src/components/ModeStackChip.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+/**
+ * ModeStackChip — sidebar chip showing the active GRIP mode stack.
+ *
+ * Reads GET /api/grip/modes on mount and on every pathname change (council rider:
+ * no cached state — if the toggle silently fails, the chip reflects reality, not
+ * intent). Click dispatches `grip:open-palette` with `presetFilter='MODES'` so the
+ * existing CommandPalette picks up the intent without coupling.
+ *
+ * Feature-flag rollback: when `localStorage.sidebarShowModeChip === 'false'`, the
+ * component returns null. Ship behind flag for first release.
+ */
+
+import { useEffect, useState, useCallback } from 'react';
+import { Layers } from 'lucide-react';
+import { usePathname } from 'next/navigation';
+
+const OPEN_PALETTE_EVENT = 'grip:open-palette';
+const FLAG_KEY = 'sidebarShowModeChip';
+
+interface ModeStackChipProps {
+  showLabels: boolean;
+  isMobile?: boolean;
+}
+
+type FetchState =
+  | { status: 'loading' }
+  | { status: 'ready'; modes: string[] }
+  | { status: 'error' };
+
+function isEnabled(): boolean {
+  if (typeof window === 'undefined') return true;
+  try {
+    return localStorage.getItem(FLAG_KEY) !== 'false';
+  } catch {
+    return true;
+  }
+}
+
+function openModesPalette(): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(
+    new CustomEvent(OPEN_PALETTE_EVENT, { detail: { presetFilter: 'MODES' } }),
+  );
+}
+
+function renderLabel(state: FetchState): string {
+  if (state.status === 'loading') return '—';
+  if (state.status === 'error') return 'MODES —';
+  if (state.modes.length === 0) return 'NO MODES';
+  return state.modes.join(' · ').toUpperCase();
+}
+
+export default function ModeStackChip({ showLabels, isMobile = false }: ModeStackChipProps) {
+  const [state, setState] = useState<FetchState>({ status: 'loading' });
+  const pathname = usePathname();
+  const [flagEnabled] = useState(() => isEnabled());
+
+  useEffect(() => {
+    if (!flagEnabled) return;
+    let cancelled = false;
+
+    fetch('/api/grip/modes')
+      .then((res) => {
+        if (!res.ok) throw new Error(`status ${res.status}`);
+        return res.json();
+      })
+      .then((data: unknown) => {
+        if (cancelled) return;
+        const modes =
+          data && typeof data === 'object' && 'modes' in data && Array.isArray((data as { modes: unknown }).modes)
+            ? ((data as { modes: string[] }).modes.filter((m): m is string => typeof m === 'string'))
+            : [];
+        setState({ status: 'ready', modes });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ status: 'error' });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pathname, flagEnabled]);
+
+  const handleClick = useCallback(() => {
+    openModesPalette();
+  }, []);
+
+  if (!flagEnabled) return null;
+
+  const label = renderLabel(state);
+  const ariaLabel =
+    state.status === 'ready' && state.modes.length > 0
+      ? `${state.modes.length} mode${state.modes.length === 1 ? '' : 's'} active: ${state.modes.join(', ')}. Click to manage.`
+      : 'No modes active. Click to stack modes.';
+  const showShortcutHint = showLabels && !isMobile;
+
+  return (
+    <button
+      onClick={handleClick}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+      data-testid="mode-stack-chip"
+      className="group/chip relative w-full flex items-center gap-2.5 px-3 py-2 border-b border-[var(--border)] text-[var(--primary)] hover:bg-[var(--secondary)] transition-colors"
+    >
+      <Layers className="w-4 h-4 shrink-0" strokeWidth={1.5} aria-hidden="true" />
+      {showLabels && (
+        <span className="flex-1 font-mono text-[10px] tracking-widest truncate text-left">
+          {label}
+        </span>
+      )}
+      {showShortcutHint && (
+        <span className="text-[9px] text-[var(--muted-foreground)] opacity-40 font-mono tabular-nums shrink-0">
+          ⌘⇧M
+        </span>
+      )}
+      {/* Collapsed tooltip — mirrors NavLink affordance */}
+      {!showLabels && (
+        <span className="absolute left-full ml-2 px-2 py-1 bg-[var(--card)] border border-[var(--border)] font-mono text-[10px] tracking-widest text-[var(--foreground)] whitespace-nowrap opacity-0 group-hover/chip:opacity-100 pointer-events-none transition-opacity z-50 shadow-sm">
+          {label}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -25,6 +25,7 @@ import { useStore } from '@/store';
 import { getTheme } from '@/lib/themes';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
+import ModeStackChip from './ModeStackChip';
 
 const navItems = [
   { href: '/', icon: Terminal, label: 'ENGINE', shortcut: '1' },
@@ -150,6 +151,10 @@ export default function Sidebar({ isMobile = false }: SidebarProps) {
           )}
         </div>
       </div>
+
+      {/* Active mode-stack chip — sits between logo and nav. Click opens the
+          MODES preset of the Command Palette via window event. */}
+      <ModeStackChip showLabels={showLabels} isMobile={isMobile} />
 
       {/* Main navigation */}
       <motion.nav


### PR DESCRIPTION
## Summary

First shipped feature of the GRIP Commander v0.5.0 UX delight sprint. S3 from the Phase 2 backlog (see Phase 1 docs PR #118).

- New component: \`src/components/ModeStackChip.tsx\` — click-to-manage chip that shows the current mode stack.
- Mounted in \`src/components/Sidebar.tsx\` between the logo and main nav.
- Reads GET \`/api/grip/modes\` on every pathname change (council scope rider — no cached state, reflects reality not intent even if POST-toggle silently fails).
- Click dispatches \`grip:open-palette\` with \`presetFilter='MODES'\` so the existing \`CommandPalette\` opens into the MODES preset without coupling.
- Feature flag rollback: \`localStorage.sidebarShowModeChip === 'false'\` → renders null.
- 17 vitest cases, all green.

## Closes

- W1 inventory friction **#9** (active mode stack invisible outside \`/modes\`).
- W1 inventory friction **#11** (12-item sidebar undifferentiated).

## H092 tracking (H-UX1)

- Branch opened: **2026-04-17T22:43:39Z**
- First push commit: **2026-04-17T22:47Z** (~4 minutes)
- Target: ≤ 8 wall-clock hours (≤ 1 dev-day). **Well within budget.**

H-UX1 is refuted if S3, S2-PR1, or S4 exceed 1 dev-day. S3 passes.

## Test plan

- [x] \`npx vitest run __tests__/renderer/ModeStackChip.test.tsx\` — 17/17 pass
- [x] \`npx eslint\` on all three touched files — clean
- [ ] Visual check with \`npm run electron:dev\` — please verify chip renders in the expected position, click opens palette MODES
- [ ] Collapse sidebar — chip should become icon-only with hover tooltip

## Out of scope (Rule 19 notes)

The full test suite shows **2 failing tests** (929 total, unrelated geography/weather component) and **tsc reports pre-existing errors** in \`ChatInterface.test.tsx\`, \`ModelSelector.test.tsx\`, \`TypingIndicator.test.tsx\` (deprecated \`JSX\` namespace reference), \`GripStatusBar.test.tsx\` (\`inputTokens\` not on \`GripMetrics\`), \`ToolUseBlock.test.tsx\` (\`id\` / \`toolUseId\` shape drift), and the mcp/orchestrator-messaging test. These are pre-existing and not introduced by this PR, but flagging per Rule 19 — they're on main.

Eslint also warns about an unused \`Palette\` import in \`Sidebar.tsx\` (pre-existing from line 14). Left alone in this PR to keep the diff surgical.

## Related

- Phase 1 docs PR: #118 (\`feat/ux-delight-phase1\`)
- Plan: \`plans/grip-commander-phase2-backlog.md\` (on branch \`feat/ux-delight-phase1\`)
- Preplan: \`~/.claude/plans/grip-commander-tui-delight-rsi.md\`