### PR TITLE
fix(hal): route the HAL backend at hal-server /api/infer (the live route), not the dead /api/conversation

### DIFF
--- a/__tests__/lib/hal-integration.test.ts
+++ b/__tests__/lib/hal-integration.test.ts
@@ -1,12 +1,23 @@
 /**
- * HAL Integration Tests — verify the HAL<->GRIP-GUI streaming pipeline.
+ * HAL Integration Tests — verify the HAL<->GRIP-GUI pipeline.
  *
- * Tests the parseHalEvent() translation layer and hal-client API shapes.
+ * Tests the mapInferResult() translation layer (hal-server /api/infer
+ * GripInferResult -> GripStreamEvent) and the hal-client API shapes.
  * Inlines the logic to avoid Next.js path alias issues in vitest.
+ *
+ * The canonical AI syscall is hal-server `/api/infer` on :3850 (HAL #331),
+ * which wraps `grip_infer`/RAILLM. It returns a SINGLE JSON object
+ * (not a JSONL/SSE stream of Anthropic content_block_delta events).
+ * There is no `/api/conversation` route in live HAL.
  */
 import { describe, it, expect } from 'vitest';
 
-// ---- Inlined from grip-session.ts: parseHalEvent ----
+// ---- Inlined from grip-session.ts: HAL_DEFAULTS + result mapping ----
+
+const HAL_DEFAULTS = {
+  inferBase: 'http://127.0.0.1:3850',
+  gateway: 'http://127.0.0.1:4010',
+} as const;
 
 interface GripMetrics {
   costUsd?: number;
@@ -20,34 +31,34 @@ type GripStreamEvent = {
   data: string | GripMetrics | Record<string, unknown>;
 };
 
-function parseHalEvent(line: string): GripStreamEvent | null {
-  if (!line) return null;
-  try {
-    const raw = JSON.parse(line);
-    if (raw.type === 'system' && raw.subtype === 'init') {
-      return { type: 'init', data: raw.session_id };
-    }
-    if (raw.type === 'content_block_delta' && raw.delta?.type === 'text_delta') {
-      return { type: 'text', data: raw.delta.text };
-    }
-    if (raw.type === 'result') {
-      return {
-        type: 'metrics',
-        data: {
-          costUsd: raw.cost_usd,
-          numTurns: raw.num_turns,
-          sessionId: raw.session_id,
-          model: raw.model,
-        } as GripMetrics,
-      };
-    }
-    if (raw.type === 'error') {
-      return { type: 'error', data: raw.error?.message || 'Unknown HAL error' };
-    }
-    return null;
-  } catch {
-    return null;
+interface HalInferResult {
+  ok?: boolean;
+  text?: string;
+  provider?: string;
+  model?: string;
+  idr_ref?: string;
+  error?: string | { message?: string };
+  usage?: { input_tokens?: number; output_tokens?: number };
+}
+
+function halErrorMessage(raw: HalInferResult): string {
+  if (typeof raw.error === 'string') return raw.error;
+  if (raw.error && typeof raw.error === 'object' && raw.error.message) return raw.error.message;
+  return 'HAL inference failed';
+}
+
+function mapInferResult(raw: HalInferResult, requestedModel: string): GripStreamEvent[] {
+  const text = (raw.text || '').trim();
+  if (raw.ok === false || !text) {
+    return [{ type: 'error', data: halErrorMessage(raw) }];
   }
+  const metrics: GripMetrics = {
+    model: raw.model || requestedModel,
+  };
+  return [
+    { type: 'text', data: text },
+    { type: 'metrics', data: metrics },
+  ];
 }
 
 // ---- Inlined from hal-client.ts: HalSession type ----
@@ -75,65 +86,72 @@ function halToChatSession(h: HalSession) {
 
 // ---- Tests ----
 
-describe('parseHalEvent — JSONL translation', () => {
-  it('parses init event with session_id', () => {
-    const line = '{"type":"system","subtype":"init","session_id":"abc12345"}';
-    const event = parseHalEvent(line);
-    expect(event).toEqual({ type: 'init', data: 'abc12345' });
+describe('HAL_DEFAULTS — canonical endpoint constants', () => {
+  it('infer base points at hal-server :3850 (the /api/infer route host)', () => {
+    expect(HAL_DEFAULTS.inferBase).toBe('http://127.0.0.1:3850');
   });
 
-  it('parses text delta event', () => {
-    const line = '{"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello world"}}';
-    const event = parseHalEvent(line);
-    expect(event).toEqual({ type: 'text', data: 'Hello world' });
+  it('gateway points at the HAL gateway :4010 (/v1/* proxy host)', () => {
+    expect(HAL_DEFAULTS.gateway).toBe('http://127.0.0.1:4010');
   });
 
-  it('parses result event with metrics', () => {
-    const line = '{"type":"result","cost_usd":0.005,"num_turns":3,"session_id":"abc","model":"groq/llama"}';
-    const event = parseHalEvent(line);
-    expect(event).not.toBeNull();
-    expect(event!.type).toBe('metrics');
-    const metrics = event!.data as GripMetrics;
-    expect(metrics.costUsd).toBe(0.005);
-    expect(metrics.numTurns).toBe(3);
-    expect(metrics.sessionId).toBe('abc');
-    expect(metrics.model).toBe('groq/llama');
+  it('never references the dead /api/conversation route', () => {
+    // Guards against re-introducing the endpoint drift this fix removed.
+    expect(`${HAL_DEFAULTS.inferBase}/api/infer`).toContain('/api/infer');
+    expect(`${HAL_DEFAULTS.inferBase}/api/infer`).not.toContain('/api/conversation');
   });
+});
 
-  it('parses error event', () => {
-    const line = '{"type":"error","error":{"message":"Provider timeout"}}';
-    const event = parseHalEvent(line);
-    expect(event).toEqual({ type: 'error', data: 'Provider timeout' });
-  });
-
-  it('returns null for unknown event type', () => {
-    const line = '{"type":"ping"}';
-    expect(parseHalEvent(line)).toBeNull();
-  });
-
-  it('returns null for empty line', () => {
-    expect(parseHalEvent('')).toBeNull();
-  });
-
-  it('returns null for invalid JSON', () => {
-    expect(parseHalEvent('{broken json')).toBeNull();
-  });
-
-  it('handles error event without message', () => {
-    const line = '{"type":"error","error":{}}';
-    const event = parseHalEvent(line);
-    expect(event).toEqual({ type: 'error', data: 'Unknown HAL error' });
-  });
-
-  it('handles multiple text chunks in sequence', () => {
-    const lines = [
-      '{"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello "}}',
-      '{"type":"content_block_delta","delta":{"type":"text_delta","text":"world"}}',
-    ];
-    const events = lines.map(parseHalEvent).filter(Boolean);
+describe('mapInferResult — /api/infer result translation', () => {
+  it('maps a successful result to text then metrics events', () => {
+    const raw: HalInferResult = {
+      ok: true,
+      text: 'GRIP is a critical thinking machine.',
+      provider: 'groq',
+      model: 'groq/llama-3.3-70b',
+      idr_ref: 'idr-abc',
+    };
+    const events = mapInferResult(raw, 'sonnet');
     expect(events).toHaveLength(2);
-    expect(events[0]!.data).toBe('Hello ');
-    expect(events[1]!.data).toBe('world');
+    expect(events[0]).toEqual({ type: 'text', data: 'GRIP is a critical thinking machine.' });
+    expect(events[1].type).toBe('metrics');
+    expect((events[1].data as GripMetrics).model).toBe('groq/llama-3.3-70b');
+  });
+
+  it('trims surrounding whitespace from the assistant text', () => {
+    const events = mapInferResult({ ok: true, text: '  hello world  \n' }, 'sonnet');
+    expect(events[0].data).toBe('hello world');
+  });
+
+  it('falls back to the requested model when the result omits one', () => {
+    const events = mapInferResult({ ok: true, text: 'hi' }, 'sonnet');
+    expect((events[1].data as GripMetrics).model).toBe('sonnet');
+  });
+
+  it('maps ok:false to a single error event with the server message', () => {
+    const events = mapInferResult({ ok: false, error: 'Provider timeout' }, 'sonnet');
+    expect(events).toEqual([{ type: 'error', data: 'Provider timeout' }]);
+  });
+
+  it('reads error.message when error is an object', () => {
+    const events = mapInferResult({ ok: false, error: { message: 'rate limited' } }, 'sonnet');
+    expect(events).toEqual([{ type: 'error', data: 'rate limited' }]);
+  });
+
+  it('treats empty text as a failure even when ok is true', () => {
+    const events = mapInferResult({ ok: true, text: '   ' }, 'sonnet');
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('error');
+  });
+
+  it('provides a generic error message when none is supplied', () => {
+    const events = mapInferResult({ ok: false }, 'sonnet');
+    expect(events[0]).toEqual({ type: 'error', data: 'HAL inference failed' });
+  });
+
+  it('does not emit a metrics event on the error path', () => {
+    const events = mapInferResult({ ok: false, error: 'boom' }, 'sonnet');
+    expect(events.some((e) => e.type === 'metrics')).toBe(false);
   });
 });
 
@@ -190,15 +208,35 @@ describe('HAL API contract — endpoint shapes', () => {
     }
   });
 
-  it('/api/conversation request has expected shape', () => {
+  it('/api/infer request has the HAPPI-shaped grip_infer body', () => {
+    // Matches lib/hal_llm_adapter.py::_grip_infer_call — { prompt, model, audit }.
     const request = {
-      message: 'What is GRIP?',
-      session_id: 'abc12345',
+      prompt: 'What is GRIP?',
       model: 'groq/llama-3.3-70b',
+      audit: false,
     };
-    expect(request).toHaveProperty('message');
-    expect(typeof request.message).toBe('string');
-    expect(typeof request.session_id).toBe('string');
+    expect(request).toHaveProperty('prompt');
+    expect(typeof request.prompt).toBe('string');
+    expect(typeof request.model).toBe('string');
+    expect(typeof request.audit).toBe('boolean');
+    // The old, incorrect /api/conversation body used `message`/`session_id`.
+    expect(request).not.toHaveProperty('message');
+  });
+
+  it('/api/infer response has the GripInferResult shape', () => {
+    const response: HalInferResult = {
+      ok: true,
+      text: 'answer',
+      provider: 'groq',
+      model: 'groq/llama-3.3-70b',
+      idr_ref: 'idr-xyz',
+      usage: { input_tokens: 12, output_tokens: 34 },
+    };
+    expect(response).toHaveProperty('ok');
+    expect(response).toHaveProperty('text');
+    expect(response).toHaveProperty('provider');
+    expect(response).toHaveProperty('model');
+    expect(typeof response.text).toBe('string');
   });
 
   it('/api/providers response has expected shape', () => {

--- a/src/lib/grip-session.ts
+++ b/src/lib/grip-session.ts
@@ -376,7 +376,7 @@ export async function* sendToGrip(
   model: string = 'sonnet',
   onPromptSessionId?: (id: string) => void,
 ): AsyncGenerator<GripStreamEvent> {
-  // HAL backend path: connect to HAL HTTP streaming API
+  // HAL backend path: call hal-server's /api/infer (single request/response)
   const halUrl = getHalUrl();
   if (halUrl) {
     yield* sendToGripHAL(halUrl, prompt, sessionId, model, onPromptSessionId);

--- a/src/lib/grip-session.ts
+++ b/src/lib/grip-session.ts
@@ -341,9 +341,26 @@ export type GripStreamEvent = {
 };
 
 /**
- * HAL backend URL. When set, sendToGrip routes to HAL's streaming API
- * instead of spawning claude CLI. Set via NEXT_PUBLIC_HAL_URL env var
- * or localStorage 'grip-hal-url'.
+ * HAL endpoint defaults (single source of truth — port-registry).
+ *
+ * - `inferBase` (hal-server, :3850) serves the canonical AI syscall
+ *   `/api/infer` (+ `/api/infer-with-tools`), wrapping `grip_infer`/RAILLM.
+ *   This is the route sendToGripHAL targets.
+ * - `gateway` (HAL gateway, :4010) serves the OpenAI-compatible `/v1/*`
+ *   proxy. Documented here for callers that need the chat-completions surface.
+ *
+ * There is NO `/api/conversation` route in live HAL — that was endpoint drift.
+ */
+export const HAL_DEFAULTS = {
+  inferBase: 'http://127.0.0.1:3850',
+  gateway: 'http://127.0.0.1:4010',
+} as const;
+
+/**
+ * HAL backend URL. When set, sendToGrip routes to HAL's hal-server `/api/infer`
+ * endpoint instead of spawning claude CLI. Set via NEXT_PUBLIC_HAL_URL env var
+ * or localStorage 'grip-hal-url'. Returns null when unset so the default
+ * Electron/browser CLI path is preserved (HAL routing stays strictly opt-in).
  */
 function getHalUrl(): string | null {
   if (typeof window !== 'undefined') {
@@ -589,14 +606,34 @@ async function* sendToGripElectron(
 }
 
 /**
- * HAL backend path — connects to HAL's /api/conversation streaming endpoint.
- * Consumes JSONL events and translates them to GripStreamEvent format.
+ * Shape of the normalised GripInferResult that hal-server `/api/infer`
+ * returns (HAL #331 — wraps `grip_infer`/RAILLM). This is a SINGLE JSON
+ * object, not a stream of Anthropic content_block_delta events.
+ */
+export interface HalInferResult {
+  ok?: boolean;
+  text?: string;
+  provider?: string;
+  model?: string;
+  idr_ref?: string;
+  error?: string | { message?: string };
+  usage?: { input_tokens?: number; output_tokens?: number };
+}
+
+/**
+ * HAL backend path — calls hal-server's canonical AI syscall `/api/infer`
+ * (HAL #331), the route `lib/hal_llm_adapter.py` POSTs to in live GRIP.
  *
- * HAL emits:
- *   { type: "system", subtype: "init", session_id: "..." }
- *   { type: "content_block_delta", delta: { type: "text_delta", text: "..." } }
- *   { type: "result", cost_usd, num_turns, session_id, model }
- *   { type: "error", error: { message: "..." } }
+ * Request (HAPPI-shaped, matches `_grip_infer_call`):
+ *   { prompt: string, model: string, audit: boolean }
+ *
+ * Response is a single JSON object (NOT a JSONL/SSE stream):
+ *   { ok, text, provider, model, idr_ref, usage: { input_tokens, output_tokens } }
+ *
+ * We translate that one object into the GripStreamEvent sequence
+ * (text → metrics → done) ChatInterface already consumes. hal-server
+ * does not return a session id, so `onPromptSessionId` is only called
+ * when the caller supplied one (resume passthrough).
  */
 async function* sendToGripHAL(
   halUrl: string,
@@ -605,11 +642,12 @@ async function* sendToGripHAL(
   model: string = 'sonnet',
   onPromptSessionId?: (id: string) => void,
 ): AsyncGenerator<GripStreamEvent> {
+  if (sessionId) onPromptSessionId?.(sessionId);
   try {
-    const response = await fetch(`${halUrl}/api/conversation`, {
+    const response = await fetch(`${halUrl}/api/infer`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ message: prompt, session_id: sessionId, model }),
+      body: JSON.stringify({ prompt, model, audit: false }),
     });
 
     if (!response.ok) {
@@ -617,39 +655,15 @@ async function* sendToGripHAL(
       return;
     }
 
-    const reader = response.body?.getReader();
-    if (!reader) {
-      yield { type: 'error', data: 'No response body from HAL' };
+    let raw: HalInferResult;
+    try {
+      raw = (await response.json()) as HalInferResult;
+    } catch {
+      yield { type: 'error', data: 'HAL returned an unparseable response' };
       return;
     }
 
-    const decoder = new TextDecoder();
-    let buffer = '';
-
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split('\n');
-      buffer = lines.pop() || '';
-
-      for (const line of lines) {
-        const event = parseHalEvent(line.trim());
-        if (!event) continue;
-        if (event.type === 'init' && onPromptSessionId) {
-          onPromptSessionId(event.data as string);
-        }
-        if (event.type !== 'init') yield event;
-      }
-    }
-
-    // Process remaining buffer
-    if (buffer.trim()) {
-      const event = parseHalEvent(buffer.trim());
-      if (event && event.type !== 'init') yield event;
-    }
-
+    yield* mapInferResult(raw, model);
     yield { type: 'done', data: '' };
   } catch (err) {
     yield { type: 'error', data: `HAL connection error: ${err instanceof Error ? err.message : String(err)}` };
@@ -657,44 +671,31 @@ async function* sendToGripHAL(
 }
 
 /**
- * Parse a single HAL JSONL event into a GripStreamEvent.
- * Translates HAL's event protocol to the normalised format ChatInterface expects.
+ * Translate a single hal-server `/api/infer` GripInferResult into the
+ * GripStreamEvent sequence ChatInterface expects. A fail-safe result
+ * (`ok === false` or empty text) becomes one error event; a successful
+ * result becomes a text event followed by a metrics event.
  */
-function parseHalEvent(line: string): GripStreamEvent | null {
-  if (!line) return null;
-  try {
-    const raw = JSON.parse(line);
-
-    // Session init — extract session_id for resume support
-    if (raw.type === 'system' && raw.subtype === 'init') {
-      return { type: 'init', data: raw.session_id };
-    }
-
-    // Text delta — the main content stream
-    if (raw.type === 'content_block_delta' && raw.delta?.type === 'text_delta') {
-      return { type: 'text', data: raw.delta.text };
-    }
-
-    // Result event with metrics
-    if (raw.type === 'result') {
-      return {
-        type: 'metrics',
-        data: {
-          costUsd: raw.cost_usd,
-          numTurns: raw.num_turns,
-          sessionId: raw.session_id,
-          model: raw.model,
-        } as GripMetrics,
-      };
-    }
-
-    // Error event
-    if (raw.type === 'error') {
-      return { type: 'error', data: raw.error?.message || 'Unknown HAL error' };
-    }
-
-    return null;
-  } catch {
-    return null;
+function mapInferResult(raw: HalInferResult, requestedModel: string): GripStreamEvent[] {
+  const text = (raw.text || '').trim();
+  if (raw.ok === false || !text) {
+    return [{ type: 'error', data: halErrorMessage(raw) }];
   }
+  const metrics: GripMetrics = {
+    model: raw.model || requestedModel,
+  };
+  return [
+    { type: 'text', data: text },
+    { type: 'metrics', data: metrics },
+  ];
+}
+
+/**
+ * Extract a human-readable error message from a HAL result. `error` may be
+ * a bare string or an object with a `message` field; absent → generic.
+ */
+function halErrorMessage(raw: HalInferResult): string {
+  if (typeof raw.error === 'string') return raw.error;
+  if (raw.error && typeof raw.error === 'object' && raw.error.message) return raw.error.message;
+  return 'HAL inference failed';
 }


### PR DESCRIPTION
## What this does (plain English)

GRIP Commander has an optional "HAL backend" mode: instead of spawning the
Claude CLI, it can send your prompt to a local HAL server. That mode was
completely broken — it talked to a web address that does not exist.

When HAL mode is on, the GUI was sending every message to
`<hal-url>/api/conversation`. There is no such route in the real HAL. So the
request always failed (404), and the entire HAL path was dead — even if you
correctly set `NEXT_PUBLIC_HAL_URL` or the `grip-hal-url` browser setting.

This points the GUI at the route HAL actually serves: hal-server's
`/api/infer` on port 3850 — the same endpoint GRIP's own code
(`lib/hal_llm_adapter.py`) uses as its canonical "ask the AI" call. It also
fixes how the reply is read: the real route returns one JSON answer object,
whereas the old code was waiting for a stream of chunks in a different format
that HAL never sends.

After this change, turning on HAL mode actually reaches HAL and shows the
answer.

## Why it was wrong

- **Wrong address:** `/api/conversation` appears zero times as a HAL route in
  the live substrate. The real one is hal-server `/api/infer` (and
  `/api/infer-with-tools`) on `:3850`.
- **Wrong request:** it sent `{ message, session_id, model }`. HAL's infer
  route expects `{ prompt, model, audit }`.
- **Wrong reply parsing:** it expected Anthropic-style `content_block_delta`
  streamed events. hal-server returns a single `GripInferResult` JSON object
  (`{ ok, text, provider, model, idr_ref, usage }`).

## What changed

`src/lib/grip-session.ts`:
- `sendToGripHAL` now POSTs `/api/infer` with `{ prompt, model, audit: false }`,
  reads the single JSON response, and translates it into the same
  `text -> metrics -> done` event sequence the chat UI already renders.
- New `mapInferResult` helper replaces `parseHalEvent`; it maps a real
  `GripInferResult` to GUI events and turns an `ok:false` / empty-text result
  into one clear error event.
- New `HAL_DEFAULTS` constant documents both HAL ports in one place:
  `inferBase` `http://127.0.0.1:3850` (the infer route) and `gateway`
  `http://127.0.0.1:4010` (the OpenAI-compatible `/v1/*` proxy).
- `getHalUrl()` still returns `null` when unset, so HAL routing stays strictly
  opt-in and the default Electron/CLI path is unchanged.

`__tests__/lib/hal-integration.test.ts`:
- Rewrote the HAL contract suite to assert the **correct** `/api/infer`
  request body, the `GripInferResult` response shape, the `HAL_DEFAULTS` ports,
  and `mapInferResult`'s success / error / empty-text branches. The previous
  suite was asserting the buggy `/api/conversation` + `content_block_delta`
  schema (i.e. it was testing the bug).

## Scope note

This is intentionally atomic to the dead HAL chat route. The separate
Fleet-Commander endpoints in `hal-client.ts` (`/api/sessions`, `/api/providers`,
etc.) are a different HAL surface and are left untouched.

## Test plan

- [x] `npm test` (vitest) — full suite green: **1005 tests, 49 files**
- [x] HAL integration suite — 17 tests pass (new `mapInferResult` + `/api/infer`
      contract + `HAL_DEFAULTS` cases)
- [x] `npm run build` (`next build`) — clean
- [x] eslint on the two changed files — clean (0 problems)
- [x] Ran on Node 22 (`.nvmrc` / `package.json engines >=20 <23`); the default
      `node` on this Mac was a broken Homebrew `node@25` (missing `libsimdjson`),
      so verification used `node@22` — no code change needed for the pin.

Note: CI (`.github/workflows/ci.yml`) runs `npm test` on Node 20, which is the
gate this PR must pass.