### PR TITLE
build: pin supported Node range and hard-fail install on unsupported Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "main": "electron/dist/main.js",
   "scripts": {
+    "preinstall": "node scripts/check-node-version.mjs",
     "dev": "next dev",
     "dev:network": "next dev -H 0.0.0.0",
     "build": "next build",
@@ -187,6 +188,9 @@
         }
       ]
     }
+  },
+  "engines": {
+    "node": ">=20 <23"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",

--- a/scripts/check-node-version.mjs
+++ b/scripts/check-node-version.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// Preinstall guard: hard-fail `npm install` / `npm ci` on an unsupported Node.
+//
+// WHY THIS EXISTS
+// Some machines default to a bleeding-edge Node (e.g. an M-series Mac whose
+// `node` is v25). Against Node 23+ the better-sqlite3 ^11 native module has no
+// prebuilt binary and node-gyp fails compiling against the newer V8 headers, so
+// `npm install` breaks before anything downstream can run. A bare `engines`
+// field is only a WARNING — easy to miss — so the wrong Node gets silently used.
+// This guard turns that into a fast, clear, actionable failure.
+//
+// SOURCE OF TRUTH: package.json "engines.node" (read below, never duplicated).
+// CI uses Node 20 and .nvmrc pins Node 22 — both satisfy the declared range.
+//
+// Built-ins only: this runs BEFORE dependencies are installed, so it must not
+// import anything from node_modules (no `semver`). A tiny tuple-compare covers
+// the simple ">=A <B" comparator form the range uses.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(here, '..', 'package.json'), 'utf8'));
+const range = (pkg.engines && pkg.engines.node) ? String(pkg.engines.node) : '';
+const current = process.versions.node;
+
+// Compare two "major.minor.patch" strings: -1 / 0 / 1.
+function cmp(a, b) {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    const d = (pa[i] || 0) - (pb[i] || 0);
+    if (d !== 0) return d > 0 ? 1 : -1;
+  }
+  return 0;
+}
+
+// True if `version` satisfies a space-separated AND-range of simple comparators.
+// Unknown tokens are ignored (fail-open) so a guard bug can never block a
+// legitimate install; the npm-native engines warning remains a backstop.
+function satisfies(version, rangeStr) {
+  return rangeStr
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .every((token) => {
+      const m = token.match(/^(>=|<=|>|<|=)?\s*(\d+(?:\.\d+){0,2})$/);
+      if (!m) return true;
+      const op = m[1] || '=';
+      const base = m[2].split('.').concat(['0', '0']).slice(0, 3).join('.');
+      const c = cmp(version, base);
+      if (op === '>=') return c >= 0;
+      if (op === '>') return c > 0;
+      if (op === '<=') return c <= 0;
+      if (op === '<') return c < 0;
+      return c === 0;
+    });
+}
+
+if (range && !satisfies(current, range)) {
+  console.error(`\n[GRIP Commander] Unsupported Node ${process.version}.`);
+  console.error(`  Required: engines.node "${range}" (see .nvmrc -> 22; CI uses Node 20).`);
+  console.error(`  Why: better-sqlite3 ^11 has no prebuilt binary for Node 23+, and`);
+  console.error(`       node-gyp then fails compiling against newer V8 headers.`);
+  console.error(`  Fix (macOS): brew install node@22 && \\`);
+  console.error(`       PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm install\n`);
+  process.exit(1);
+}


### PR DESCRIPTION
## What this does (plain English)

On a fresh clone, `npm install` fails on a Mac whose default Node is **v25**.
better-sqlite3 (the embedded database we depend on) ships prebuilt binaries
only for supported Node versions. Against Node 23+, there is no prebuilt
binary, so npm falls back to compiling it from source with node-gyp — and that
compile fails against Node 25's newer V8 headers. Because `npm install` itself
dies, nothing downstream (rebuild, test, build, pack) can run. This is the
first thing that breaks for anyone cloning the repo with a bleeding-edge Node.

The repo already worked under **Node 22** (`.nvmrc` pins 22) and CI already
uses **Node 20** — the problem was only that nothing *stopped* the wrong Node
from being used silently.

## The fix

Make the supported Node range explicit and **enforce** it, so the wrong Node
can never be used by accident:

- **`engines.node": ">=20 <23"`** in `package.json` — the single source of
  truth for which Node versions are supported. Node 20 (CI) and Node 22 (local
  dev / `.nvmrc`) both satisfy it; Node 23/24/25 do not.
- **`scripts/check-node-version.mjs`** wired as a **`preinstall`** guard — it
  reads `engines.node` (no duplicated version numbers) and, if the running Node
  is out of range, hard-fails `npm install` / `npm ci` with a clear, actionable
  message telling the developer to use Node 22 (`brew install node@22`). It uses
  only Node built-ins, so it is safe to run before any dependencies exist.

We deliberately keep **better-sqlite3 on `^11`** (no version bump): it builds
correctly as a Mach-O arm64 binary under Node 22, and bumping it risks breaking
the `@types/better-sqlite3 ^7` pairing and the architecture-regression guards.

## Why a preinstall guard instead of an `.npmrc`

An `.npmrc engine-strict=true` would also enforce `engines`, but `.npmrc` files
commonly carry registry auth tokens, so committing one is risky by shape. The
preinstall guard keeps enforcement in `package.json`, is more robust (it runs on
both `npm install` and `npm ci` and prints a tailored fix), and never introduces
a token-bearing file.

## Test plan

Verified locally under Node 22:

- [x] `npm ci` → "added 1124 packages" (preinstall guard runs and passes)
- [x] `better_sqlite3.node` and `node-pty` `pty.node` are both **Mach-O arm64**
- [x] `npm test` → **1002 / 1002 pass**
- [x] Guard admits Node 20 and 22, blocks Node 23 / 24 / 25 (matches npm's own
      semver evaluation of the same range)
- [x] CI uses Node 20, which satisfies the range, so the CI `npm ci` step is
      unchanged

Note: pre-existing `npm run lint` errors and a pre-existing `npm run build`
TypeScript error (in `src/lib/session-bridge.ts`, unchanged by this PR) are
unrelated to this change and are not run by the PR CI workflow (`ci.yml` runs
`npm test` only; `build.yml` runs on tags).