### PR TITLE
feat(status-bar): S2-PR1 — live version + honest contextPercent

### DIFF
--- a/__tests__/renderer/GripStatusBar.test.tsx
+++ b/__tests__/renderer/GripStatusBar.test.tsx
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import GripStatusBar from '../../src/components/Engine/GripStatusBar';
+import { APP_VERSION } from '../../src/lib/app-version';
 
 // GripPulse and SessionSparkline are canvas-heavy — stub them
 vi.mock('../../src/components/Engine/GripPulse', () => ({
@@ -60,6 +61,67 @@ describe('GripStatusBar', () => {
     it('shows turn count', () => {
       render(<GripStatusBar metrics={{ model: 'sonnet', numTurns: 7, totalDurationMs: 5000, inputTokens: 100, outputTokens: 50, sessionId: 'x' }} />);
       expect(screen.getByText('7 TURNS')).toBeInTheDocument();
+    });
+  });
+
+  describe('context percent (S2-PR1)', () => {
+    it('renders "CTX --" when contextPercent is not passed', () => {
+      render(<GripStatusBar />);
+      expect(screen.getByText(/CTX --/)).toBeInTheDocument();
+    });
+
+    it('renders an empty gauge (0% width, transparent fill) when contextPercent is undefined', () => {
+      render(<GripStatusBar />);
+      const ctx = screen.getByTestId('status-bar-context');
+      const gauge = ctx.querySelector('[style]') as HTMLDivElement;
+      expect(gauge).not.toBeNull();
+      expect(gauge.style.width).toBe('0%');
+      expect(gauge.className).toMatch(/bg-transparent/);
+    });
+
+    it('renders an active gauge when contextPercent is a real value', () => {
+      render(<GripStatusBar contextPercent={47} />);
+      const ctx = screen.getByTestId('status-bar-context');
+      const gauge = ctx.querySelector('[style*="width"]') as HTMLDivElement;
+      expect(gauge.style.width).toBe('47%');
+      expect(gauge.className).toMatch(/bg-\[var\(--primary\)\]/);
+    });
+
+    it('uses the warning colour band between 60 and 80', () => {
+      render(<GripStatusBar contextPercent={72} />);
+      const gauge = screen
+        .getByTestId('status-bar-context')
+        .querySelector('[style*="width"]') as HTMLDivElement;
+      expect(gauge.className).toMatch(/bg-\[var\(--warning\)\]/);
+    });
+
+    it('uses the danger colour band above 80', () => {
+      render(<GripStatusBar contextPercent={91} />);
+      const gauge = screen
+        .getByTestId('status-bar-context')
+        .querySelector('[style*="width"]') as HTMLDivElement;
+      expect(gauge.className).toMatch(/bg-\[var\(--danger\)\]/);
+    });
+  });
+
+  describe('version (S2-PR1)', () => {
+    it('falls back to APP_VERSION from package.json when no prop is passed', () => {
+      render(<GripStatusBar />);
+      const versionEl = screen.getByTestId('status-bar-version');
+      expect(versionEl.textContent).toBe(`GRIP ${APP_VERSION}`);
+      // Sanity: the app is post-v0.1.0. Anyone shipping a status bar that
+      // claims "GRIP 0.1.0" while `package.json` says otherwise is regressing.
+      expect(versionEl.textContent).not.toBe('GRIP 0.1.0');
+    });
+
+    it('renders the passed version string verbatim', () => {
+      render(<GripStatusBar version="9.9.9" />);
+      expect(screen.getByTestId('status-bar-version').textContent).toBe('GRIP 9.9.9');
+    });
+
+    it('accepts non-semver version identifiers (pre-release, git sha)', () => {
+      render(<GripStatusBar version="0.5.0-rc.1" />);
+      expect(screen.getByTestId('status-bar-version').textContent).toBe('GRIP 0.5.0-rc.1');
     });
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import { useState, useCallback, useEffect } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useStore } from '@/store';
 import { isElectronEnv } from '@/lib/grip-session';
+import { APP_VERSION } from '@/lib/app-version';
 import {
   getChatSessions,
   getActiveChatId,
@@ -250,7 +251,14 @@ export default function EnginePage() {
           )}
         </div>
 
-        {!focusMode && <GripStatusBar skillCount={health.skillCount} />}
+        {!focusMode && (
+          <GripStatusBar
+            skillCount={health.skillCount}
+            version={APP_VERSION}
+            // contextPercent omitted deliberately: no authoritative source wired
+            // yet. Widget renders "CTX --" per the S2-PR1 council scope rider.
+          />
+        )}
       </div>
 
       {/* Mobile bottom toolbar */}

--- a/src/components/Engine/GripStatusBar.tsx
+++ b/src/components/Engine/GripStatusBar.tsx
@@ -5,15 +5,28 @@ import { Activity, Layers, Sparkles, Shield, Clock, Cpu, Zap } from 'lucide-reac
 import GripPulse from './GripPulse';
 import SessionSparkline from './SessionSparkline';
 import type { GripMetrics } from '@/lib/grip-session';
+import { formatStatusBarVersion } from '@/lib/app-version';
 
 interface GripStatusBarProps {
   activeMode?: string;
   skillCount?: number;
+  /**
+   * Session context usage. When `undefined` the widget renders `--` with an
+   * empty gauge (Devil's Advocate council rider: "an honestly blank gauge is
+   * safer than a calibration error"). Pass a real percentage when the parent
+   * has authoritative telemetry; omit until then.
+   */
   contextPercent?: number;
   safetyActive?: boolean;
   metrics?: GripMetrics | null;
   isStreaming?: boolean;
   messageTimestamps?: number[];
+  /**
+   * Version string shown in the footer corner. Defaults to the app version
+   * read from `package.json` via `@/lib/app-version`; parent can override for
+   * tests or custom builds.
+   */
+  version?: string;
 }
 
 /**
@@ -24,11 +37,12 @@ interface GripStatusBarProps {
 export default function GripStatusBar({
   activeMode = 'code',
   skillCount = 5,
-  contextPercent = 23,
+  contextPercent,
   safetyActive = true,
   metrics,
   isStreaming = false,
   messageTimestamps = [],
+  version,
 }: GripStatusBarProps) {
   // Session elapsed time — updates every 30s (not every second, to avoid re-renders)
   const [elapsed, setElapsed] = useState('');
@@ -65,16 +79,24 @@ export default function GripStatusBar({
         </span>
       </div>
 
-      {/* Context */}
-      <div className="flex items-center gap-1.5">
+      {/* Context — honest-blank "--" when parent has no authoritative reading */}
+      <div className="flex items-center gap-1.5" data-testid="status-bar-context">
         <Activity className="w-3 h-3 text-[var(--muted-foreground)]" strokeWidth={1.5} />
         <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">
-          CTX {contextPercent}%
+          {contextPercent === undefined ? 'CTX --' : `CTX ${contextPercent}%`}
         </span>
         <div className="w-16 h-1 bg-[var(--border)]">
           <div
-            className={`h-full transition-all ${contextPercent > 80 ? 'bg-[var(--danger)]' : contextPercent > 60 ? 'bg-[var(--warning)]' : 'bg-[var(--primary)]'}`}
-            style={{ width: `${contextPercent}%` }}
+            className={`h-full transition-all ${
+              contextPercent === undefined
+                ? 'bg-transparent'
+                : contextPercent > 80
+                  ? 'bg-[var(--danger)]'
+                  : contextPercent > 60
+                    ? 'bg-[var(--warning)]'
+                    : 'bg-[var(--primary)]'
+            }`}
+            style={{ width: contextPercent === undefined ? '0%' : `${contextPercent}%` }}
           />
         </div>
       </div>
@@ -140,8 +162,11 @@ export default function GripStatusBar({
           {elapsed}
         </span>
       )}
-      <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] opacity-40">
-        GRIP 0.1.0
+      <span
+        className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] opacity-40"
+        data-testid="status-bar-version"
+      >
+        {formatStatusBarVersion(version)}
       </span>
     </div>
   );

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -1,0 +1,20 @@
+/**
+ * Single source of truth for the app version displayed in chrome (status bar,
+ * about dialogs, telemetry). Reads from package.json at build time — Next.js
+ * bundles the import statically, so the runtime never touches disk.
+ *
+ * Keeping this in a helper (rather than inlining `import pkg from ...`) means
+ * the rest of the app depends on the `APP_VERSION` constant, not on
+ * package.json's shape — a small DIP win.
+ */
+import pkg from '../../package.json';
+
+export const APP_VERSION: string = typeof pkg.version === 'string' ? pkg.version : 'dev';
+
+/**
+ * Formats the version for status-bar display: `GRIP 0.4.3`.
+ * Kept alongside the constant so every rendered version uses the same shape.
+ */
+export function formatStatusBarVersion(version: string = APP_VERSION): string {
+  return `GRIP ${version}`;
+}


### PR DESCRIPTION
## Summary

Wave 1 of the /rsi-optimal Phase 2 sprint. Kills two of the worst lies on screen per W1 inventory:

1. **Version**: \`GRIP 0.1.0\` hardcoded footer on a v0.4.3 app → new \`src/lib/app-version.ts\` reads from \`package.json\`.
2. **Context gauge**: hardcoded 23% → optional prop, \`CTX --\` honest-blank when parent lacks authoritative reading (Devil's Advocate council rider).

## Closes

- W1 #1 (status-bar signals hardcoded)
- W1 #2 (stale v0.1.0)
- W1 #63 (inconsistent branding)
- Partial #49 (more widgets wire up in S2-PR2+PR3)

## H092 tracking

- Branch opened: **2026-04-17T22:51:29Z**
- Target: ≤ 8 wall-clock hours. Currently **<5 minutes**.

## Test plan

- [x] 17 GripStatusBar vitest cases pass (5 new: context-undefined renders '--', empty gauge, warning/danger threshold bands; 3 for version fallback, passthrough, pre-release SemVer)
- [x] ESLint clean on touched files (pre-existing \`page.tsx:100\` warning flagged in commit, not fixed)
- [ ] Visual check with \`npm run electron:dev\` — version footer shows \`GRIP 0.4.3\`, context widget shows \`CTX --\` with empty gauge

## Out of scope (Rule 19 flags)

Pre-existing tsc errors in \`__tests__/renderer/\` (\`inputTokens\` not on \`GripMetrics\`, deprecated \`JSX\` namespace) and unused eslint-disable on \`page.tsx:100\` — not introduced by this PR, not in scope.

## Related

- Parent: PR #118 (Phase 1 docs, merged as c9c558f)
- Sibling: PR #119 (S3 mode-stack chip, merged as e2b924e)
- Backlog: \`plans/grip-commander-phase2-backlog.md\`