### PR TITLE
fix(node): shell bootstrap to select a working Node when the default is dyld-broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,16 +247,24 @@ GRIP Commander bundles MCP servers for programmatic control:
 - **Claude Code CLI**: `npm install -g @anthropic-ai/claude-code`
 - **Claude login**: `claude login` (each user authenticates with their own Anthropic account)
 
-> **macOS / no version manager.** If `node --version` reports 23+ and you have no
-> `nvm`/`fnm` installed (so `.nvmrc` is not honoured automatically), install and
-> select Node 22 explicitly before building:
+> **macOS / no version manager.** If your default `node` is unsupported (23+) —
+> **or cannot start at all** (a `brew upgrade` can leave Homebrew's `node`
+> linked against a removed library, so `node --version` aborts with
+> `dyld: Library not loaded: .../libsimdjson.NN.dylib` and exits 134) — install a
+> supported Node once, then let the bootstrap put it on your PATH for this shell:
 >
 > ```bash
-> brew install node@22
-> # one-off, per shell — no global switch needed:
-> export PATH="/opt/homebrew/opt/node@22/bin:$PATH"
-> node --version            # must print v22.x before continuing
+> brew install node@22                    # one-time, if not already present
+> source scripts/use-supported-node.sh     # selects a working Node 22 for THIS shell
+> node --version                           # must print v22.x before continuing
 > ```
+>
+> `scripts/use-supported-node.sh` is pure POSIX shell, so it works even when the
+> default `node` is dyld-broken (the `preinstall` JS guard cannot run in that
+> case — it needs `node` to start). It is idempotent: if your `node` is already
+> supported it makes no change. It only **selects** an already-installed Node — it
+> never installs or repairs one; if none is found it prints the exact `brew`
+> command. The required major comes from `.nvmrc`.
 
 ### Install (any platform)
 
@@ -266,11 +274,14 @@ GRIP Commander bundles MCP servers for programmatic control:
 
 ### Build from Source
 
-Build on **Node 22** (see Prerequisites — confirm `node --version` prints `v22.x` first).
+Build on **Node 22** (see Prerequisites). If your default `node` is unsupported
+or broken, run `source scripts/use-supported-node.sh` first, then confirm
+`node --version` prints `v22.x`.
 
 ```bash
 git clone https://github.com/CodeTonight-SA/GRIP-GUI.git
 cd GRIP-GUI
+source scripts/use-supported-node.sh   # macOS: select a working Node 22 (no-op if already fine)
 npm install                   # preinstall guard rejects an unsupported Node
 npx @electron/rebuild         # rebuild better-sqlite3 + node-pty against Electron's ABI
 npm run electron:dev          # Development mode

--- a/scripts/use-supported-node.sh
+++ b/scripts/use-supported-node.sh
@@ -1,0 +1,82 @@
+# shellcheck shell=sh
+# Select a working, supported Node for this repo — even when the default `node`
+# cannot start at all.
+#
+# WHY THIS EXISTS (the gap the JS preinstall guard cannot cover)
+# `scripts/check-node-version.mjs` runs via `node`, so it only catches a Node
+# that STARTS but is the wrong version. On a real macOS failure the default
+# `node` is dyld-broken and aborts before it runs anything — e.g. Homebrew's
+# `node` linked against a `libsimdjson.NN.dylib` that a later `brew upgrade`
+# removed:
+#     dyld: Library not loaded: .../libsimdjson.29.dylib  (node exits 134)
+# When that happens `npm install`, `npm run dev`, and the whole `electron:dev`
+# chain die instantly and the JS guard never executes. This is pure POSIX sh:
+# it works with a dead `node`, and it prepends an already-installed supported
+# Node to PATH so the documented launch commands resolve a Node that runs.
+#
+# SOURCE OF TRUTH for the required major: .nvmrc (never duplicated here).
+#
+# Usage:
+#   source scripts/use-supported-node.sh   # fix PATH for the current shell
+#   sh     scripts/use-supported-node.sh    # print the export line + diagnose
+#
+# Honest scope: this only SELECTS an already-installed supported Node. It never
+# installs Node and never repairs a broken Homebrew keg. If no supported Node is
+# found it prints the exact install command and returns non-zero.
+
+_uns_repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+_uns_want_major=$(tr -dc '0-9' <"$_uns_repo_root/.nvmrc" 2>/dev/null | cut -c1-2)
+[ -n "$_uns_want_major" ] || _uns_want_major=22
+
+# Does the Node currently on PATH both START and report a supported major?
+# better-sqlite3 ^11 has no prebuilt for Node 23+, so the supported floor is the
+# .nvmrc major and the ceiling is < 23 (matches package.json engines.node).
+_uns_node_ok() {
+  _v=$(node --version 2>/dev/null) || return 1   # crash (e.g. dyld) => not ok
+  _maj=$(printf '%s' "$_v" | tr -dc '0-9.' | cut -d. -f1)
+  [ -n "$_maj" ] && [ "$_maj" -ge "$_uns_want_major" ] && [ "$_maj" -lt 23 ]
+}
+
+# Print the bin dir of the first working supported Node we can find, else nothing.
+_uns_find_bin() {
+  # 1) Homebrew keg-only node@<major> (Apple Silicon then Intel prefix).
+  for _p in "/opt/homebrew/opt/node@${_uns_want_major}/bin" \
+            "/usr/local/opt/node@${_uns_want_major}/bin"; do
+    if [ -x "$_p/node" ] && "$_p/node" --version >/dev/null 2>&1; then
+      printf '%s\n' "$_p"; return 0
+    fi
+  done
+  # 2) A version manager's installed copy (fnm / nvm), if present and supported.
+  for _mgr_node in \
+    "$HOME/.local/state/fnm_multishells"/*/bin/node \
+    "$HOME/Library/Application Support/fnm/node-versions/v${_uns_want_major}".*/installation/bin/node \
+    "$HOME/.nvm/versions/node/v${_uns_want_major}".*/bin/node; do
+    if [ -x "$_mgr_node" ] && "$_mgr_node" --version >/dev/null 2>&1; then
+      dirname -- "$_mgr_node"; return 0
+    fi
+  done
+  return 1
+}
+
+if _uns_node_ok; then
+  printf '[use-supported-node] node %s already supported — no change.\n' \
+    "$(node --version)" >&2
+else
+  _uns_bin=$(_uns_find_bin) || _uns_bin=''
+  if [ -n "$_uns_bin" ]; then
+    PATH="$_uns_bin:$PATH"
+    export PATH
+    printf '[use-supported-node] using node %s (%s)\n' \
+      "$("$_uns_bin/node" --version)" "$_uns_bin" >&2
+    # When run (not sourced), echo the line so `eval "$(...)"` also works.
+    case "$0" in *use-supported-node.sh) printf 'export PATH="%s:$PATH"\n' "$_uns_bin" ;; esac
+  else
+    printf '[use-supported-node] no working Node %s+ (<23) found.\n' "$_uns_want_major" >&2
+    printf '  Install it, then re-run:\n' >&2
+    printf '    brew install node@%s   # macOS\n' "$_uns_want_major" >&2
+    printf '    source scripts/use-supported-node.sh\n' >&2
+    case "$0" in *use-supported-node.sh) exit 1 ;; esac
+  fi
+fi
+
+unset _uns_repo_root _uns_want_major _uns_bin _uns_node_ok _uns_find_bin _v _maj _p _mgr_node 2>/dev/null || true


### PR DESCRIPTION
## What this does (plain English)

On a Mac, the system `node` can sometimes refuse to even start. A Homebrew
upgrade can leave Homebrew's `node` pointing at a library that a later upgrade
deleted, so running `node --version` crashes immediately:

```
dyld: Library not loaded: /opt/homebrew/opt/simdjson/lib/libsimdjson.29.dylib
```

(exit code 134). When that happens, **nothing runs** — `npm install`, `next dev`,
the Electron `tsc` step, and the whole `npm run electron:dev` chain all die before
they start, so GRIP Commander cannot be launched on that machine.

The project already has a guard (`scripts/check-node-version.mjs`) that rejects an
unsupported Node — but that guard is written in JavaScript, so it runs *via* Node.
If Node can't start at all, the guard never runs. It only catches a Node that
starts but is the wrong version, not a Node that is completely broken.

This PR closes that gap with a tiny shell helper that works even when Node is
dead.

## The fix

A new POSIX-shell script, `scripts/use-supported-node.sh`. You `source` it before
working in the repo:

```bash
source scripts/use-supported-node.sh
```

It:

- **Works when the default Node is broken**, because it is pure shell and never
  depends on Node starting.
- **Picks an already-installed supported Node** (Homebrew `node@22`, or an
  `fnm`/`nvm` copy) and puts it on your PATH for the current shell.
- **Is idempotent** — if your Node is already supported, it changes nothing.
- **Only selects** a Node; it never installs or repairs one. If none is found it
  prints the exact `brew install node@22` command.
- **Reads the required major from `.nvmrc`** (single source of truth) and uses the
  same `< 23` ceiling as `engines.node`, so the supported range is never
  duplicated.

The README's macOS section now points at this helper instead of asking the user
to hand-type a `PATH=` export, and documents the "Node won't start at all" case.

## Why it is safe / minimal

- Adds **one** shell script + README prose. No code, dependency, CI, or native
  changes.
- Pre-existing lint state is **unchanged** (1509 problems before and after — the
  helper is shell, not linted; README is prose). Lint is not a CI-gated check on
  this repo.

## Verified on the affected Mac (broken Homebrew node 25.2.1)

After `source scripts/use-supported-node.sh`:

- `node --version` → `v22.23.0`, `npm --version` → `10.9.8`
- `node scripts/check-node-version.mjs` → passes (it was previously unreachable)
- `tsc -p electron/tsconfig.json` → exit 0
- `npm test` → exit 0
- `npm run build` → exit 0

## Test plan

- [ ] On a Mac whose default `node` is broken/unsupported, run
      `source scripts/use-supported-node.sh`, confirm `node --version` prints
      `v22.x`, then `npm install && npm run electron:dev` launches.
- [ ] On a machine already on Node 22, confirm the script is a no-op.
- [ ] CI (`npm test`) is green.
