### PR TITLE
build: make Node 22 the single canonical supported version (engines + README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ GRIP Commander bundles MCP servers for programmatic control:
 
 ### Prerequisites
 
-- **Node.js** 18+
+- **Node.js** 22 (LTS) — pinned in `.nvmrc`. Newer majors (e.g. 25) are unsupported: the `better-sqlite3` native module has no prebuilt binary and will not compile. `npm install` hard-fails on an unsupported Node by design.
 - **Claude Code CLI**: `npm install -g @anthropic-ai/claude-code`
 - **Claude login**: `claude login` (each user authenticates with their own Anthropic account)
 

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     }
   },
   "engines": {
-    "node": ">=20 <23"
+    "node": ">=22 <23"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",


### PR DESCRIPTION
## What this does (plain English)

The project currently says four different things about which version of Node it supports. That contradiction is the root cause that let someone build with a Node version (25) that breaks the app, because the database library (`better-sqlite3`) has no prebuilt binary for Node 23+ and the compile step crashes.

The four conflicting statements today:

| Where | Said |
|-------|------|
| `.nvmrc` | Node **22** |
| `package.json` engines | `>=20 <23` (allowed **20 or 22**) |
| `.github/workflows` (CI + release) | Node **20** |
| `README` | "Node.js **18+**" |

This PR makes **Node 22 (LTS)** the single answer, matching the value already pinned in `.nvmrc`:

- `package.json` engines: `>=20 <23` -> `>=22 <23`
- `README`: "Node.js 18+" -> "Node.js 22 (LTS); newer majors e.g. 25 are unsupported"

The existing preinstall guard (`scripts/check-node-version.mjs`, from PR #144) reads `engines.node`, so tightening engines automatically tightens the hard-fail install check — no extra wiring needed.

## IMPORTANT — needs a human + a follow-up before/with merge

This PR is intentionally **not** auto-merged. Tightening engines to `>=22 <23` means the **existing** preinstall guard will hard-fail `npm ci` on any Node outside 22. **CI and the release build still pin Node 20**, so as soon as this lands, `npm ci` on those runners fails the guard and CI goes red.

The fix is to bump both workflows to read the pinned version:

```yaml
# .github/workflows/ci.yml  and  .github/workflows/build.yml
- uses: actions/setup-node@v4
  with:
    node-version-file: '.nvmrc'   # was: node-version: 20
    cache: 'npm'
```

That change **could not** go in this PR: GitHub suppresses `pull_request` CI triggers when a PR modifies files under `.github/workflows/`, which would silently break CI for the PR. It must land as a **separate workflow-only change on `main`**, either just before this PR or merged together by an admin who accepts the trigger caveat.

A small `engine-strict=true` npm config (belt-and-braces over the existing guard) belongs with that same workflow follow-up.

**Merge order:** (1) bump the two workflows to `node-version-file: .nvmrc` on main, then (2) merge this PR. Done the other way round, CI is red.

## Also found (pre-existing, not caused by this PR)

While verifying locally on Node 22 I hit two failures that already exist on `main` and are unrelated to the Node-version change (this PR touches no source files):

- **`npm run build` fails** at the TypeScript type-check: `src/lib/session-bridge.ts:69` — `WindowWithElectron` incompatibly extends `Window` (`electronAPI` missing `pty`, `agent`, `skill`, `fs`, and 5 more). Note: CI does not run `npm run build` (only `npm test`), so this is not a required check, but it blocks local release builds.
- **`npm run lint` fails** with 93 errors / 176 warnings across `src/**` (unused vars, `no-img-element`, `no-require-imports`). Lint is not wired into CI either.

Both are worth separate tracked follow-ups.

## Test plan

- [x] `npm test` on Node 22 — green, 1002 tests / 49 files
- [ ] CI green — will be RED until the workflow Node bump lands on main (see above)
- [ ] `npm run build` — pre-existing type error, separate issue
