### PR TITLE
fix(api): /api/grip/status reads genome + instance with the correct file shapes

### DIFF
--- a/__tests__/lib/grip-readers.test.ts
+++ b/__tests__/lib/grip-readers.test.ts
@@ -1,0 +1,117 @@
+/**
+ * grip-readers.test.ts — verifies the shared genome/instance parsers extract
+ * the correct values from the REAL on-disk shapes of a live GRIP install.
+ *
+ * Goodhart-resistant: each fixture is the actual live shape (genes-as-dict,
+ * no top-level `fitness`, index-with-instances-list, no `sha` field). The
+ * assertions fail under the previous buggy logic that did `genes.length`,
+ * `genome.fitness`, `inst.sha`, `inst.generation`, `inst.messages` — so a
+ * regression to that logic turns these tests red.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseGenome, parseLatestInstance } from '@/lib/grip-readers';
+
+describe('parseGenome', () => {
+  // Live shape: genes is a DICT, fitness lives in fitness_history (last), and
+  // there is NO top-level `fitness` key.
+  const liveGenome = {
+    generation: 111,
+    genes: { a: {}, b: {}, c: {} },
+    fitness: null,
+    fitness_history: [0.4, 0.6, 0.8],
+  };
+
+  it('counts genes from the dict (not .length)', () => {
+    expect(parseGenome(liveGenome)?.geneCount).toBe(3);
+    // The old buggy `genes.length` would be undefined -> 0 here.
+    expect((liveGenome.genes as { length?: number }).length).toBeUndefined();
+  });
+
+  it('reads fitness from the last fitness_history entry, not top-level fitness', () => {
+    expect(parseGenome(liveGenome)?.fitness).toBe(0.8);
+    // The old buggy `genome.fitness` is null -> 0.
+    expect(liveGenome.fitness).toBeNull();
+  });
+
+  it('reads generation', () => {
+    expect(parseGenome(liveGenome)?.generation).toBe(111);
+  });
+
+  it('returns zeros for an empty genome and null for non-objects', () => {
+    expect(parseGenome({})).toEqual({ generation: 0, geneCount: 0, fitness: 0 });
+    expect(parseGenome(null)).toBeNull();
+    expect(parseGenome([])).toBeNull();
+  });
+});
+
+describe('parseLatestInstance', () => {
+  // Live shape: index.json is an INDEX. `instances` is a LIST of records, each
+  // with content_hash (no `sha`), message_count, and a nested lineage.generation.
+  const liveIndex = {
+    instances: [
+      {
+        content_hash: '11111111aaaaaaaa',
+        serialized_at: '2026-02-17T12:36:06Z',
+        message_count: 213,
+        lineage: { generation: 1, branch: 'main' },
+      },
+      {
+        content_hash: 'e3b666bb4a629ce0',
+        serialized_at: '2026-06-23T03:54:52Z',
+        message_count: 129,
+        lineage: { generation: 110, branch: 'main' },
+      },
+    ],
+    created_at: '2026-02-17T12:36:07Z',
+    branches: { main: {} },
+  };
+
+  it('picks the latest instance by serialized_at and reads its fields', () => {
+    const v = parseLatestInstance(liveIndex);
+    // sha = content_hash[:8] of the LATEST record (no `sha` field exists).
+    expect(v?.sha).toBe('e3b666bb');
+    // gen = lineage.generation (not a top-level `generation`).
+    expect(v?.gen).toBe(110);
+    // messages = message_count (not a top-level `messages`).
+    expect(v?.messages).toBe(129);
+  });
+
+  it('does not treat the index itself as an instance (the original bug)', () => {
+    // The old code did `inst.sha` / `inst.generation` / `inst.messages` on the
+    // index object — all absent, yielding '?'/0/0. Prove they are absent so a
+    // regression to that path cannot quietly pass.
+    const idx = liveIndex as Record<string, unknown>;
+    expect(idx.sha).toBeUndefined();
+    expect(idx.generation).toBeUndefined();
+    expect(idx.messages).toBeUndefined();
+  });
+
+  it('falls back to created_at when serialized_at is missing', () => {
+    const v = parseLatestInstance({
+      instances: [
+        { content_hash: 'deadbeefdeadbeef', created_at: '2026-01-01T00:00:00Z', message_count: 5, lineage: { generation: 7 } },
+        { content_hash: 'cafebabecafebabe', created_at: '2026-09-09T00:00:00Z', message_count: 9, lineage: { generation: 9 } },
+      ],
+    });
+    expect(v?.sha).toBe('cafebabe');
+    expect(v?.gen).toBe(9);
+    expect(v?.messages).toBe(9);
+  });
+
+  it('handles a missing content_hash with the ? sentinel', () => {
+    const v = parseLatestInstance({
+      instances: [{ serialized_at: '2026-06-23T00:00:00Z', message_count: 1, lineage: { generation: 2 } }],
+    });
+    expect(v?.sha).toBe('?');
+    expect(v?.gen).toBe(2);
+    expect(v?.messages).toBe(1);
+  });
+
+  it('returns null for an empty index and non-objects', () => {
+    expect(parseLatestInstance({ instances: [] })).toBeNull();
+    expect(parseLatestInstance({})).toBeNull();
+    expect(parseLatestInstance(null)).toBeNull();
+    expect(parseLatestInstance([])).toBeNull();
+  });
+});

--- a/src/app/api/grip/health/route.ts
+++ b/src/app/api/grip/health/route.ts
@@ -3,6 +3,7 @@ import { readFile } from 'fs/promises';
 import { homedir } from 'os';
 import { join } from 'path';
 import { readdirSync, existsSync } from 'fs';
+import { parseGenome } from '@/lib/grip-readers';
 
 const GRIP_DIR = join(homedir(), '.claude');
 
@@ -20,11 +21,12 @@ export async function GET() {
     try {
       const genomePath = join(GRIP_DIR, 'cache', 'genome.json');
       const raw = await readFile(genomePath, 'utf-8');
-      const genome = JSON.parse(raw);
-      generation = genome.generation || 33;
-      geneCount = genome.genes ? Object.keys(genome.genes).length : 212;
-      const history = genome.fitness_history || [];
-      fitness = history.length > 0 ? history[history.length - 1] : 0.467;
+      const view = parseGenome(JSON.parse(raw));
+      if (view) {
+        generation = view.generation || 33;
+        geneCount = view.geneCount || 212;
+        fitness = view.fitness || 0.467;
+      }
     } catch { /* use defaults */ }
 
     // Count skills

--- a/src/app/api/grip/status/route.ts
+++ b/src/app/api/grip/status/route.ts
@@ -3,27 +3,23 @@ import { readFile } from 'fs/promises';
 import { homedir } from 'os';
 import { join } from 'path';
 import { readdirSync } from 'fs';
+import { parseGenome, parseLatestInstance } from '@/lib/grip-readers';
 
 export async function GET() {
   const home = homedir();
   const claudeDir = join(home, '.claude');
 
-  // Genome
+  // Genome — genes is a dict (Object.keys), fitness is the last fitness_history
+  // entry. Shared with /api/grip/health via parseGenome so the two never drift.
   let genome = null;
   try {
     const raw = await readFile(join(claudeDir, 'cache', 'genome.json'), 'utf-8');
-    const g = JSON.parse(raw);
-    genome = { generation: g.generation || 0, geneCount: g.genes?.length || 0, fitness: g.fitness || 0 };
+    genome = parseGenome(JSON.parse(raw));
   } catch { /* no genome */ }
 
-  // Active modes
-  let activeModes: string[] = [];
-  try {
-    const raw = await readFile(join(claudeDir, '.active-modes'), 'utf-8');
-    activeModes = raw.trim().split('\n').filter(Boolean);
-  } catch { /* no modes */ }
-
-  // Instance — find first project grip index
+  // Instance — grip/index.json is an INDEX whose `instances` list holds the
+  // per-instance records. Pick the latest by serialized_at; the record itself
+  // carries content_hash / lineage.generation / message_count.
   let instance = null;
   try {
     const projectsDir = join(claudeDir, 'projects');
@@ -32,12 +28,21 @@ export async function GET() {
       try {
         const indexPath = join(projectsDir, dir.name, 'grip', 'index.json');
         const raw = await readFile(indexPath, 'utf-8');
-        const inst = JSON.parse(raw);
-        instance = { sha: (inst.sha || '').slice(0, 8) || '?', gen: inst.generation || 0, messages: inst.messages || 0 };
-        break;
+        const parsed = parseLatestInstance(JSON.parse(raw));
+        if (parsed) {
+          instance = parsed;
+          break;
+        }
       } catch { continue; }
     }
   } catch { /* no projects */ }
+
+  // Active modes
+  let activeModes: string[] = [];
+  try {
+    const raw = await readFile(join(claudeDir, '.active-modes'), 'utf-8');
+    activeModes = raw.trim().split('\n').filter(Boolean);
+  } catch { /* no modes */ }
 
   return NextResponse.json({ genome, activeModes, instance });
 }

--- a/src/lib/grip-readers.ts
+++ b/src/lib/grip-readers.ts
@@ -1,0 +1,119 @@
+/**
+ * Shared readers for GRIP genome + instance state.
+ *
+ * Both the /api/grip/health and /api/grip/status routes need the same view of
+ * the local GRIP installation's genome and latest instance. Keeping the parse
+ * logic here (rather than duplicating it per-route) is a DRY win and — more
+ * importantly — guarantees the two routes can never drift onto different,
+ * incompatible readings of the same files.
+ *
+ * The on-disk shapes (verified against a live Gen 111 installation):
+ *
+ *   cache/genome.json
+ *     { generation: number,
+ *       genes: { [id]: ... },        // a DICT, not an array — no `.length`
+ *       fitness_history: number[],   // current fitness = last element
+ *       ... }                        // there is NO top-level `fitness` key
+ *
+ *   projects/<dir>/grip/index.json
+ *     { instances: [ {                // an INDEX (list of records), not one instance
+ *         content_hash: string,       // 16-hex; the only stable id (no `sha` field)
+ *         serialized_at: string,      // ISO ts — pick the latest by this
+ *         message_count: number,
+ *         lineage: { generation: number, ... },
+ *       }, ... ],
+ *       created_at: string,
+ *       branches: { ... } }
+ *
+ * Parsing is split from disk I/O so it can be unit-tested against the exact
+ * live shapes without touching the filesystem.
+ */
+
+export interface GenomeView {
+  generation: number;
+  geneCount: number;
+  fitness: number;
+}
+
+export interface InstanceView {
+  sha: string;
+  gen: number;
+  messages: number;
+}
+
+type Json = Record<string, unknown>;
+
+function asObject(value: unknown): Json | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Json)
+    : null;
+}
+
+/**
+ * Extract the genome view from a parsed genome.json object.
+ *
+ * geneCount = Object.keys(genes).length because `genes` is a dict.
+ * fitness   = last element of `fitness_history` (there is no top-level
+ *             `fitness` key in the live shape — it is always null when present).
+ */
+export function parseGenome(raw: unknown): GenomeView | null {
+  const g = asObject(raw);
+  if (!g) return null;
+
+  const generation = typeof g.generation === 'number' ? g.generation : 0;
+
+  const genes = asObject(g.genes);
+  const geneCount = genes ? Object.keys(genes).length : 0;
+
+  const history = Array.isArray(g.fitness_history) ? g.fitness_history : [];
+  const last = history.length > 0 ? history[history.length - 1] : 0;
+  const fitness = typeof last === 'number' ? last : 0;
+
+  return { generation, geneCount, fitness };
+}
+
+/**
+ * Extract the latest-instance view from a parsed grip/index.json object.
+ *
+ * index.json is an INDEX whose `instances` is a list of per-instance records.
+ * The latest is chosen by `serialized_at` (falling back to `created_at`). The
+ * record carries everything the panel needs, so no sibling per-UUID file read
+ * is required:
+ *   sha      -> content_hash[:8]      (there is no `sha` field)
+ *   gen      -> lineage.generation
+ *   messages -> message_count
+ */
+export function parseLatestInstance(raw: unknown): InstanceView | null {
+  const index = asObject(raw);
+  if (!index) return null;
+
+  const instances = Array.isArray(index.instances) ? index.instances : [];
+  if (instances.length === 0) return null;
+
+  const sortKey = (e: unknown): string => {
+    const o = asObject(e);
+    const ts = o?.serialized_at ?? o?.created_at;
+    return typeof ts === 'string' ? ts : '';
+  };
+
+  let latest = asObject(instances[0]);
+  let latestKey = sortKey(instances[0]);
+  for (const entry of instances) {
+    const key = sortKey(entry);
+    if (key > latestKey) {
+      latest = asObject(entry);
+      latestKey = key;
+    }
+  }
+  if (!latest) return null;
+
+  const hash = typeof latest.content_hash === 'string' ? latest.content_hash : '';
+  const sha = hash.slice(0, 8) || '?';
+
+  const lineage = asObject(latest.lineage);
+  const gen = typeof lineage?.generation === 'number' ? lineage.generation : 0;
+
+  const messages = typeof latest.message_count === 'number' ? latest.message_count : 0;
+
+  return { sha, gen, messages };
+}


### PR DESCRIPTION
## What this does (plain English)

The GRIP status panel was showing a **zeroed-out** genome and instance — generation 0, 0 genes, 0 fitness, instance sha "?", 0 messages — even on a live install at Gen 111. This fixes that so the panel shows the real numbers.

Two separate reading mistakes in `src/app/api/grip/status/route.ts` caused it:

1. **Instance**: the route opened `projects/<dir>/grip/index.json` and treated it as if it were a single instance, reading `inst.sha`, `inst.generation`, `inst.messages`. But that file is an **index** — its real shape is `{ instances: [...], created_at, branches }`. The actual per-instance records live inside the `instances` list, so every one of those reads came back empty (sha "?", gen 0, messages 0).

2. **Genome**: the route read `genome.genes.length` and `genome.fitness`. The live `genome.json` stores `genes` as a **dictionary** (no `.length`) and has **no** top-level `fitness` key — the current fitness is the last entry of `fitness_history`. So gene count and fitness were always 0 too. (The sibling `/api/grip/health` route already read the genome correctly; the status route had drifted.)

## The fix

- New small shared reader `src/lib/grip-readers.ts` with two pure functions, `parseGenome` and `parseLatestInstance`, that know the real on-disk shapes.
- Both the **status** and **health** routes now use `parseGenome`, so the two panels can never again drift onto different readings of the same file (DRY).
- For the instance, the latest record is chosen by `serialized_at`, and `sha`/`gen`/`messages` are read straight from that index entry: `content_hash` (there is no `sha` field), `lineage.generation`, and `message_count`. No extra per-UUID file read is needed — verified against the live data, the index entry is actually the *better* source (the per-UUID file's `lineage.generation` is `null`).

## Why no sibling-file read (small deviation from the ticket sketch)

The ticket suggested opening the referenced per-UUID instance file for `sha`/`generation`. On the live install that file carries no usable `sha` and a `null` `lineage.generation`, whereas the index entry has the correct `generation` (110), `message_count` (129), and `content_hash`. So the minimal, correct, and cheaper fix reads everything from the index entry.

## Test plan

- [x] New `__tests__/lib/grip-readers.test.ts` (9 cases) asserts the parsers against the **real** shapes (genes-as-dict, no top-level fitness, index-with-instances-list, no `sha` field). These assertions fail under the old buggy logic, so a regression turns them red.
- [x] `npm test` — 1014/1014 pass (50 files), including the 9 new cases.
- [x] `npm run build` — compiles successfully; both `/api/grip/health` and `/api/grip/status` build clean.
- [x] `eslint` on all touched files — clean.

Note: built and tested under Node 22 (per the repo `.nvmrc` and `engines: ">=20 <23"`); the machine's default Node 25 is out of range and has a broken native link. CI runs on Node 20.