### PR TITLE
docs: correct Node requirement to 22 (was 18+) and document native-module rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,9 +243,20 @@ GRIP Commander bundles MCP servers for programmatic control:
 
 ### Prerequisites
 
-- **Node.js** 18+
+- **Node.js 22** (`.nvmrc` pins it). The supported range is `engines.node` `>=20 <23` — CI runs on Node 20, local dev uses Node 22. **Node 23, 24 and 25 are not supported**: `better-sqlite3` ^11 has no prebuilt binary for them and `node-gyp` fails compiling against the newer V8 headers. The `preinstall` guard (`scripts/check-node-version.mjs`) hard-fails a wrong Node before anything installs.
 - **Claude Code CLI**: `npm install -g @anthropic-ai/claude-code`
 - **Claude login**: `claude login` (each user authenticates with their own Anthropic account)
+
+> **macOS / no version manager.** If `node --version` reports 23+ and you have no
+> `nvm`/`fnm` installed (so `.nvmrc` is not honoured automatically), install and
+> select Node 22 explicitly before building:
+>
+> ```bash
+> brew install node@22
+> # one-off, per shell — no global switch needed:
+> export PATH="/opt/homebrew/opt/node@22/bin:$PATH"
+> node --version            # must print v22.x before continuing
+> ```
 
 ### Install (any platform)
 
@@ -255,14 +266,21 @@ GRIP Commander bundles MCP servers for programmatic control:
 
 ### Build from Source
 
+Build on **Node 22** (see Prerequisites — confirm `node --version` prints `v22.x` first).
+
 ```bash
 git clone https://github.com/CodeTonight-SA/GRIP-GUI.git
 cd GRIP-GUI
-npm install
-npx @electron/rebuild
+npm install                   # preinstall guard rejects an unsupported Node
+npx @electron/rebuild         # rebuild better-sqlite3 + node-pty against Electron's ABI
 npm run electron:dev          # Development mode
 npm run commander:dmg         # Build unsigned DMG
 ```
+
+`npx @electron/rebuild` compiles the native modules (`better-sqlite3`, `node-pty`)
+against Electron's bundled Node ABI rather than your system Node — skipping it
+causes `ERR_DLOPEN_FAILED` at launch. Re-run it after any `npm install` that
+touches a native dependency or after switching Node versions.
 
 ### Web Only (No Electron)
 


### PR DESCRIPTION
## What this does (plain English)

On a Mac, building or running GRIP Commander from source could fail outright. The README told developers "Node.js 18+", but the project actually requires **Node 22** — and it actively rejects anything newer than 22. When someone's Mac defaulted to a bleeding-edge Node (this machine had Homebrew's Node 25, which is itself broken — `node` aborts with a missing `libsimdjson` library), they'd hit one of two confusing failures:

- the install would be rejected by the project's own version guard, or
- the app would crash at launch with `ERR_DLOPEN_FAILED`, because the `better-sqlite3` native module had been compiled against the wrong Node version.

With no `nvm`/`fnm` installed, the `.nvmrc` pin (which says 22) was silently ignored, so nothing steered them to the right Node.

This PR fixes the **documentation** so the setup instructions match reality. No code changes — the version guard (`scripts/check-node-version.mjs`), the `engines.node` field (`>=20 <23`), and the native-arch verifier already exist and are correct. The README was simply lying about which Node to use.

## Changes

- **Prerequisites**: "Node.js 18+" → "Node.js 22" with the real supported range (`>=20 <23`; CI runs Node 20), and an explanation of why 23/24/25 are unsupported (`better-sqlite3` ^11 has no prebuilt binary for them).
- **macOS recipe**: a copy-paste block to select `node@22` via `PATH` when no version manager is installed, so `.nvmrc` not being honoured is no longer a trap.
- **Build from Source**: note to confirm `node --version` is 22 first, and an explanation that `npx @electron/rebuild` compiles the native modules against Electron's ABI and must be re-run after switching Node or installing a native dependency.

## Verification (local, under node@22)

Reproduced the live blocker, then proved the documented fix resolves it:

- Before: `better-sqlite3` failed to load — `NODE_MODULE_VERSION 130` (Node 25 ABI) vs `127` (Node 22) → `ERR_DLOPEN_FAILED`.
- After `npm rebuild better-sqlite3` under node@22: loads cleanly (`rows=1`). `node-pty` loaded fine throughout (ships multi-platform prebuilds).
- `npm test` — **1002 passed / 49 files** (this is the CI-gating check), including `verify-native-arch.test.ts`.
- `npm run build` (`next build`) — passes, all routes compiled.
- `scripts/check-node-version.mjs` preinstall guard — passes on Node 22.

## Test plan

- [ ] CI green (`CI - Tests`: `npm ci` + `npm test` on Node 20)
- [x] `npm test` passes locally on Node 22 (1002 tests)
- [x] `npm run build` passes locally on Node 22
- [x] Native modules load after rebuild on Node 22

Note: `npm run lint` reports pre-existing errors (387, across generated/source files) on `main`. Lint is **not** a CI-gated step (`ci.yml` runs only `npm ci` + `npm test`), and this README-only change introduces none. Out of scope for this atomic doc fix; flagged for a separate lint-debt pass.
