### PR TITLE
refactor(feature-flag): extract isFeatureEnabled helper (YSH 3-instance)

### DIFF
--- a/__tests__/renderer/feature-flag.test.ts
+++ b/__tests__/renderer/feature-flag.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isFeatureEnabled } from '../../src/lib/feature-flag';
+
+// Environment-agnostic localStorage stub, matching the repo convention
+// established in ChatStorage.test.tsx / ModeStackChip.test.tsx.
+let lsStore: Record<string, string> = {};
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => lsStore[key] ?? null,
+  setItem: (key: string, value: string) => {
+    lsStore[key] = String(value);
+  },
+  removeItem: (key: string) => {
+    delete lsStore[key];
+  },
+  clear: () => {
+    lsStore = {};
+  },
+  get length() {
+    return Object.keys(lsStore).length;
+  },
+  key: (i: number) => Object.keys(lsStore)[i] ?? null,
+});
+
+beforeEach(() => {
+  lsStore = {};
+});
+
+describe('isFeatureEnabled', () => {
+  it('returns true when the flag key is absent (opt-out contract)', () => {
+    expect(isFeatureEnabled('myFlag')).toBe(true);
+  });
+
+  it('returns true when the flag value is the string "true"', () => {
+    localStorage.setItem('myFlag', 'true');
+    expect(isFeatureEnabled('myFlag')).toBe(true);
+  });
+
+  it('returns true for any non-"false" string (e.g. "1", "on", "yes")', () => {
+    localStorage.setItem('myFlag', '1');
+    expect(isFeatureEnabled('myFlag')).toBe(true);
+    localStorage.setItem('myFlag', 'on');
+    expect(isFeatureEnabled('myFlag')).toBe(true);
+    localStorage.setItem('myFlag', 'yes');
+    expect(isFeatureEnabled('myFlag')).toBe(true);
+  });
+
+  it('returns false ONLY when the flag value is the literal string "false"', () => {
+    localStorage.setItem('myFlag', 'false');
+    expect(isFeatureEnabled('myFlag')).toBe(false);
+  });
+
+  it('is case-sensitive — "False" and "FALSE" do not disable (literal match only)', () => {
+    localStorage.setItem('myFlag', 'False');
+    expect(isFeatureEnabled('myFlag')).toBe(true);
+    localStorage.setItem('myFlag', 'FALSE');
+    expect(isFeatureEnabled('myFlag')).toBe(true);
+  });
+
+  it('returns true when localStorage.getItem throws (privacy mode / quota)', () => {
+    const originalGetItem = localStorage.getItem;
+    vi.spyOn(localStorage, 'getItem').mockImplementation(() => {
+      throw new Error('access denied');
+    });
+    expect(isFeatureEnabled('myFlag')).toBe(true);
+    vi.mocked(localStorage.getItem).mockRestore?.();
+    localStorage.getItem = originalGetItem;
+  });
+
+  it('returns true when window is undefined (SSR)', () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error — deliberately removing window to simulate SSR
+    delete globalThis.window;
+    expect(isFeatureEnabled('myFlag')).toBe(true);
+    globalThis.window = originalWindow;
+  });
+
+  it('treats different flag keys independently', () => {
+    localStorage.setItem('flagA', 'false');
+    localStorage.setItem('flagB', 'true');
+    expect(isFeatureEnabled('flagA')).toBe(false);
+    expect(isFeatureEnabled('flagB')).toBe(true);
+    expect(isFeatureEnabled('flagC')).toBe(true);
+  });
+});

--- a/src/components/Engine/ContextGateSlideUp.tsx
+++ b/src/components/Engine/ContextGateSlideUp.tsx
@@ -24,6 +24,7 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import { AlertTriangle, Compass, Save, Zap } from 'lucide-react';
+import { isFeatureEnabled } from '@/lib/feature-flag';
 
 const WARN_EVENT = 'grip:context-gate-warning';
 const ACTION_EVENT = 'grip:context-gate-action';
@@ -36,15 +37,6 @@ interface WarnDetail {
   percent: number;
 }
 
-function isEnabled(): boolean {
-  if (typeof window === 'undefined') return true;
-  try {
-    return localStorage.getItem(FLAG_KEY) !== 'false';
-  } catch {
-    return true;
-  }
-}
-
 function dispatchAction(action: Action): void {
   if (typeof window === 'undefined') return;
   window.dispatchEvent(new CustomEvent(ACTION_EVENT, { detail: { action } }));
@@ -53,7 +45,7 @@ function dispatchAction(action: Action): void {
 export default function ContextGateSlideUp() {
   const [percent, setPercent] = useState<number | null>(null);
   const [dismissed, setDismissed] = useState(false);
-  const [flagEnabled] = useState(() => isEnabled());
+  const [flagEnabled] = useState(() => isFeatureEnabled(FLAG_KEY));
 
   useEffect(() => {
     if (!flagEnabled) return;

--- a/src/components/Engine/RetrievalTierChip.tsx
+++ b/src/components/Engine/RetrievalTierChip.tsx
@@ -19,6 +19,7 @@
 
 import { useEffect, useState } from 'react';
 import { Database, Search } from 'lucide-react';
+import { isFeatureEnabled } from '@/lib/feature-flag';
 
 const EVENT_NAME = 'grip:retrieval-tier';
 const FLAG_KEY = 'retrievalTierChip';
@@ -44,18 +45,9 @@ function renderLabel(state: ChipState): string {
   return 'SEARCHED';
 }
 
-function isEnabled(): boolean {
-  if (typeof window === 'undefined') return true;
-  try {
-    return localStorage.getItem(FLAG_KEY) !== 'false';
-  } catch {
-    return true;
-  }
-}
-
 export default function RetrievalTierChip() {
   const [state, setState] = useState<ChipState>({ status: 'idle' });
-  const [flagEnabled] = useState(() => isEnabled());
+  const [flagEnabled] = useState(() => isFeatureEnabled(FLAG_KEY));
 
   useEffect(() => {
     if (!flagEnabled) return;

--- a/src/components/ModeStackChip.tsx
+++ b/src/components/ModeStackChip.tsx
@@ -15,6 +15,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { Layers } from 'lucide-react';
 import { usePathname } from 'next/navigation';
+import { isFeatureEnabled } from '@/lib/feature-flag';
 
 const OPEN_PALETTE_EVENT = 'grip:open-palette';
 const FLAG_KEY = 'sidebarShowModeChip';
@@ -28,15 +29,6 @@ type FetchState =
   | { status: 'loading' }
   | { status: 'ready'; modes: string[] }
   | { status: 'error' };
-
-function isEnabled(): boolean {
-  if (typeof window === 'undefined') return true;
-  try {
-    return localStorage.getItem(FLAG_KEY) !== 'false';
-  } catch {
-    return true;
-  }
-}
 
 function openModesPalette(): void {
   if (typeof window === 'undefined') return;
@@ -55,7 +47,7 @@ function renderLabel(state: FetchState): string {
 export default function ModeStackChip({ showLabels, isMobile = false }: ModeStackChipProps) {
   const [state, setState] = useState<FetchState>({ status: 'loading' });
   const pathname = usePathname();
-  const [flagEnabled] = useState(() => isEnabled());
+  const [flagEnabled] = useState(() => isFeatureEnabled(FLAG_KEY));
 
   useEffect(() => {
     if (!flagEnabled) return;

--- a/src/lib/feature-flag.ts
+++ b/src/lib/feature-flag.ts
@@ -1,0 +1,30 @@
+/**
+ * Feature-flag helper — Phase 2 delight surfaces ship behind localStorage flags
+ * so operators can disable any chip/strip without a rebuild.
+ *
+ * The contract is opt-out, not opt-in: absence of the key means "enabled".
+ * That matches the Phase 2 council's "ship on by default, give the escape
+ * hatch" posture. Only the literal string "false" disables the feature —
+ * any other value (or a missing key) keeps it on. This keeps localStorage
+ * inspection obvious to operators ("why is my chip gone? the value is
+ * literally 'false'") and avoids boolean-string edge cases.
+ *
+ * SSR safety: when `window` is undefined (Next.js server render), the helper
+ * defaults to enabled. The component then re-runs on the client with the
+ * real flag value. If a component needs to avoid the SSR flash, it should
+ * gate its own rendering, not rely on this helper to know the difference.
+ *
+ * Extracted from the inline `isEnabled()` helpers that lived in S3
+ * ModeStackChip, S4 RetrievalTierChip, and S5 ContextGateSlideUp. Three
+ * proven instances = YSH trigger per CLAUDE.md (dialectical inverse of
+ * YAGNI — abstract NOW, not later).
+ */
+
+export function isFeatureEnabled(flagKey: string): boolean {
+  if (typeof window === 'undefined') return true;
+  try {
+    return localStorage.getItem(flagKey) !== 'false';
+  } catch {
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary

- Extracts identical `isEnabled()` helper from 3 Phase 2 delight surfaces (S3 ModeStackChip, S4 RetrievalTierChip, S5 ContextGateSlideUp) into a single `src/lib/feature-flag.ts` exposing `isFeatureEnabled(flagKey)`.
- Net -24 LOC, zero behaviour change, 8 new Vitest cases (SSR, throw-safety, case-sensitivity, key-independence).
- Triggered by the Phase 3 W1 internal council: three proven instances = YSH trigger per CLAUDE.md (dialectical inverse of YAGNI).

## Why

Every Phase 2 delight surface ships behind a localStorage feature flag. The 8-line `isEnabled()` helper was byte-identical across all three components modulo the `FLAG_KEY` string. The next flagged surface was going to duplicate it a 4th time. Extracting now costs a single file and prevents the pattern from calcifying into "how we do feature flags here".

## Contract

- Opt-out: absence of key = enabled (matches "ship on by default" posture).
- Literal-string `"false"` disables. Any other value (including `"False"`, `"FALSE"`, `"1"`, `"on"`) keeps the feature on.
- SSR-safe (returns `true` when `window` is undefined).
- Privacy-mode safe (try/catch returns `true` on `localStorage` throws).

## Test plan

- [x] 8 Vitest cases in `__tests__/renderer/feature-flag.test.ts` cover every branch of the contract.
- [x] All 47 existing tests for the 3 migrated components still pass unchanged.
- [ ] CI green before admin-merge.

## Related

Phase 3 W1 council (see Phase 2 delight sprint). v0.5.1 candidate #1 of 3 (findings #2 and #3 filed as follow-up issues).