### PR TITLE
feat(retrieval): chip above input surfaces GRIP Rule 0 tier (S4)

### DIFF
--- a/__tests__/renderer/RetrievalTierChip.test.tsx
+++ b/__tests__/renderer/RetrievalTierChip.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, cleanup } from '@testing-library/react';
+import RetrievalTierChip from '../../src/components/Engine/RetrievalTierChip';
+
+// Environment-agnostic localStorage stub (matches ChatStorage.test.tsx pattern).
+let lsStore: Record<string, string> = {};
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => lsStore[key] ?? null,
+  setItem: (key: string, value: string) => {
+    lsStore[key] = String(value);
+  },
+  removeItem: (key: string) => {
+    delete lsStore[key];
+  },
+  clear: () => {
+    lsStore = {};
+  },
+  get length() {
+    return Object.keys(lsStore).length;
+  },
+  key: (i: number) => Object.keys(lsStore)[i] ?? null,
+});
+
+function dispatchTier(tier: number) {
+  act(() => {
+    window.dispatchEvent(
+      new CustomEvent('grip:retrieval-tier', { detail: { tier } }),
+    );
+  });
+}
+
+beforeEach(() => {
+  lsStore = {};
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('RetrievalTierChip', () => {
+  describe('honest-blank', () => {
+    it('renders a dash placeholder before any retrieval event fires', () => {
+      render(<RetrievalTierChip />);
+      const chip = screen.getByTestId('retrieval-tier-chip');
+      expect(chip).toHaveTextContent('—');
+      expect(screen.queryByTestId('retrieval-tier-chip-tier-hint')).toBeNull();
+    });
+
+    it('has a role=status and plain-English aria-label in the idle state', () => {
+      render(<RetrievalTierChip />);
+      const chip = screen.getByTestId('retrieval-tier-chip');
+      expect(chip).toHaveAttribute('role', 'status');
+      expect(chip).toHaveAttribute(
+        'aria-label',
+        'Retrieval tier: no retrieval yet in this session.',
+      );
+    });
+  });
+
+  describe('binary label (Pragmatist PR1 scope)', () => {
+    it('renders CACHED when tier=0 fires (session memory hit)', () => {
+      render(<RetrievalTierChip />);
+      dispatchTier(0);
+      expect(screen.getByTestId('retrieval-tier-chip')).toHaveTextContent('CACHED');
+    });
+
+    it('renders CACHED when tier=1 fires (KONO semantic search still counts as cache)', () => {
+      render(<RetrievalTierChip />);
+      dispatchTier(1);
+      expect(screen.getByTestId('retrieval-tier-chip')).toHaveTextContent('CACHED');
+    });
+
+    it('renders SEARCHED when tier=2 fires', () => {
+      render(<RetrievalTierChip />);
+      dispatchTier(2);
+      expect(screen.getByTestId('retrieval-tier-chip')).toHaveTextContent('SEARCHED');
+    });
+
+    it('renders SEARCHED when tier=3 fires', () => {
+      render(<RetrievalTierChip />);
+      dispatchTier(3);
+      expect(screen.getByTestId('retrieval-tier-chip')).toHaveTextContent('SEARCHED');
+    });
+
+    it('renders SEARCHED when tier=4 fires (Explore agent)', () => {
+      render(<RetrievalTierChip />);
+      dispatchTier(4);
+      expect(screen.getByTestId('retrieval-tier-chip')).toHaveTextContent('SEARCHED');
+    });
+
+    it('updates to the latest tier when consecutive events fire', () => {
+      render(<RetrievalTierChip />);
+      dispatchTier(0);
+      expect(screen.getByTestId('retrieval-tier-chip')).toHaveTextContent('CACHED');
+      dispatchTier(4);
+      expect(screen.getByTestId('retrieval-tier-chip')).toHaveTextContent('SEARCHED');
+      dispatchTier(1);
+      expect(screen.getByTestId('retrieval-tier-chip')).toHaveTextContent('CACHED');
+    });
+  });
+
+  describe('tier-hint metadata (non-jargon)', () => {
+    it('exposes the raw tier number as a dim T{n} hint for debugging', () => {
+      render(<RetrievalTierChip />);
+      dispatchTier(3);
+      expect(screen.getByTestId('retrieval-tier-chip-tier-hint')).toHaveTextContent('T3');
+    });
+
+    it('does not render the "TIER N" jargon anywhere in the chip body', () => {
+      render(<RetrievalTierChip />);
+      dispatchTier(2);
+      const chip = screen.getByTestId('retrieval-tier-chip');
+      expect(chip.textContent).not.toMatch(/\bTIER\b/i);
+    });
+  });
+
+  describe('malformed events', () => {
+    it('ignores events with no detail', () => {
+      render(<RetrievalTierChip />);
+      act(() => {
+        window.dispatchEvent(new CustomEvent('grip:retrieval-tier'));
+      });
+      expect(screen.getByTestId('retrieval-tier-chip')).toHaveTextContent('—');
+    });
+
+    it('ignores events with non-numeric tier', () => {
+      render(<RetrievalTierChip />);
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent('grip:retrieval-tier', {
+            detail: { tier: 'two' as unknown as number },
+          }),
+        );
+      });
+      expect(screen.getByTestId('retrieval-tier-chip')).toHaveTextContent('—');
+    });
+  });
+
+  describe('feature flag', () => {
+    it('returns null when retrievalTierChip === "false"', () => {
+      localStorage.setItem('retrievalTierChip', 'false');
+      const { container } = render(<RetrievalTierChip />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders when the flag is unset', () => {
+      render(<RetrievalTierChip />);
+      expect(screen.getByTestId('retrieval-tier-chip')).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('updates aria-label to reflect the cached state', () => {
+      render(<RetrievalTierChip />);
+      dispatchTier(0);
+      expect(screen.getByTestId('retrieval-tier-chip')).toHaveAttribute(
+        'aria-label',
+        'Last retrieval: cached (memory hit, near-zero cost).',
+      );
+    });
+
+    it('updates aria-label to reflect the searched state', () => {
+      render(<RetrievalTierChip />);
+      dispatchTier(4);
+      expect(screen.getByTestId('retrieval-tier-chip')).toHaveAttribute(
+        'aria-label',
+        'Last retrieval: searched (disk or agent, higher cost).',
+      );
+    });
+  });
+});

--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -8,6 +8,7 @@ import TypingIndicator from './TypingIndicator';
 import ThinkingIndicator from './ThinkingIndicator';
 import ToolUseBlock from './ToolUseBlock';
 import GateIndicator from './GateIndicator';
+import RetrievalTierChip from './RetrievalTierChip';
 import {
   getChatMessages,
   saveChatMessages,
@@ -717,6 +718,13 @@ export default function ChatInterface({ chatId, onModelChange }: ChatInterfacePr
               </button>
             </div>
           )}
+
+          {/* Retrieval-tier chip — surfaces Rule 0 (GRIP-First Thinking) above
+              the input. Honest-blank until the first grip:retrieval-tier
+              event fires; binary cached/searched label in this PR, upgraded
+              to 5-way detail in a follow-on. */}
+          <RetrievalTierChip />
+
           <div className="flex items-end gap-3">
             <div className="flex-1 relative">
               <textarea

--- a/src/components/Engine/RetrievalTierChip.tsx
+++ b/src/components/Engine/RetrievalTierChip.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+/**
+ * RetrievalTierChip — the chat-input companion to RetrievalTierIndicator.
+ *
+ * Surfaces GRIP's Rule 0 (GRIP-First Thinking) retrieval tier in real time:
+ * whenever a retrieval fires, a CustomEvent 'grip:retrieval-tier' is emitted
+ * with { tier: number }; this chip listens and shows the plain-English label
+ * for the most recent firing.
+ *
+ * Council scope rider (Devil's Advocate, Rule 17): labels are plain English,
+ * NOT "TIER 0 / TIER 4". The first shippable slice is binary (cached vs
+ * searched) per the Pragmatist scope note; the 5-way detail ships in a
+ * follow-on once the tiers are observable from real telemetry sessions.
+ *
+ * Honest-blank state: the chip renders "—" with a dimmed icon until the first
+ * event arrives. A dishonest default is worse than no default.
+ */
+
+import { useEffect, useState } from 'react';
+import { Database, Search } from 'lucide-react';
+
+const EVENT_NAME = 'grip:retrieval-tier';
+const FLAG_KEY = 'retrievalTierChip';
+
+export interface RetrievalTierEventDetail {
+  tier: number; // 0-4, per rules/efficiency-rules.md Rule 0 tier table
+}
+
+type ChipState =
+  | { status: 'idle' }
+  | { status: 'cached'; tier: number }
+  | { status: 'searched'; tier: number };
+
+function classifyTier(tier: number): Exclude<ChipState, { status: 'idle' }> {
+  // Binary slice per Pragmatist scope: tier 0-1 = cached, 2-4 = searched.
+  // The full 5-way detail is deferred to S4-PR2 once live telemetry exists.
+  return tier <= 1 ? { status: 'cached', tier } : { status: 'searched', tier };
+}
+
+function renderLabel(state: ChipState): string {
+  if (state.status === 'idle') return '—';
+  if (state.status === 'cached') return 'CACHED';
+  return 'SEARCHED';
+}
+
+function isEnabled(): boolean {
+  if (typeof window === 'undefined') return true;
+  try {
+    return localStorage.getItem(FLAG_KEY) !== 'false';
+  } catch {
+    return true;
+  }
+}
+
+export default function RetrievalTierChip() {
+  const [state, setState] = useState<ChipState>({ status: 'idle' });
+  const [flagEnabled] = useState(() => isEnabled());
+
+  useEffect(() => {
+    if (!flagEnabled) return;
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<RetrievalTierEventDetail>).detail;
+      if (!detail || typeof detail.tier !== 'number') return;
+      setState(classifyTier(detail.tier));
+    };
+    window.addEventListener(EVENT_NAME, handler);
+    return () => window.removeEventListener(EVENT_NAME, handler);
+  }, [flagEnabled]);
+
+  if (!flagEnabled) return null;
+
+  const label = renderLabel(state);
+  // Icon: Database for cached (memory hit), Search for searched (went to disk).
+  // Keep both always imported so we don't get a render flash on first event.
+  const Icon = state.status === 'searched' ? Search : Database;
+  const isIdle = state.status === 'idle';
+  const tone =
+    state.status === 'cached'
+      ? 'text-[var(--primary)]'
+      : state.status === 'searched'
+        ? 'text-[var(--warning)]'
+        : 'text-[var(--muted-foreground)] opacity-60';
+
+  const aria =
+    state.status === 'idle'
+      ? 'Retrieval tier: no retrieval yet in this session.'
+      : state.status === 'cached'
+        ? 'Last retrieval: cached (memory hit, near-zero cost).'
+        : 'Last retrieval: searched (disk or agent, higher cost).';
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label={aria}
+      data-testid="retrieval-tier-chip"
+      className={`inline-flex items-center gap-1.5 border border-[var(--border)] px-2 py-0.5 w-fit mb-2 transition-colors ${tone}`}
+    >
+      <Icon className="w-3 h-3 shrink-0" strokeWidth={1.5} aria-hidden="true" />
+      <span className="font-mono text-[9px] tracking-widest">
+        {label}
+      </span>
+      {!isIdle && (
+        <span
+          className="font-mono text-[8px] tracking-widest opacity-40"
+          data-testid="retrieval-tier-chip-tier-hint"
+        >
+          T{state.tier}
+        </span>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Third Phase 2 feature of /rsi-optimal sprint. Surfaces GRIP Rule 0 (GRIP-First Thinking) as a plain-English chip above the chat input, listening for \`grip:retrieval-tier\` CustomEvents.

Council scope riders applied:
- **Rule 17 plain English**: labels are CACHED / SEARCHED, not TIER 0 / TIER 4
- **Pragmatist PR1 slice**: binary (cached vs searched); 5-way detail deferred to S4-PR2
- **Devil's Advocate honest-blank**: renders "—" before first event

## Closes

- W1 #51 (RetrievalTierIndicator component exists, unwired)

## Test plan

- [x] 16 RetrievalTierChip vitest cases pass (honest-blank, binary classifier tier 0-4, latest-wins, malformed events, feature flag, accessibility)
- [x] ESLint clean on new file (2 pre-existing warnings in ChatInterface.tsx flagged per Rule 19)
- [ ] Visual check \`npm run electron:dev\` — chip shows "—" above input
- [ ] Dispatch \`window.dispatchEvent(new CustomEvent('grip:retrieval-tier', { detail: { tier: 3 } }))\` — chip updates to "SEARCHED"

## Follow-up

No emitter is wired yet; a hook in the /lib/grip-session path or the preload bridge dispatches \`grip:retrieval-tier\` events in a separate PR. This PR is the renderer-only slice.

## H092 tracking

- Branch opened: **2026-04-17T22:54:43Z**
- Within budget (target 8h, actual ~3 min)

## Related

- Parent main commit: ab4bc61 (S2-PR1)
- Backlog: \`plans/grip-commander-phase2-backlog.md\` (S4)