### PR TITLE
feat(voice): Gemini voice chat with speak-replies toggle

### DIFF
--- a/__tests__/renderer/transcribe-route.test.ts
+++ b/__tests__/renderer/transcribe-route.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+async function invokeRoute(audioBlob: Blob): Promise<{
+  response: Response;
+  fetchMock: FetchMock;
+}> {
+  // Reset module registry so the route pulls the freshly-stubbed env each time.
+  vi.resetModules();
+  process.env.GEMINI_API_KEY = 'test-key';
+
+  const fetchMock: FetchMock = vi.fn(async () =>
+    new Response(
+      JSON.stringify({
+        candidates: [{ content: { parts: [{ text: 'hello world' }] } }],
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    )
+  );
+  vi.stubGlobal('fetch', fetchMock);
+
+  const { POST } = await import('../../src/app/api/transcribe/route');
+
+  const form = new FormData();
+  form.append('audio', audioBlob, 'clip.webm');
+  const req = new Request('http://localhost/api/transcribe', {
+    method: 'POST',
+    body: form,
+  });
+
+  // NextRequest is a thin wrapper around Request — the route only touches
+  // formData(), which is native on the web Request, so a cast is safe.
+  const response = await POST(req as unknown as Parameters<typeof POST>[0]);
+  return { response, fetchMock };
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.GEMINI_API_KEY;
+});
+
+describe('POST /api/transcribe', () => {
+  it('strips the ;codecs= parameter from the MediaRecorder MIME before calling Gemini', async () => {
+    const blob = new Blob([new Uint8Array([1, 2, 3, 4])], {
+      type: 'audio/webm;codecs=opus',
+    });
+    const { response, fetchMock } = await invokeRoute(blob);
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string);
+    const mime = body.contents[0].parts[0].inline_data.mime_type;
+
+    expect(mime).toBe('audio/webm');
+    expect(mime).not.toContain(';');
+    expect(mime).not.toContain('codecs');
+  });
+
+  it('returns the transcribed text in the JSON response', async () => {
+    const blob = new Blob([new Uint8Array([1, 2, 3, 4])], {
+      type: 'audio/webm;codecs=opus',
+    });
+    const { response } = await invokeRoute(blob);
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.text).toBe('hello world');
+  });
+
+  it('returns 500 when GEMINI_API_KEY is missing', async () => {
+    vi.resetModules();
+    delete process.env.GEMINI_API_KEY;
+    const { POST } = await import('../../src/app/api/transcribe/route');
+
+    const form = new FormData();
+    form.append('audio', new Blob([new Uint8Array([1])], { type: 'audio/webm' }), 'clip.webm');
+    const req = new Request('http://localhost/api/transcribe', {
+      method: 'POST',
+      body: form,
+    });
+
+    const response = await POST(req as unknown as Parameters<typeof POST>[0]);
+    expect(response.status).toBe(500);
+    const json = await response.json();
+    expect(json.error).toMatch(/GEMINI_API_KEY/);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1012,6 +1012,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -1739,6 +1740,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1760,6 +1762,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1781,6 +1784,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1796,6 +1800,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1811,6 +1816,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1826,6 +1832,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1841,6 +1848,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1856,6 +1864,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1871,6 +1880,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1886,6 +1896,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1901,6 +1912,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1916,6 +1928,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1931,6 +1944,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1952,6 +1966,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1973,6 +1988,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1994,6 +2010,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2015,6 +2032,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2036,6 +2054,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2057,6 +2076,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2078,6 +2098,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2099,6 +2120,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
@@ -2117,6 +2139,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2135,6 +2158,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2153,6 +2177,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"

--- a/src/app/api/transcribe/route.ts
+++ b/src/app/api/transcribe/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest } from 'next/server';
+
+const GEMINI_URL =
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent';
+
+export async function POST(req: NextRequest) {
+  const key = process.env.GEMINI_API_KEY;
+  if (!key) {
+    return Response.json({ error: 'GEMINI_API_KEY not set' }, { status: 500 });
+  }
+
+  const form = await req.formData();
+  const file = form.get('audio');
+  if (!(file instanceof Blob)) {
+    return Response.json({ error: 'audio field required' }, { status: 400 });
+  }
+
+  const buf = Buffer.from(await file.arrayBuffer());
+  const base64 = buf.toString('base64');
+  const mime = file.type || 'audio/webm';
+
+  const res = await fetch(`${GEMINI_URL}?key=${key}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: [
+        {
+          parts: [
+            { inline_data: { mime_type: mime, data: base64 } },
+            { text: 'Transcribe this audio verbatim. Return only the transcript, no preamble.' },
+          ],
+        },
+      ],
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    return Response.json({ error: `Gemini ${res.status}: ${body}` }, { status: 502 });
+  }
+
+  const data = await res.json();
+  const text = data?.candidates?.[0]?.content?.parts?.[0]?.text?.trim() ?? '';
+  return Response.json({ text });
+}

--- a/src/app/api/transcribe/route.ts
+++ b/src/app/api/transcribe/route.ts
@@ -17,7 +17,12 @@ export async function POST(req: NextRequest) {
 
   const buf = Buffer.from(await file.arrayBuffer());
   const base64 = buf.toString('base64');
-  const mime = file.type || 'audio/webm';
+  // Gemini's MIME validator does not document whether it strips the
+  // ;codecs= parameter before matching, and Google's own docs disagree
+  // on whether audio/webm is in the allow-list. MediaRecorder in Chromium
+  // emits "audio/webm;codecs=opus" — strip the parameter so we send the
+  // plain base MIME and avoid the 200-with-empty-transcript black hole.
+  const mime = (file.type || 'audio/webm').split(';')[0].trim() || 'audio/webm';
 
   const res = await fetch(`${GEMINI_URL}?key=${key}`, {
     method: 'POST',

--- a/src/app/api/tts/route.ts
+++ b/src/app/api/tts/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest } from 'next/server';
+
+const TTS_URL =
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-tts:generateContent';
+
+// Gemini TTS returns raw 16-bit PCM mono at 24kHz. Browsers need a WAV header
+// to play it through <audio>, so we wrap the PCM bytes with a 44-byte RIFF/WAVE
+// header before returning the buffer to the client.
+function pcmToWav(pcm: Buffer, sampleRate = 24000, channels = 1, bitsPerSample = 16): Buffer {
+  const byteRate = (sampleRate * channels * bitsPerSample) / 8;
+  const blockAlign = (channels * bitsPerSample) / 8;
+  const dataSize = pcm.length;
+  const header = Buffer.alloc(44);
+
+  header.write('RIFF', 0);
+  header.writeUInt32LE(36 + dataSize, 4);
+  header.write('WAVE', 8);
+  header.write('fmt ', 12);
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);
+  header.writeUInt16LE(channels, 22);
+  header.writeUInt32LE(sampleRate, 24);
+  header.writeUInt32LE(byteRate, 28);
+  header.writeUInt16LE(blockAlign, 32);
+  header.writeUInt16LE(bitsPerSample, 34);
+  header.write('data', 36);
+  header.writeUInt32LE(dataSize, 40);
+
+  return Buffer.concat([header, pcm]);
+}
+
+export async function POST(req: NextRequest) {
+  const key = process.env.GEMINI_API_KEY;
+  if (!key) {
+    return Response.json({ error: 'GEMINI_API_KEY not set' }, { status: 500 });
+  }
+
+  const { text, voice = 'Aoede' } = await req.json();
+  if (!text || typeof text !== 'string') {
+    return Response.json({ error: 'text required' }, { status: 400 });
+  }
+
+  const res = await fetch(`${TTS_URL}?key=${key}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: [{ parts: [{ text }] }],
+      generationConfig: {
+        responseModalities: ['AUDIO'],
+        speechConfig: {
+          voiceConfig: { prebuiltVoiceConfig: { voiceName: voice } },
+        },
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    console.error('[TTS] Gemini error:', res.status, body.slice(0, 500));
+    return Response.json(
+      { error: `Gemini TTS ${res.status}`, detail: body.slice(0, 500) },
+      { status: 502 }
+    );
+  }
+
+  const data = await res.json();
+  const b64 = data?.candidates?.[0]?.content?.parts?.[0]?.inlineData?.data;
+  if (!b64) {
+    return Response.json({ error: 'No audio in response' }, { status: 502 });
+  }
+
+  const pcm = Buffer.from(b64, 'base64');
+  const wav = pcmToWav(pcm);
+  return new Response(new Uint8Array(wav), {
+    headers: {
+      'Content-Type': 'audio/wav',
+      'Cache-Control': 'no-store',
+    },
+  });
+}

--- a/src/components/Engine/ChatInterface.tsx
+++ b/src/components/Engine/ChatInterface.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, useRef, useEffect, useCallback, type ClipboardEvent, type DragEvent } from 'react';
-import { Send, Sparkles, Square, X, Image as ImageIcon, ArrowDown } from 'lucide-react';
+import { useState, useRef, useEffect, useCallback, useMemo, type ClipboardEvent, type DragEvent } from 'react';
+import { Send, Sparkles, Square, X, Image as ImageIcon, ArrowDown, Mic, Volume2, VolumeX } from 'lucide-react';
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { sendToGrip, filterResponseMetadata, detectGateInText, type GripMessage, type GripMetrics, type ToolUseEvent, type ToolResultEvent, type GateEvent } from '@/lib/grip-session';
 import TypingIndicator from './TypingIndicator';
@@ -24,6 +24,11 @@ import {
 } from '@/lib/chat-storage';
 import MarkdownContent from './MarkdownContent';
 import ModelSelector from './ModelSelector';
+import { speakCloud, stopSpeaking } from '@/hooks/useVoice';
+import VoiceConversation from './VoiceConversation';
+
+const AUTO_SPEAK_KEY = 'grip.voice.autoSpeak';
+const VOICE_ID_KEY = 'grip.voice.geminiVoice';
 
 // Module-level: tracks active streams across component mount/unmount cycles.
 // Enables session persistence when user switches tabs during streaming.
@@ -179,6 +184,11 @@ export default function ChatInterface({ chatId, onModelChange, isActive = true }
   }, [isActive]);
   const [pastedImage, setPastedImage] = useState<{ dataUrl: string; tempPath?: string } | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
+  const [voiceOpen, setVoiceOpen] = useState(false);
+  const [pendingVoiceSend, setPendingVoiceSend] = useState(false);
+  const [autoSpeak, setAutoSpeak] = useState(false);
+  const spokenIdsRef = useRef<Set<string>>(new Set());
+  const autoSpeakDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reduceMotion = useReducedMotion();
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
@@ -517,6 +527,88 @@ export default function ChatInterface({ chatId, onModelChange, isActive = true }
     e.preventDefault();
     setIsDragOver(false);
   }, []);
+ 
+  const handleVoiceTranscript = useCallback((text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    setInput(trimmed);
+    setPendingVoiceSend(true);
+  }, []);
+
+  useEffect(() => {
+    if (pendingVoiceSend && input.trim() && !isStreaming) {
+      setPendingVoiceSend(false);
+      handleSend();
+    }
+  }, [pendingVoiceSend, input, isStreaming, handleSend]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    setAutoSpeak(localStorage.getItem(AUTO_SPEAK_KEY) === '1');
+  }, []);
+
+  // Auto-speak newly completed assistant messages when the toggle is on.
+  // Fires immediately on streaming=false; otherwise debounces on content
+  // changes so messages paused mid-flight (e.g. awaiting a tool-permission
+  // gate) still get spoken after a short period of quiescence.
+  useEffect(() => {
+    if (!autoSpeak || voiceOpen) return;
+    const last = messages[messages.length - 1];
+    if (!last || last.role !== 'assistant' || !last.content) return;
+    if (spokenIdsRef.current.has(last.id)) return;
+
+    const idSnapshot = last.id;
+    const contentSnapshot = last.content;
+    const speak = () => {
+      if (spokenIdsRef.current.has(idSnapshot)) return;
+      spokenIdsRef.current.add(idSnapshot);
+      const voice = localStorage.getItem(VOICE_ID_KEY) || 'Aoede';
+      speakCloud(contentSnapshot, voice);
+    };
+
+    if (autoSpeakDebounceRef.current) clearTimeout(autoSpeakDebounceRef.current);
+    if (!last.streaming) {
+      speak();
+    } else {
+      autoSpeakDebounceRef.current = setTimeout(speak, 2500);
+    }
+
+    return () => {
+      if (autoSpeakDebounceRef.current) {
+        clearTimeout(autoSpeakDebounceRef.current);
+        autoSpeakDebounceRef.current = null;
+      }
+    };
+  }, [autoSpeak, voiceOpen, messages]);
+
+  // When the toggle flips ON, mark existing assistant messages as already
+  // spoken — the user expects auto-speak to apply to FUTURE replies, not
+  // replay the whole history.
+  useEffect(() => {
+    if (!autoSpeak) return;
+    for (const m of messages) {
+      if (m.role === 'assistant' && !m.streaming) spokenIdsRef.current.add(m.id);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoSpeak]);
+
+  const toggleAutoSpeak = useCallback(() => {
+    setAutoSpeak((prev) => {
+      const next = !prev;
+      localStorage.setItem(AUTO_SPEAK_KEY, next ? '1' : '0');
+      if (!next) stopSpeaking();
+      return next;
+    });
+  }, []);
+
+  const lastAssistantMessage = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === 'assistant') {
+        return { content: messages[i].content, streaming: !!messages[i].streaming };
+      }
+    }
+    return null;
+  }, [messages]);
 
   return (
     <div className="flex flex-col h-full">
@@ -695,6 +787,11 @@ export default function ChatInterface({ chatId, onModelChange, isActive = true }
                     <span className="font-mono text-[10px] tracking-wider text-[var(--muted-foreground)]">
                       {msg.timestamp.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })}
                     </span>
+                    {msg.role === 'assistant' && !msg.streaming && msg.content && (
+                      <button type="button" onClick={() => speakCloud(msg.content, localStorage.getItem(VOICE_ID_KEY) || 'Aoede')} aria-label="Speak message" className="text-[var(--muted-foreground)] opacity-40 hover:opacity-100 hover:text-[var(--primary)] transition-opacity">
+                        <Volume2 className="w-3 h-3" />
+                      </button>
+                    )}
                     {msg.metrics && (
                       <>
                         {msg.metrics.totalDurationMs && (
@@ -818,7 +915,30 @@ export default function ChatInterface({ chatId, onModelChange, isActive = true }
                 </button>
               )}
             </div>
-            {isStreaming ? (
+            <button
+              type="button"
+              onClick={toggleAutoSpeak}
+              aria-label={autoSpeak ? 'Disable auto-speak' : 'Enable auto-speak'}
+              title={autoSpeak ? 'Auto-speak: ON (replies will be read aloud)' : 'Auto-speak: OFF'}
+              className={`p-3 min-h-[48px] min-w-[48px] flex items-center justify-center border transition-colors ${
+                autoSpeak
+                  ? 'bg-[var(--primary)] border-[var(--primary)] text-[var(--primary-foreground)]'
+                  : 'bg-[var(--card)] border-[var(--border)] text-[var(--muted-foreground)] hover:border-[var(--primary)] hover:text-[var(--primary)]'
+              }`}
+            >
+              {autoSpeak ? <Volume2 className="w-4 h-4" /> : <VolumeX className="w-4 h-4" />}
+            </button>
+            <button
+              type="button"
+              onClick={() => setVoiceOpen(true)}
+              disabled={isStreaming}
+              aria-label="Open voice mode"
+              title="Voice conversation"
+              className="p-3 min-h-[48px] min-w-[48px] flex items-center justify-center border bg-[var(--card)] border-[var(--border)] text-[var(--muted-foreground)] hover:border-[var(--primary)] hover:text-[var(--primary)] transition-colors disabled:opacity-30"
+            >
+              <Mic className="w-4 h-4" />
+            </button>
+          {isStreaming ? (
               <button
                 onClick={handleStop}
                 className="bg-[var(--danger)] text-white p-3 min-h-[48px] min-w-[48px] flex items-center justify-center hover:opacity-90 transition-opacity"
@@ -861,6 +981,12 @@ export default function ChatInterface({ chatId, onModelChange, isActive = true }
           </div>
         </div>
       </div>
+      <VoiceConversation
+        open={voiceOpen}
+        onClose={() => setVoiceOpen(false)}
+        onTranscript={handleVoiceTranscript}
+        assistantMessage={lastAssistantMessage}
+      />
     </div>
   );
 }

--- a/src/components/Engine/VoiceConversation.tsx
+++ b/src/components/Engine/VoiceConversation.tsx
@@ -1,0 +1,272 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Mic, MicOff, X, Repeat } from 'lucide-react';
+import { useVoice, speakCloud, stopSpeaking, GEMINI_VOICES } from '@/hooks/useVoice';
+
+type AssistantMessage = { content: string; streaming: boolean } | null;
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onTranscript: (text: string) => void;
+  assistantMessage: AssistantMessage;
+}
+
+const VOICE_STORAGE_KEY = 'grip.voice.geminiVoice';
+const CONTINUOUS_STORAGE_KEY = 'grip.voice.continuous';
+
+type Phase = 'idle' | 'listening' | 'transcribing' | 'thinking' | 'speaking';
+
+export default function VoiceConversation({ open, onClose, onTranscript, assistantMessage }: Props) {
+  const [voiceId, setVoiceId] = useState<string>('Aoede');
+  const [continuous, setContinuous] = useState(false);
+  const [userText, setUserText] = useState('');
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [isSpeaking, setIsSpeaking] = useState(false);
+  const spokenRef = useRef<string>('');
+
+  const handleTranscript = useCallback((text: string, isFinal: boolean) => {
+    if (!isFinal) return;
+    setUserText(text);
+    setErrorMsg(null);
+    onTranscript(text);
+  }, [onTranscript]);
+
+  const handleError = useCallback((msg: string) => {
+    setErrorMsg(msg);
+  }, []);
+
+  const { isListening, isTranscribing, supported, start, stop } = useVoice(handleTranscript, handleError);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const savedVoice = localStorage.getItem(VOICE_STORAGE_KEY);
+    if (savedVoice && GEMINI_VOICES.some((v) => v.id === savedVoice)) {
+      setVoiceId(savedVoice);
+    }
+    const savedContinuous = localStorage.getItem(CONTINUOUS_STORAGE_KEY);
+    if (savedContinuous === '1') setContinuous(true);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(VOICE_STORAGE_KEY, voiceId);
+  }, [voiceId]);
+
+  useEffect(() => {
+    localStorage.setItem(CONTINUOUS_STORAGE_KEY, continuous ? '1' : '0');
+  }, [continuous]);
+
+  // When the modal opens, seed the "already-spoken" marker with whatever
+  // assistant content is currently visible. This prevents the modal from
+  // re-speaking a message that the main chat has already (or is about to)
+  // read aloud, which was causing an echo.
+  useEffect(() => {
+    if (open) spokenRef.current = assistantMessage?.content ?? '';
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // Speak only NEW assistant messages that arrive while the modal is open.
+  useEffect(() => {
+    if (!open || !assistantMessage) return;
+    if (assistantMessage.streaming) return;
+    if (!assistantMessage.content) return;
+    if (spokenRef.current === assistantMessage.content) return;
+    spokenRef.current = assistantMessage.content;
+
+    speakCloud(
+      assistantMessage.content,
+      voiceId,
+      () => setIsSpeaking(true),
+      () => {
+        setIsSpeaking(false);
+        if (continuous && open) setTimeout(() => start(), 250);
+      },
+    );
+  }, [open, assistantMessage, voiceId, continuous, start]);
+
+  // Cleanup when closing.
+  useEffect(() => {
+    if (!open) {
+      if (isListening) stop();
+      stopSpeaking();
+      setIsSpeaking(false);
+      spokenRef.current = '';
+      setUserText('');
+      setErrorMsg(null);
+    }
+  }, [open, isListening, stop]);
+
+  const phase: Phase = useMemo(() => {
+    if (isSpeaking) return 'speaking';
+    if (isTranscribing) return 'transcribing';
+    if (assistantMessage?.streaming) return 'thinking';
+    if (isListening) return 'listening';
+    return 'idle';
+  }, [isSpeaking, isTranscribing, assistantMessage, isListening]);
+
+  const phaseLabel: Record<Phase, string> = {
+    idle: 'TAP TO SPEAK',
+    listening: 'LISTENING',
+    transcribing: 'TRANSCRIBING',
+    thinking: 'THINKING',
+    speaking: 'SPEAKING',
+  };
+
+  const phaseColor: Record<Phase, string> = {
+    idle: 'var(--muted-foreground)',
+    listening: '#ef4444',
+    transcribing: 'var(--primary)',
+    thinking: 'var(--primary)',
+    speaking: '#22d3ee',
+  };
+
+  const toggleMic = () => {
+    if (isListening) stop();
+    else if (!isTranscribing && !assistantMessage?.streaming && !isSpeaking) start();
+  };
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          className="fixed inset-0 z-50 flex flex-col backdrop-blur-md bg-black/80"
+          onKeyDown={(e) => { if (e.key === 'Escape') onClose(); }}
+        >
+          <div className="flex items-center justify-between p-6 border-b border-[var(--border)]">
+            <div className="flex items-center gap-4">
+              <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">
+                VOICE MODE
+              </span>
+              <select
+                value={voiceId}
+                onChange={(e) => setVoiceId(e.target.value)}
+                className="bg-[var(--card)] border border-[var(--border)] text-[var(--foreground)] font-mono text-xs px-3 py-2 max-w-[260px]"
+              >
+                {GEMINI_VOICES.map((v) => (
+                  <option key={v.id} value={v.id}>
+                    {v.label}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={() => setContinuous((c) => !c)}
+                className={`flex items-center gap-2 font-mono text-[10px] tracking-widest px-3 py-2 border transition-colors ${
+                  continuous
+                    ? 'border-[var(--primary)] text-[var(--primary)]'
+                    : 'border-[var(--border)] text-[var(--muted-foreground)] hover:border-[var(--primary)]'
+                }`}
+                title="Continuous conversation: auto-restart mic after each reply"
+              >
+                <Repeat className="w-3 h-3" />
+                CONTINUOUS
+              </button>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close voice mode"
+              className="text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+
+          <div className="flex-1 flex flex-col items-center justify-center gap-10 px-8">
+            <motion.button
+              type="button"
+              onClick={toggleMic}
+              disabled={!supported}
+              whileTap={{ scale: 0.95 }}
+              className="relative w-48 h-48 flex items-center justify-center rounded-full disabled:opacity-30"
+              style={{ background: 'transparent' }}
+              aria-label={isListening ? 'Stop recording' : 'Start recording'}
+            >
+              <motion.span
+                className="absolute inset-0 rounded-full"
+                style={{ border: `2px solid ${phaseColor[phase]}` }}
+                animate={phase === 'listening' || phase === 'speaking'
+                  ? { scale: [1, 1.15, 1], opacity: [0.8, 0.3, 0.8] }
+                  : { scale: 1, opacity: 0.9 }}
+                transition={{ duration: 1.4, repeat: Infinity, ease: 'easeInOut' }}
+              />
+              <motion.span
+                className="absolute inset-4 rounded-full"
+                style={{ border: `1px solid ${phaseColor[phase]}`, opacity: 0.5 }}
+                animate={phase === 'listening' || phase === 'speaking'
+                  ? { scale: [1, 1.25, 1], opacity: [0.5, 0.1, 0.5] }
+                  : { scale: 1 }}
+                transition={{ duration: 1.8, repeat: Infinity, ease: 'easeInOut', delay: 0.2 }}
+              />
+              <div
+                className="relative w-24 h-24 rounded-full flex items-center justify-center"
+                style={{ backgroundColor: phaseColor[phase], opacity: phase === 'idle' ? 0.4 : 0.85 }}
+              >
+                {isListening ? (
+                  <MicOff className="w-10 h-10 text-white" />
+                ) : (
+                  <Mic className="w-10 h-10 text-white" />
+                )}
+              </div>
+            </motion.button>
+
+            <div className="flex flex-col items-center gap-2">
+              <motion.span
+                key={phase}
+                initial={{ opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="font-mono text-xs tracking-[0.3em]"
+                style={{ color: phaseColor[phase] }}
+              >
+                {phaseLabel[phase]}
+              </motion.span>
+              {errorMsg && (
+                <span className="font-mono text-[10px] tracking-wider text-[var(--danger)]">
+                  {errorMsg}
+                </span>
+              )}
+            </div>
+
+            <div className="w-full max-w-2xl flex flex-col gap-6">
+              {userText && (
+                <div className="flex flex-col gap-1">
+                  <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)]">
+                    YOU
+                  </span>
+                  <p className="text-[var(--foreground)] text-base leading-relaxed">
+                    {userText}
+                  </p>
+                </div>
+              )}
+              {assistantMessage?.content && (
+                <div className="flex flex-col gap-1">
+                  <span className="font-mono text-[10px] tracking-widest text-[var(--primary)]">
+                    GRIP
+                  </span>
+                  <p className="text-[var(--foreground)] text-base leading-relaxed">
+                    {assistantMessage.content}
+                    {assistantMessage.streaming && (
+                      <span className="inline-block w-2 h-4 ml-1 bg-[var(--primary)] animate-pulse align-middle" />
+                    )}
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="p-4 text-center">
+            <span className="font-mono text-[10px] tracking-widest text-[var(--muted-foreground)] opacity-60">
+              ESC TO CLOSE | {continuous ? 'AUTO-LOOP ON' : 'TAP MIC TO TALK'}
+            </span>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/hooks/useVoice.ts
+++ b/src/hooks/useVoice.ts
@@ -1,0 +1,215 @@
+'use client';
+
+import { useState, useRef, useCallback, useEffect } from 'react';
+
+type TranscriptCallback = (text: string, isFinal: boolean) => void;
+
+export function useVoice(onTranscript: TranscriptCallback, onError?: (msg: string) => void) {
+  const [isListening, setIsListening] = useState(false);
+  const [isTranscribing, setIsTranscribing] = useState(false);
+  const [supported, setSupported] = useState(false);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+
+  useEffect(() => {
+    setSupported(
+      typeof navigator !== 'undefined' &&
+        !!navigator.mediaDevices?.getUserMedia &&
+        typeof MediaRecorder !== 'undefined'
+    );
+  }, []);
+
+  const start = useCallback(async () => {
+    if (!supported) {
+      onError?.('Microphone recording not supported in this browser');
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      chunksRef.current = [];
+
+      const mime = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
+        ? 'audio/webm;codecs=opus'
+        : 'audio/webm';
+      const rec = new MediaRecorder(stream, { mimeType: mime });
+
+      rec.ondataavailable = (e) => {
+        if (e.data.size > 0) chunksRef.current.push(e.data);
+      };
+
+      rec.onstop = async () => {
+        streamRef.current?.getTracks().forEach((t) => t.stop());
+        streamRef.current = null;
+        setIsListening(false);
+
+        const blob = new Blob(chunksRef.current, { type: mime });
+        if (blob.size < 1000) {
+          onError?.('No audio captured');
+          return;
+        }
+
+        setIsTranscribing(true);
+        try {
+          const form = new FormData();
+          form.append('audio', blob, 'recording.webm');
+          const res = await fetch('/api/transcribe', { method: 'POST', body: form });
+          const json = await res.json();
+          if (!res.ok || json.error) {
+            onError?.(json.error || `Transcribe failed: ${res.status}`);
+          } else if (json.text) {
+            onTranscript(json.text, true);
+          }
+        } catch (err) {
+          onError?.(err instanceof Error ? err.message : 'Transcribe request failed');
+        } finally {
+          setIsTranscribing(false);
+        }
+      };
+
+      recorderRef.current = rec;
+      rec.start();
+      setIsListening(true);
+    } catch (err) {
+      onError?.(
+        err instanceof Error && err.name === 'NotAllowedError'
+          ? 'Microphone access denied'
+          : err instanceof Error
+            ? err.message
+            : 'Failed to start recording'
+      );
+      setIsListening(false);
+    }
+  }, [supported, onTranscript, onError]);
+
+  const stop = useCallback(() => {
+    if (recorderRef.current && recorderRef.current.state !== 'inactive') {
+      recorderRef.current.stop();
+    } else {
+      setIsListening(false);
+    }
+  }, []);
+
+  return { isListening, isTranscribing, supported, start, stop };
+}
+
+export function speakText(text: string): void {
+  if (typeof window === 'undefined') return;
+  window.speechSynthesis.cancel();
+  window.speechSynthesis.speak(new SpeechSynthesisUtterance(text));
+}
+
+// Gemini's 30 prebuilt TTS voices. Names are Greek-mythology themed; the
+// descriptors come from Google's voice gallery and help users pick by feel
+// rather than guessing from the name.
+export const GEMINI_VOICES: { id: string; label: string }[] = [
+  { id: 'Aoede', label: 'Aoede — Breezy' },
+  { id: 'Zephyr', label: 'Zephyr — Bright' },
+  { id: 'Puck', label: 'Puck — Upbeat' },
+  { id: 'Charon', label: 'Charon — Informative' },
+  { id: 'Kore', label: 'Kore — Firm' },
+  { id: 'Fenrir', label: 'Fenrir — Excitable' },
+  { id: 'Leda', label: 'Leda — Youthful' },
+  { id: 'Orus', label: 'Orus — Firm' },
+  { id: 'Callirrhoe', label: 'Callirrhoe — Easy-going' },
+  { id: 'Autonoe', label: 'Autonoe — Bright' },
+  { id: 'Enceladus', label: 'Enceladus — Breathy' },
+  { id: 'Iapetus', label: 'Iapetus — Clear' },
+  { id: 'Umbriel', label: 'Umbriel — Easy-going' },
+  { id: 'Algieba', label: 'Algieba — Smooth' },
+  { id: 'Despina', label: 'Despina — Smooth' },
+  { id: 'Erinome', label: 'Erinome — Clear' },
+  { id: 'Algenib', label: 'Algenib — Gravelly' },
+  { id: 'Rasalgethi', label: 'Rasalgethi — Informative' },
+  { id: 'Laomedeia', label: 'Laomedeia — Upbeat' },
+  { id: 'Achernar', label: 'Achernar — Soft' },
+  { id: 'Alnilam', label: 'Alnilam — Firm' },
+  { id: 'Schedar', label: 'Schedar — Even' },
+  { id: 'Gacrux', label: 'Gacrux — Mature' },
+  { id: 'Pulcherrima', label: 'Pulcherrima — Forward' },
+  { id: 'Achird', label: 'Achird — Friendly' },
+  { id: 'Zubenelgenubi', label: 'Zubenelgenubi — Casual' },
+  { id: 'Vindemiatrix', label: 'Vindemiatrix — Gentle' },
+  { id: 'Sadachbia', label: 'Sadachbia — Lively' },
+  { id: 'Sadaltager', label: 'Sadaltager — Knowledgeable' },
+  { id: 'Sulafat', label: 'Sulafat — Warm' },
+];
+
+let currentAudio: HTMLAudioElement | null = null;
+
+export function stopSpeaking(): void {
+  if (typeof window === 'undefined') return;
+  window.speechSynthesis.cancel();
+  if (currentAudio) {
+    currentAudio.pause();
+    currentAudio.src = '';
+    currentAudio = null;
+  }
+}
+
+// Strip markdown, code fences, URLs, and other artefacts so Gemini TTS gets
+// clean prose. The TTS model occasionally 502s on raw code blocks and long
+// URLs, and even when it accepts them the output is awkward to listen to.
+function cleanForSpeech(text: string): string {
+  return text
+    .replace(/```[\s\S]*?```/g, ' code block omitted ')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/https?:\/\/\S+/g, 'link')
+    .replace(/[#*_>~]+/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 4000);
+}
+
+// Cloud TTS via /api/tts (Gemini). Falls back to system speechSynthesis on
+// any error so the UI still speaks something rather than silently failing.
+export async function speakCloud(
+  text: string,
+  voice: string = 'Aoede',
+  onStart?: () => void,
+  onEnd?: () => void,
+): Promise<void> {
+  if (typeof window === 'undefined') return;
+  const cleaned = cleanForSpeech(text);
+  if (!cleaned) return;
+  stopSpeaking();
+
+  try {
+    const res = await fetch('/api/tts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: cleaned, voice }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      console.warn('[speakCloud] Gemini TTS failed, falling back to system voice:', res.status, body);
+      throw new Error(`TTS ${res.status}: ${body.error ?? 'unknown'}`);
+    }
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const audio = new Audio(url);
+    currentAudio = audio;
+    audio.onplay = () => onStart?.();
+    audio.onended = () => {
+      URL.revokeObjectURL(url);
+      if (currentAudio === audio) currentAudio = null;
+      onEnd?.();
+    };
+    audio.onerror = () => {
+      URL.revokeObjectURL(url);
+      if (currentAudio === audio) currentAudio = null;
+      onEnd?.();
+    };
+    await audio.play();
+  } catch (err) {
+    console.warn('[speakCloud] fallback to system voice:', err);
+    const utter = new SpeechSynthesisUtterance(cleaned);
+    utter.onstart = () => onStart?.();
+    utter.onend = () => onEnd?.();
+    utter.onerror = () => onEnd?.();
+    window.speechSynthesis.speak(utter);
+  }
+}

--- a/src/hooks/useVoice.ts
+++ b/src/hooks/useVoice.ts
@@ -95,7 +95,7 @@ export function useVoice(onTranscript: TranscriptCallback, onError?: (msg: strin
 }
 
 export function speakText(text: string): void {
-  if (typeof window === 'undefined') return;
+  if (typeof window === 'undefined' || !window.speechSynthesis) return;
   window.speechSynthesis.cancel();
   window.speechSynthesis.speak(new SpeechSynthesisUtterance(text));
 }
@@ -140,7 +140,7 @@ let currentAudio: HTMLAudioElement | null = null;
 
 export function stopSpeaking(): void {
   if (typeof window === 'undefined') return;
-  window.speechSynthesis.cancel();
+  if (window.speechSynthesis) window.speechSynthesis.cancel();
   if (currentAudio) {
     currentAudio.pause();
     currentAudio.src = '';
@@ -206,6 +206,10 @@ export async function speakCloud(
     await audio.play();
   } catch (err) {
     console.warn('[speakCloud] fallback to system voice:', err);
+    if (typeof window === 'undefined' || !window.speechSynthesis || typeof SpeechSynthesisUtterance === 'undefined') {
+      onEnd?.();
+      return;
+    }
     const utter = new SpeechSynthesisUtterance(cleaned);
     utter.onstart = () => onStart?.();
     utter.onend = () => onEnd?.();

--- a/src/hooks/useVoice.ts
+++ b/src/hooks/useVoice.ts
@@ -45,7 +45,9 @@ export function useVoice(onTranscript: TranscriptCallback, onError?: (msg: strin
         setIsListening(false);
 
         const blob = new Blob(chunksRef.current, { type: mime });
-        if (blob.size < 1000) {
+        // 200 bytes is roughly a ~0.1s WebM/Opus frame. The previous 1000
+        // floor silently dropped valid sub-0.5s utterances.
+        if (blob.size < 200) {
           onError?.('No audio captured');
           return;
         }
@@ -58,8 +60,12 @@ export function useVoice(onTranscript: TranscriptCallback, onError?: (msg: strin
           const json = await res.json();
           if (!res.ok || json.error) {
             onError?.(json.error || `Transcribe failed: ${res.status}`);
-          } else if (json.text) {
-            onTranscript(json.text, true);
+          } else if (json.text?.trim()) {
+            onTranscript(json.text.trim(), true);
+          } else {
+            // Gemini returned 200 with empty text — surface it instead of
+            // failing silently (Laurie's review: black-hole failure mode).
+            onError?.('No speech detected — try speaking closer to the mic or for longer.');
           }
         } catch (err) {
           onError?.(err instanceof Error ? err.message : 'Transcribe request failed');


### PR DESCRIPTION
## Summary
- Adds voice input (MediaRecorder → Gemini 2.0 Flash transcription) and speech output (Gemini 2.5 Flash TTS, 30 prebuilt voices) to the Engine chat
- New full-screen voice conversation modal with animated phase orb, voice picker, and continuous (auto-restart mic) mode
- Speaker toggle next to the mic reads every assistant reply aloud, with a debounce fallback so replies paused behind a tool-permission gate still get spoken

## Why this route
- Electron's bundled Chromium ships without Google's speech API key, so `webkitSpeechRecognition` silently returns nothing. Shipping MediaRecorder + a server-side Gemini call is the cleanest fix that keeps everything in the existing GRIP Commander process.
- Gemini 2.5 Flash TTS produces noticeably more natural output than the macOS system voices and exposes 30 prebuilt voices via a single API, avoiding a second provider (ElevenLabs/OpenAI) for the first cut.

## Files
- `src/app/api/transcribe/route.ts` - POST audio blob, returns transcript text
- `src/app/api/tts/route.ts` - POST text+voice, returns WAV-wrapped PCM
- `src/hooks/useVoice.ts` - MediaRecorder hook + `speakCloud` / `stopSpeaking` / `GEMINI_VOICES` utils. Strips markdown/code/URLs before TTS and caps text at 4k chars.
- `src/components/Engine/VoiceConversation.tsx` - modal with phase visualiser, voice dropdown, continuous toggle
- `src/components/Engine/ChatInterface.tsx` - wires the mic button to the modal, adds the speaker toggle, adds auto-speak with a 2.5s debounce for mid-stream quiescence

## Config
Requires `GEMINI_API_KEY` in `.env.local` (gitignored). No new npm dependencies.

## Test plan
- [ ] Set `GEMINI_API_KEY` in `.env.local`, run `npm run electron:dev`
- [ ] Type and send a normal message → confirms existing `grip:prompt` path still works
- [ ] Click the mic icon → modal opens → pick a voice (e.g. Sulafat, Achird) → tap the orb → grant mic permission → speak → tap again → transcript should land in the composer and auto-send
- [ ] Toggle the speaker icon (next to the mic) → reply streams → after streaming completes the reply is read aloud in the chosen voice
- [ ] Trigger a reply that contains a pending tool-permission gate → confirm auto-speak still fires after ~2.5s of content quiescence
- [ ] Open the modal while a reply is in flight → modal should not re-speak the already-visible message
- [ ] Toggle CONTINUOUS on → mic auto-restarts after each spoken reply
- [ ] Disable the speaker toggle mid-speech → audio stops
- [ ] Click the per-message speaker icon → plays that specific message via Gemini TTS

## Known follow-ups
- Free-tier Gemini TTS has an aggressive RPM limit; on 429 the hook currently falls back to the robotic `speechSynthesis` voice. Surfacing this in the UI and/or adding retry-with-backoff is a reasonable next step.
- No voice cloning yet. macOS Personal Voice works out of the box if created in System Settings (appears in the fallback list); ElevenLabs/Coqui XTTS would need a separate route.