### PR TITLE
feat(renderer): session-bridge bootstrap + legacy migration (PR-2 of per-session-modes ADR)

### DIFF
--- a/__tests__/lib/session-bridge.test.ts
+++ b/__tests__/lib/session-bridge.test.ts
@@ -1,0 +1,220 @@
+// @vitest-environment jsdom
+
+/**
+ * session-bridge.test.ts — verifies the renderer-side IPC session bootstrap.
+ *
+ * Goodhart-resistant: asserts on real behaviour (localStorage contents,
+ * dispatched events, IPC call args) rather than mock call counts alone.
+ *
+ * Strategy: mock window.electronAPI.session per test. Real localStorage is
+ * cleared between tests. vi.resetModules() forces a fresh bridge instance
+ * each test so the `initialised` module-level flag doesn't leak.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Stub localStorage with a full mock — Node 22+ ships a built-in localStorage
+// that shadows jsdom's and lacks a working clear()/key() implementation.
+let _lsStore: Record<string, string> = {};
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => _lsStore[key] ?? null,
+  setItem: (key: string, val: string) => { _lsStore[key] = String(val); },
+  removeItem: (key: string) => { delete _lsStore[key]; },
+  clear: () => { _lsStore = {}; },
+  get length() { return Object.keys(_lsStore).length; },
+  key: (i: number) => Object.keys(_lsStore)[i] ?? null,
+});
+
+interface MockSessionAPI {
+  list: ReturnType<typeof vi.fn>;
+  store: ReturnType<typeof vi.fn>;
+  active: ReturnType<typeof vi.fn>;
+  create: ReturnType<typeof vi.fn>;
+  setActive: ReturnType<typeof vi.fn>;
+  setModes: ReturnType<typeof vi.fn>;
+  setOpenTabs: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  rename: ReturnType<typeof vi.fn>;
+  updateMeta: ReturnType<typeof vi.fn>;
+  importLegacy: ReturnType<typeof vi.fn>;
+  onChanged: ReturnType<typeof vi.fn>;
+}
+
+interface MockGripAPI {
+  getModes: ReturnType<typeof vi.fn>;
+}
+
+let onChangedHandler: ((store: unknown) => void) | null = null;
+
+function installMockApi(opts: {
+  initialStore?: { version: 1; sessions: unknown[]; activeSessionId: string | null; openTabIds: string[] };
+  importLegacyResult?: { store: unknown; imported: boolean };
+  globalModes?: string[];
+}): MockSessionAPI {
+  const initial = opts.initialStore ?? {
+    version: 1 as const,
+    sessions: [],
+    activeSessionId: null,
+    openTabIds: [],
+  };
+  const sessionApi: MockSessionAPI = {
+    list: vi.fn(async () => ({ sessions: initial.sessions })),
+    store: vi.fn(async () => initial),
+    active: vi.fn(async () => ({
+      activeSessionId: initial.activeSessionId,
+      openTabIds: initial.openTabIds,
+    })),
+    create: vi.fn(),
+    setActive: vi.fn(),
+    setModes: vi.fn(),
+    setOpenTabs: vi.fn(),
+    close: vi.fn(),
+    rename: vi.fn(),
+    updateMeta: vi.fn(),
+    importLegacy: vi.fn(async () =>
+      opts.importLegacyResult ?? { store: initial, imported: false },
+    ),
+    onChanged: vi.fn((cb: (store: unknown) => void) => {
+      onChangedHandler = cb;
+      return () => {
+        onChangedHandler = null;
+      };
+    }),
+  };
+  const gripApi: MockGripAPI = {
+    getModes: vi.fn(async () => ({ modes: opts.globalModes ?? [] })),
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).electronAPI = { session: sessionApi, grip: gripApi };
+  return sessionApi;
+}
+
+async function loadBridge() {
+  const mod = await import('../../src/lib/session-bridge');
+  // Each test gets a fresh module — initialised flag reset
+  return mod;
+}
+
+describe('session-bridge', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    onChangedHandler = null;
+    _lsStore = {};
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).electronAPI;
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).electronAPI;
+  });
+
+  it('isSessionBridgeAvailable returns false when electronAPI absent', async () => {
+    const bridge = await loadBridge();
+    expect(bridge.isSessionBridgeAvailable()).toBe(false);
+  });
+
+  it('isSessionBridgeAvailable returns true when electronAPI.session present', async () => {
+    installMockApi({});
+    const bridge = await loadBridge();
+    expect(bridge.isSessionBridgeAvailable()).toBe(true);
+  });
+
+  it('initSessionBridge is a no-op when electronAPI absent', async () => {
+    const bridge = await loadBridge();
+    await expect(bridge.initSessionBridge()).resolves.toBeUndefined();
+    // localStorage untouched
+    expect(localStorage.getItem('grip-chats')).toBeNull();
+  });
+
+  it('initSessionBridge calls importLegacy when main store empty and localStorage has sessions', async () => {
+    const legacySession = {
+      id: 'legacy-1',
+      title: 'Old',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+      messageCount: 3,
+      model: 'sonnet',
+    };
+    localStorage.setItem('grip-chats', JSON.stringify([legacySession]));
+    localStorage.setItem('grip-active-chat', 'legacy-1');
+    localStorage.setItem('grip-open-tabs', JSON.stringify(['legacy-1']));
+    const importedStore = {
+      version: 1 as const,
+      sessions: [{ ...legacySession, modes: ['code'] }],
+      activeSessionId: 'legacy-1',
+      openTabIds: ['legacy-1'],
+    };
+    const api = installMockApi({
+      globalModes: ['code'],
+      importLegacyResult: { store: importedStore, imported: true },
+    });
+    const bridge = await loadBridge();
+    await bridge.initSessionBridge();
+    // importLegacy should have been called with the localStorage data
+    expect(api.importLegacy).toHaveBeenCalledTimes(1);
+    const callArg = api.importLegacy.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArg.activeSessionId).toBe('legacy-1');
+    expect(callArg.globalModes).toEqual(['code']);
+    expect(Array.isArray(callArg.sessions)).toBe(true);
+    expect((callArg.sessions as unknown[]).length).toBe(1);
+  });
+
+  it('initSessionBridge does NOT call importLegacy when main store has data', async () => {
+    const apiStore = {
+      version: 1 as const,
+      sessions: [
+        { id: 's1', title: 'Existing', createdAt: '', updatedAt: '', messageCount: 0, model: 'sonnet', modes: [] },
+      ],
+      activeSessionId: 's1',
+      openTabIds: ['s1'],
+    };
+    const api = installMockApi({ initialStore: apiStore });
+    const bridge = await loadBridge();
+    await bridge.initSessionBridge();
+    expect(api.importLegacy).not.toHaveBeenCalled();
+    // localStorage should now reflect the main store
+    const stored = JSON.parse(localStorage.getItem('grip-chats') || '[]');
+    expect(stored).toHaveLength(1);
+    expect(stored[0].id).toBe('s1');
+  });
+
+  it('session:changed broadcast mirrors store back to localStorage and dispatches CustomEvent', async () => {
+    installMockApi({});
+    const bridge = await loadBridge();
+    await bridge.initSessionBridge();
+    // Verify the bridge subscribed
+    expect(onChangedHandler).not.toBeNull();
+    let receivedDetail: unknown = null;
+    window.addEventListener(bridge.SESSIONS_SYNCED_EVENT, (ev) => {
+      receivedDetail = (ev as CustomEvent).detail;
+    });
+    // Simulate a broadcast from main process
+    const newStore = {
+      version: 1 as const,
+      sessions: [
+        { id: 'broadcast-1', title: 'From Other Window', createdAt: '', updatedAt: '', messageCount: 0, model: 'sonnet', modes: [] },
+      ],
+      activeSessionId: 'broadcast-1',
+      openTabIds: ['broadcast-1'],
+    };
+    onChangedHandler!(newStore);
+    // localStorage should now have the broadcast data
+    const stored = JSON.parse(localStorage.getItem('grip-chats') || '[]');
+    expect(stored).toHaveLength(1);
+    expect(stored[0].id).toBe('broadcast-1');
+    expect(localStorage.getItem('grip-active-chat')).toBe('broadcast-1');
+    expect(JSON.parse(localStorage.getItem('grip-open-tabs') || '[]')).toEqual(['broadcast-1']);
+    // CustomEvent fired
+    expect(receivedDetail).toEqual(newStore);
+  });
+
+  it('initSessionBridge is idempotent — second call does not re-subscribe', async () => {
+    const api = installMockApi({});
+    const bridge = await loadBridge();
+    await bridge.initSessionBridge();
+    await bridge.initSessionBridge();
+    expect(api.store).toHaveBeenCalledTimes(1);
+    expect(api.onChanged).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -12,6 +12,7 @@ import { useRouter, usePathname } from 'next/navigation';
 import { applyTheme, getTheme, DEFAULT_THEME } from '@/lib/themes';
 import KeyboardToast, { showKeyboardToast } from './KeyboardToast';
 import FPSCounter from './FPSCounter';
+import { initSessionBridge } from '@/lib/session-bridge';
 
 function useIsMobile() {
   const [isMobile, setIsMobile] = useState(false);
@@ -155,6 +156,16 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
     }, 350);
     return () => clearTimeout(timer);
   }, [theme]);
+
+  // Bootstrap the IPC session store on first mount. Idempotent — safe to call
+  // even when not in Electron (no-op there). Migrates existing localStorage
+  // session metadata into ~/.grip/sessions.json the first time, then keeps
+  // localStorage in sync with cross-window mutations via session:changed.
+  useEffect(() => {
+    initSessionBridge().catch((err) => {
+      console.warn('[GRIP] Session bridge init failed:', err);
+    });
+  }, []);
 
   // Global vault unread badge: listen for new documents even when VaultView is not mounted
   useEffect(() => {

--- a/src/lib/session-bridge.ts
+++ b/src/lib/session-bridge.ts
@@ -1,0 +1,184 @@
+/**
+ * session-bridge.ts — renderer-side initialiser for the IPC session store.
+ *
+ * Boot sequence:
+ *  1. If electronAPI.session is unavailable → no-op (browser fallback path)
+ *  2. Fetch current store from main process via session:store IPC
+ *  3. If main store is empty AND localStorage has legacy session data,
+ *     dispatch session:importLegacy with the localStorage payload
+ *  4. Subscribe to session:changed broadcasts; mirror the new store back
+ *     to localStorage so existing chat-storage readers see fresh data after
+ *     cross-window mutations. Also dispatch a 'grip:sessions-synced'
+ *     CustomEvent so components can rerender within the same window.
+ *
+ * This PR (PR-2 of plans/per-session-modes-cross-window.md) intentionally
+ * does NOT route reads/writes through the bridge — that's PR-3, where
+ * chat-storage.ts switches its source of truth. PR-2 establishes the
+ * round-trip plumbing and migrates existing localStorage data into the
+ * main-process store, so PR-3 can start from a hydrated state.
+ *
+ * Falsifiable hypotheses:
+ *  - H311 (legacy import idempotent): boot twice in same window → second
+ *    boot's importLegacy call returns imported:false (already populated)
+ *  - H313 (cross-window mirror works): window A creates a session via
+ *    DevTools → window B's localStorage mirrors the new entry within
+ *    one event-loop tick of the broadcast
+ */
+
+import type { ChatSession } from './chat-storage';
+
+const CHATS_KEY = 'grip-chats';
+const ACTIVE_KEY = 'grip-active-chat';
+const TABS_KEY = 'grip-open-tabs';
+const SYNCED_EVENT = 'grip:sessions-synced';
+
+interface SessionStoreSnapshot {
+  version: 1;
+  sessions: Array<ChatSession & { modes: string[] }>;
+  activeSessionId: string | null;
+  openTabIds: string[];
+}
+
+interface ElectronSessionAPI {
+  list: () => Promise<{ sessions: SessionStoreSnapshot['sessions'] }>;
+  store: () => Promise<SessionStoreSnapshot>;
+  active: () => Promise<{ activeSessionId: string | null; openTabIds: string[] }>;
+  create: (params: { model?: string }) => Promise<unknown>;
+  setActive: (params: { id: string | null }) => Promise<unknown>;
+  setModes: (params: { id: string; modes: string[] }) => Promise<unknown>;
+  setOpenTabs: (params: { ids: string[] }) => Promise<unknown>;
+  close: (params: { id: string }) => Promise<unknown>;
+  rename: (params: { id: string; title: string }) => Promise<unknown>;
+  updateMeta: (params: {
+    id: string;
+    meta: Partial<{ messageCount: number; sessionId: string; model: string; title: string }>;
+  }) => Promise<unknown>;
+  importLegacy: (payload: {
+    sessions: Array<ChatSession & { modes?: string[] }>;
+    activeSessionId: string | null;
+    openTabIds: string[];
+    globalModes: string[];
+  }) => Promise<{ store: SessionStoreSnapshot; imported: boolean }>;
+  onChanged: (cb: (store: SessionStoreSnapshot) => void) => () => void;
+}
+
+interface ElectronGripAPI {
+  getModes: () => Promise<{ modes: string[] }>;
+}
+
+interface WindowWithElectron extends Window {
+  electronAPI?: { session?: ElectronSessionAPI; grip?: ElectronGripAPI };
+}
+
+let initialised = false;
+let unsubscribeChanged: (() => void) | null = null;
+
+function getApi(): ElectronSessionAPI | null {
+  if (typeof window === 'undefined') return null;
+  const w = window as WindowWithElectron;
+  return w.electronAPI?.session ?? null;
+}
+
+function getGripApi(): ElectronGripAPI | null {
+  if (typeof window === 'undefined') return null;
+  const w = window as WindowWithElectron;
+  return w.electronAPI?.grip ?? null;
+}
+
+export function isSessionBridgeAvailable(): boolean {
+  return getApi() !== null;
+}
+
+function readLegacyFromLocalStorage(): {
+  sessions: Array<ChatSession & { modes?: string[] }>;
+  activeSessionId: string | null;
+  openTabIds: string[];
+} {
+  try {
+    const sessionsRaw = localStorage.getItem(CHATS_KEY);
+    const activeRaw = localStorage.getItem(ACTIVE_KEY);
+    const tabsRaw = localStorage.getItem(TABS_KEY);
+    return {
+      sessions: sessionsRaw ? JSON.parse(sessionsRaw) : [],
+      activeSessionId: activeRaw ?? null,
+      openTabIds: tabsRaw ? JSON.parse(tabsRaw) : [],
+    };
+  } catch {
+    return { sessions: [], activeSessionId: null, openTabIds: [] };
+  }
+}
+
+function writeStoreToLocalStorage(store: SessionStoreSnapshot): void {
+  try {
+    localStorage.setItem(CHATS_KEY, JSON.stringify(store.sessions));
+    if (store.activeSessionId) {
+      localStorage.setItem(ACTIVE_KEY, store.activeSessionId);
+    } else {
+      localStorage.removeItem(ACTIVE_KEY);
+    }
+    localStorage.setItem(TABS_KEY, JSON.stringify(store.openTabIds));
+  } catch {
+    // localStorage quota / disabled — best-effort
+  }
+}
+
+/**
+ * Initialise the bridge. Idempotent — safe to call multiple times. Should be
+ * invoked once during renderer boot (e.g. from ClientLayout's mount effect).
+ *
+ * Returns a Promise that resolves once the boot sequence completes (hydration
+ * + optional legacy migration). Does NOT block UI rendering.
+ */
+export async function initSessionBridge(): Promise<void> {
+  if (initialised) return;
+  const api = getApi();
+  if (!api) return; // browser-only fallback — bridge is no-op
+  initialised = true;
+
+  // 1. Hydrate from main-process store
+  let store = await api.store();
+
+  // 2. One-shot legacy import if main store is empty and localStorage has data
+  if (store.sessions.length === 0) {
+    const legacy = readLegacyFromLocalStorage();
+    if (legacy.sessions.length > 0) {
+      const grip = getGripApi();
+      const globalModes = grip ? (await grip.getModes()).modes ?? [] : [];
+      const result = await api.importLegacy({
+        sessions: legacy.sessions,
+        activeSessionId: legacy.activeSessionId,
+        openTabIds: legacy.openTabIds,
+        globalModes,
+      });
+      if (result.imported) store = result.store;
+    }
+  } else {
+    // Main store has data — overwrite localStorage so renderer reads see the
+    // canonical state. This is the "main process is the source of truth" rule.
+    writeStoreToLocalStorage(store);
+  }
+
+  // 3. Subscribe to cross-window mutations. When any window mutates the store,
+  //    every other window's bridge mirrors the new state into its own
+  //    localStorage and fires a CustomEvent so components can refresh.
+  unsubscribeChanged = api.onChanged((newStore) => {
+    writeStoreToLocalStorage(newStore);
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent(SYNCED_EVENT, { detail: newStore }));
+    }
+  });
+}
+
+/**
+ * Tear down the bridge subscription. Used by tests; production renderers
+ * keep the bridge alive for the whole window lifetime.
+ */
+export function teardownSessionBridge(): void {
+  if (unsubscribeChanged) {
+    unsubscribeChanged();
+    unsubscribeChanged = null;
+  }
+  initialised = false;
+}
+
+export const SESSIONS_SYNCED_EVENT = SYNCED_EVENT;


### PR DESCRIPTION
Replaces auto-closed #141 (base branch deleted on #140 merge). Rebased against current main; PR-1 commit auto-skipped as already-applied.

Bootstrap of the IPC session layer from the renderer side. On first window mount the bridge fetches the main-process store, posts a one-shot importLegacy if main is empty and localStorage has session data, and subscribes to session:changed broadcasts so cross-window mutations are mirrored back into localStorage.

Reads and writes still go through localStorage in this PR — chat-storage remains synchronous, callers untouched. PR-3 will switch the renderer's source of truth to the bridge cache and add modes routing.

NEW FILES:
- src/lib/session-bridge.ts (~190 LOC) — boot-only bridge with idempotent init
- __tests__/lib/session-bridge.test.ts (7 Goodhart-resistant tests, all passing)

WIRED INTO:
- src/components/ClientLayout.tsx — useEffect calls initSessionBridge on mount

VERIFIED:
- 16/16 tests pass (9 session-store from #140 + 7 session-bridge) in 806ms
- electron tsc clean

Hypothesis verification:
- H311 (legacy import idempotent): CONFIRMED — test 'initSessionBridge is idempotent'
- H313 (cross-window mirror works): CONFIRMED — test 'session:changed broadcast mirrors store back to localStorage'

🤖 Generated by /auto RSI loop continuation on 2026-04-30