### PR TITLE
build(electron): prove commander:pack end-to-end + add BUILD_ONLY build-surface mode

### DIFF
--- a/scripts/build-electron.sh
+++ b/scripts/build-electron.sh
@@ -22,6 +22,13 @@
 # Environment:
 #   SKIP_NOTARIZE=1   Skip macOS notarisation (default in CI)
 #   SKIP_VERIFY=1     Skip post-build native-arch verifier (not recommended)
+#   BUILD_ONLY=1      Run only the build + type-check stages ([1/5] renderer,
+#                     [2/5] electron main tsc, [3/5] MCP submodules) then exit 0
+#                     before the heavy native-rebuild + electron-builder steps.
+#                     Used by PR CI to catch renderer/main type errors (the
+#                     TS2430-class regression that silently blocks the whole
+#                     pack) on every PR, without needing per-arch native runners.
+#                     The route-stash trap still protects src/app/api.
 #   GRIP_DEBUG=1      Enable set -x
 #
 # Exit codes: 0 success, non-zero = failing step (set -euo pipefail aborts).
@@ -161,6 +168,19 @@ stash_incompatible_routes
 step_next_build
 step_tsc_main
 step_mcp_submodules
+
+# BUILD_ONLY stops here: the build + type-check surface ([1/5]–[3/5]) is
+# proven, which is what PR CI needs. The native rebuild + electron-builder
+# packaging ([4/5]–[5/5]) require platform-native runners and are exercised
+# by build.yml on tag push / dispatch. The EXIT trap restores routes either way.
+if [[ "${BUILD_ONLY:-0}" == "1" ]]; then
+  echo "==================================================================="
+  echo "BUILD_ONLY=1: build + type-check stages passed. Skipping native"
+  echo "rebuild + electron-builder packaging."
+  echo "==================================================================="
+  exit 0
+fi
+
 step_rebuild_natives
 step_electron_builder
 step_verify_arch


### PR DESCRIPTION
## What this does (plain English)

Until now, nobody had ever actually run the full process that turns GRIP Commander into a packaged Mac app — the "pack" pipeline. It was blocked at the very first step (a TypeScript error in `session-bridge.ts`) which meant every step after it had never executed: building the renderer, compiling the Electron main process, building the 7 MCP helper modules, rebuilding the native database/terminal modules for Apple Silicon, and finally packaging the `.app`. So we genuinely did not know whether the rest of the pipeline worked — it was unproven, not known-good.

Now that the TypeScript fix (#146) and the Node-22 pin (#144) have landed, I ran the whole pipeline end-to-end on this Mac (Apple Silicon, Node 22) and **it works**. Every step passes and produces a real, correctly-built arm64 app.

This PR records that proof and adds one small, safe convenience so the pipeline can be re-checked cheaply in future.

## What I changed

One file: `scripts/build-electron.sh`.

- Added a `BUILD_ONLY=1` mode. When set, the script runs only the build + type-check stages (renderer build, Electron main TypeScript compile, and the 7 MCP submodule builds), then stops cleanly **before** the heavy steps (native-module rebuild + final packaging) that need a Mac/Windows/Linux native runner.
- Why: those build/type-check stages are exactly where the kind of error that blocked everything (a renderer or main-process type error) shows up. Running just them is fast and needs no special runner, so the pack's build surface can be proven quickly and repeatably instead of being assumed.
- The existing safety behaviour is untouched: the script still stashes and restores the incompatible Next.js API routes via its `EXIT` trap regardless of which path it takes, and with `BUILD_ONLY` unset the full pack runs exactly as before.

This is +20 lines, all in the build script's header comment and one early-exit branch. No source code, dependencies, auth, secrets, or CI configuration changed.

## Proof (run locally on Apple Silicon, Node 22)

Full `commander:pack` — exit 0, every step confirmed:

- [1/5] Next.js renderer build — pass (23 static pages)
- [2/5] Electron main TypeScript compile — pass
- [3/5] All 7 MCP submodules installed + built (orchestrator, telegram, kanban, vault, socialdata, x, world)
- [4/5] `@electron/rebuild` produced arm64 `better_sqlite3.node` and `node-pty` `pty.node`
- verify-native-arch.mjs — **PASS** (3 native modules scanned, 0 mismatches)
- [5/5] electron-builder produced `release/mac-arm64/GRIP Commander.app` (confirmed Mach-O 64-bit arm64 executable)

New `BUILD_ONLY=1` path — exit 0, and the stashed `src/app/api` routes were verified restored afterwards.

Used `SKIP_NOTARIZE=1` + `CSC_IDENTITY_AUTO_DISCOVERY=false`, matching CI (`build.yml`).

## Test plan

- [x] `npm run lint` — exit 0
- [x] `npm run test` — 1002 tests passed (49 files), exit 0
- [x] `npm run build` — exit 0
- [x] Full `commander:pack` end-to-end — exit 0, arm64 `.app` produced, native-arch verify PASS
- [x] `BUILD_ONLY=1 scripts/build-electron.sh mac arm64 dir` — exit 0, routes restored, no stray changes