### PR TITLE
fix: rebuild native modules against Electron ABI in electron:dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "electron:dev": "concurrently \"npm run dev\" \"npm run electron:start\"",
-    "electron:start": "wait-on http://localhost:3000 && tsc -p electron/tsconfig.json && NODE_ENV=development electron .",
+    "electron:start": "npx @electron/rebuild -f --only better-sqlite3,node-pty && wait-on http://localhost:3000 && tsc -p electron/tsconfig.json && NODE_ENV=development electron .",
     "electron:build": "bash scripts/build-electron.sh mac arm64 dmg",
     "electron:pack": "bash scripts/build-electron.sh mac arm64 dir",
     "commander:dev": "concurrently \"npm run dev\" \"npm run electron:start\"",


### PR DESCRIPTION
## What this does (plain English)

If you set up GRIP Commander the obvious way — `npm install` then
`npm run electron:dev` — the app window opens but **agents, the document
vault, and the terminal are all silently dead**. This PR fixes that with
a one-line change to the dev script.

### Why it was broken

GRIP Commander uses two "native" modules — `better-sqlite3` (the vault's
database) and `node-pty` (the terminal/PTY). Native modules are compiled
binaries that must match the exact engine they run inside.

- `npm install` compiles them for the **Node** on your machine.
- The app runs inside **Electron 33**, which has its own, *different*
  Node engine (a different ABI — 130 vs Node 22's 127).

When the engines don't match, both modules fail to load at startup with
`ERR_DLOPEN_FAILED`. That error aborts the chain that registers all the
app's backend handlers, so the window still appears but nothing behind it
works. This is the same v0.4.0 startup regression that
`scripts/verify-native-arch.mjs` was written to catch.

The tool to fix it (`@electron/rebuild`) was already installed, and the
**release build** already rebuilds these modules correctly. The gap was
only the **dev run** — the README listed `npx @electron/rebuild` as a
separate manual step, which the two obvious commands skip.

### The fix

Fold the rebuild into the shared `electron:start` script (used by both
`electron:dev` and `commander:dev`), so it runs automatically just before
Electron launches:

```
npx @electron/rebuild -f --only better-sqlite3,node-pty
```

- `-f` (force) is **required**: after `npm install` the compiled file
  already exists, and `@electron/rebuild` otherwise assumes it is fine and
  skips it — leaving the wrong-engine binary in place. Verified: without
  `-f`, `better-sqlite3` still fails.
- `--only better-sqlite3,node-pty` keeps it fast by rebuilding just the
  two modules that need it.

### Why a dev-script change, not a `postinstall`

A `postinstall` would also run during the test CI job's `npm ci`, where
it is unnecessary and would switch the modules to Electron's engine —
risking the Node-based tests. `electron:start` runs **once per dev
session** (not on every renderer hot-reload), so the rebuild cost is paid
once at launch and never touches CI.

## Verification (local, Node 22)

Probed each module inside Electron's bundled Node:

- **Before:** `require('better-sqlite3')` -> `ERR_DLOPEN_FAILED`
- **After the rebuild:** `better-sqlite3` opens a DB and runs a query OK;
  `node-pty` spawns a process OK

## Test plan

- [x] `npm run build` — passes (exit 0)
- [x] `npm test` — passes (1002 tests, 49 files), including the
      `verify-native-arch` suite
- [x] Native modules load under Electron's ABI after the new
      `electron:start` rebuild step
- [ ] Smoke-launch the dev app on a fresh `npm install` and confirm the
      vault, agents, and terminal work (recommended manual check on a
      clean machine)

Note: `npm run lint` is red on `main` today (pre-existing issues in
generated bundle files); it is not part of CI and is unrelated to this
one-line change.
