### PR TITLE
fix(session-bridge): resolve TS2430 type error blocking the Mac build and commander:pack

### DIFF
--- a/src/lib/session-bridge.ts
+++ b/src/lib/session-bridge.ts
@@ -66,9 +66,13 @@ interface ElectronGripAPI {
   getModes: () => Promise<{ modes: string[] }>;
 }
 
-interface WindowWithElectron extends Window {
+// Intersection alias, NOT `interface extends Window`: re-declaring the
+// inherited `electronAPI` (globally `ElectronAPI`, see types/electron.d.ts)
+// with a narrower literal triggers TS2430. An `&` intersection composes the
+// session/grip shape onto Window without overriding the inherited member.
+type WindowWithElectron = Window & {
   electronAPI?: { session?: ElectronSessionAPI; grip?: ElectronGripAPI };
-}
+};
 
 let initialised = false;
 let unsubscribeChanged: (() => void) | null = null;


### PR DESCRIPTION
## What this does (plain English)

The Mac app build was completely broken by a single TypeScript error. Running `npm run build` (or `npm run commander:pack` to package the desktop app) failed type-checking on **one line** — `src/lib/session-bridge.ts:69` — and because the packaging script dies on that step, **no Mac app was ever produced**. This PR fixes that one line so the build passes and the app packages again.

### The bug
`session-bridge.ts` declared:

```ts
interface WindowWithElectron extends Window {
  electronAPI?: { session?: ElectronSessionAPI; grip?: ElectronGripAPI }
}
```

The browser's `Window` type already has `electronAPI` — and globally (`src/types/electron.d.ts`) it's the **full** `ElectronAPI` (pty, agent, skill, fs, claude, settings, +30 more keys). Re-declaring an inherited property with a **narrower, incompatible** 2-key shape is a `TS2430` error under `strict`. So `next build` compiled fine, then failed the type-check, and `commander:pack` died at step **[1/5]** before ever reaching native-module rebuild or electron-builder.

### The fix
Change the `interface … extends Window` into a `Window` **intersection type alias**:

```ts
type WindowWithElectron = Window & {
  electronAPI?: { session?: ElectronSessionAPI; grip?: ElectronGripAPI }
}
```

An `&` intersection **composes** the session/grip shape onto `Window` instead of overriding the inherited member, so `TS2430` cannot fire. This is the minimal, correct, atomic fix — one file, +6/−2 lines.

**Why not move the types into `electron.d.ts` (the 'DRY' option)?** The two local interfaces are used *only* in this file, and the other 8 `electronAPI.session`/`.grip` call-sites in the codebase already access them via `(window as any)` with differing grip shapes — so there is no shared canonical type to hoist. Hoisting would widen the blast radius for no real DRY gain.

## Test plan (all run locally under Node 22)
- [x] `npm run build` — compiles + type-checks clean, **0 TS errors**, no TS2430 ("✓ Compiled successfully in 2.9s")
- [x] `npm test` — **1002 tests pass** (49 files, incl. `session-bridge.test.ts`)
- [x] `npm run commander:pack` (with `SKIP_NOTARIZE=1 CSC_IDENTITY_AUTO_DISCOVERY=false`, matching CI `build.yml`) — **completes all 5 steps** and produces `release/mac-arm64/GRIP Commander.app`; `verify-native-arch` reports `PASS: all native modules match target`
- [x] `eslint src/lib/session-bridge.ts` — clean (repo-wide lint baseline is pre-existing and unchanged by this PR; lint is not a gated CI check)

## Notes
- The required PR check is `CI - Tests` (`npm test` on Node 20). `build.yml` only runs on tag push / manual dispatch, not on PRs.
- The local node v25 (Homebrew) is currently broken by an unrelated missing `libsimdjson` dylib; all verification was done with `node@22` (22.23.0), which is the supported range.