### PR TITLE
fix(currency): refresh health-route fallbacks + add Opus 4.8 / Sonnet 4.6 pricing

### DIFF
--- a/electron/services/slack-bot.ts
+++ b/electron/services/slack-bot.ts
@@ -350,6 +350,12 @@ export async function handleSlackCommand(
           cache5mWritePerMTok: number;
         }
       > = {
+        'claude-opus-4-8': {
+          inputPerMTok: 5,
+          outputPerMTok: 25,
+          cacheHitsPerMTok: 0.5,
+          cache5mWritePerMTok: 6.25,
+        },
         'claude-opus-4-5-20251101': {
           inputPerMTok: 5,
           outputPerMTok: 25,
@@ -362,6 +368,12 @@ export async function handleSlackCommand(
           cacheHitsPerMTok: 0.5,
           cache5mWritePerMTok: 6.25,
         },
+        'claude-sonnet-4-6': {
+          inputPerMTok: 3,
+          outputPerMTok: 15,
+          cacheHitsPerMTok: 0.3,
+          cache5mWritePerMTok: 3.75,
+        },
         'claude-sonnet-4': {
           inputPerMTok: 3,
           outputPerMTok: 15,
@@ -373,8 +385,13 @@ export async function handleSlackCommand(
       const getModelPricing = (modelId: string) => {
         if (MODEL_PRICING[modelId]) return MODEL_PRICING[modelId];
         const lower = modelId.toLowerCase();
+        if (lower.includes('opus-4-8') || lower.includes('opus-4.8'))
+          return MODEL_PRICING['claude-opus-4-8'];
         if (lower.includes('opus-4-5') || lower.includes('opus-4.5'))
           return MODEL_PRICING['claude-opus-4-5'];
+        if (lower.includes('opus')) return MODEL_PRICING['claude-opus-4-8'];
+        if (lower.includes('sonnet-4-6') || lower.includes('sonnet-4.6'))
+          return MODEL_PRICING['claude-sonnet-4-6'];
         if (lower.includes('sonnet')) return MODEL_PRICING['claude-sonnet-4'];
         return MODEL_PRICING['claude-sonnet-4'];
       };

--- a/electron/services/telegram-bot.ts
+++ b/electron/services/telegram-bot.ts
@@ -788,6 +788,8 @@ export function initTelegramBot() {
 
         // Token pricing per million tokens (MTok) - same as frontend
         const MODEL_PRICING: Record<string, { inputPerMTok: number; outputPerMTok: number; cacheHitsPerMTok: number; cache5mWritePerMTok: number }> = {
+          'claude-opus-4-8': { inputPerMTok: 5, outputPerMTok: 25, cacheHitsPerMTok: 0.50, cache5mWritePerMTok: 6.25 },
+          'claude-sonnet-4-6': { inputPerMTok: 3, outputPerMTok: 15, cacheHitsPerMTok: 0.30, cache5mWritePerMTok: 3.75 },
           'claude-opus-4-5-20251101': { inputPerMTok: 5, outputPerMTok: 25, cacheHitsPerMTok: 0.50, cache5mWritePerMTok: 6.25 },
           'claude-opus-4-5': { inputPerMTok: 5, outputPerMTok: 25, cacheHitsPerMTok: 0.50, cache5mWritePerMTok: 6.25 },
           'claude-opus-4-1-20250501': { inputPerMTok: 15, outputPerMTok: 75, cacheHitsPerMTok: 1.50, cache5mWritePerMTok: 18.75 },
@@ -807,9 +809,11 @@ export function initTelegramBot() {
         const getModelPricing = (modelId: string) => {
           if (MODEL_PRICING[modelId]) return MODEL_PRICING[modelId];
           const lower = modelId.toLowerCase();
+          if (lower.includes('opus-4-8') || lower.includes('opus-4.8')) return MODEL_PRICING['claude-opus-4-8'];
           if (lower.includes('opus-4-5') || lower.includes('opus-4.5')) return MODEL_PRICING['claude-opus-4-5'];
           if (lower.includes('opus-4-1') || lower.includes('opus-4.1')) return MODEL_PRICING['claude-opus-4-1'];
           if (lower.includes('opus-4') || lower.includes('opus4')) return MODEL_PRICING['claude-opus-4'];
+          if (lower.includes('sonnet-4-6') || lower.includes('sonnet-4.6')) return MODEL_PRICING['claude-sonnet-4-6'];
           if (lower.includes('sonnet-4-5') || lower.includes('sonnet-4.5')) return MODEL_PRICING['claude-sonnet-4-5'];
           if (lower.includes('sonnet-4') || lower.includes('sonnet4')) return MODEL_PRICING['claude-sonnet-4'];
           if (lower.includes('sonnet-3') || lower.includes('sonnet3')) return MODEL_PRICING['claude-3-7-sonnet-20250219'];
@@ -820,9 +824,11 @@ export function initTelegramBot() {
 
         const getModelDisplayName = (modelId: string): string => {
           const lower = modelId.toLowerCase();
+          if (lower.includes('opus-4-8') || lower.includes('opus-4.8')) return 'Opus 4.8';
           if (lower.includes('opus-4-5') || lower.includes('opus-4.5')) return 'Opus 4.5';
           if (lower.includes('opus-4-1') || lower.includes('opus-4.1')) return 'Opus 4.1';
           if (lower.includes('opus-4') || lower.includes('opus4')) return 'Opus 4';
+          if (lower.includes('sonnet-4-6') || lower.includes('sonnet-4.6')) return 'Sonnet 4.6';
           if (lower.includes('sonnet-4-5') || lower.includes('sonnet-4.5')) return 'Sonnet 4.5';
           if (lower.includes('sonnet-4') || lower.includes('sonnet4')) return 'Sonnet 4';
           if (lower.includes('sonnet-3') || lower.includes('sonnet3')) return 'Sonnet 3.7';

--- a/src/app/api/grip/health/route.ts
+++ b/src/app/api/grip/health/route.ts
@@ -15,22 +15,22 @@ const GRIP_DIR = join(homedir(), '.claude');
 export async function GET() {
   try {
     // Read genome
-    let generation = 33;
-    let geneCount = 212;
-    let fitness = 0.467;
+    let generation = 91;
+    let geneCount = 378;
+    let fitness = 0.376;
     try {
       const genomePath = join(GRIP_DIR, 'cache', 'genome.json');
       const raw = await readFile(genomePath, 'utf-8');
       const view = parseGenome(JSON.parse(raw));
       if (view) {
-        generation = view.generation || 33;
-        geneCount = view.geneCount || 212;
-        fitness = view.fitness || 0.467;
+        generation = view.generation || generation;
+        geneCount = view.geneCount || geneCount;
+        fitness = view.fitness || fitness;
       }
     } catch { /* use defaults */ }
 
     // Count skills
-    let skillCount = 149;
+    let skillCount = 288;
     try {
       const skillsDir = join(GRIP_DIR, 'skills');
       if (existsSync(skillsDir)) {
@@ -40,7 +40,7 @@ export async function GET() {
     } catch { /* use default */ }
 
     // Count modes
-    let modeCount = 30;
+    let modeCount = 31;
     try {
       const modesDir = join(GRIP_DIR, 'modes', 'definitions');
       if (existsSync(modesDir)) {
@@ -50,7 +50,7 @@ export async function GET() {
     } catch { /* use default */ }
 
     // Count agents
-    let agentCount = 21;
+    let agentCount = 41;
     try {
       const agentsDir = join(GRIP_DIR, 'agents');
       if (existsSync(agentsDir)) {
@@ -75,10 +75,10 @@ export async function GET() {
     return NextResponse.json({
       status: 'error',
       error: err instanceof Error ? err.message : 'Unknown error',
-      generation: 33,
-      skillCount: 149,
-      modeCount: 30,
-      agentCount: 21,
+      generation: 91,
+      skillCount: 288,
+      modeCount: 31,
+      agentCount: 41,
       gateCount: 10,
     });
   }

--- a/src/app/usage/page.tsx
+++ b/src/app/usage/page.tsx
@@ -26,6 +26,8 @@ const MODEL_PRICING: Record<string, {
   cache5mWritePerMTok: number;
   cache1hWritePerMTok: number;
 }> = {
+  // Opus 4.8 (current)
+  'claude-opus-4-8': { inputPerMTok: 5, outputPerMTok: 25, cacheHitsPerMTok: 0.50, cache5mWritePerMTok: 6.25, cache1hWritePerMTok: 10 },
   // Opus 4.6
   'claude-opus-4-6-20250514': { inputPerMTok: 5, outputPerMTok: 25, cacheHitsPerMTok: 0.50, cache5mWritePerMTok: 6.25, cache1hWritePerMTok: 10 },
   'claude-opus-4-6': { inputPerMTok: 5, outputPerMTok: 25, cacheHitsPerMTok: 0.50, cache5mWritePerMTok: 6.25, cache1hWritePerMTok: 10 },
@@ -71,6 +73,9 @@ function getModelPricing(modelId: string) {
 
   // Try partial match
   const lowerModel = modelId.toLowerCase();
+  if (lowerModel.includes('opus-4-8') || lowerModel.includes('opus-4.8')) {
+    return MODEL_PRICING['claude-opus-4-8'];
+  }
   if (lowerModel.includes('opus-4-6') || lowerModel.includes('opus-4.6')) {
     return MODEL_PRICING['claude-opus-4-6'];
   }
@@ -813,6 +818,7 @@ export default function UsagePage() {
               </thead>
               <tbody>
                 {[
+                  { name: 'Claude Opus 4.8', key: 'claude-opus-4-8' },
                   { name: 'Claude Opus 4.6', key: 'claude-opus-4-6' },
                   { name: 'Claude Opus 4.5', key: 'claude-opus-4-5' },
                   { name: 'Claude Opus 4.1', key: 'claude-opus-4-1' },


### PR DESCRIPTION
## What this does (plain English)

Two unrelated-but-related "stale numbers" bugs, both in the currency bucket.

**1. The dashboard's offline fallback numbers were years out of date.**
`src/app/api/grip/health/route.ts` reports live GRIP stats (generation, skill count, etc.). It reads them from the local install, but if that read fails it falls back to hardcoded numbers. Those were frozen at gen 33 / 212 genes / 149 skills / 30 modes / 21 agents / fitness 0.467 — far behind the live install (gen 91, 378 genes, 288 skills, 31 modes, 41 agents, fitness 0.376). They only show on a read failure, but when they do they badly misrepresent the system. Refreshed to current values; the fail-closed structure is unchanged.

**2. The current Claude model was being costed at the wrong price.**
The Slack and Telegram bots each keep a `MODEL_PRICING` table to estimate token cost. Both topped out at `claude-opus-4-5` / `claude-sonnet-4-5` and older — there was no row for the current model, `claude-opus-4-8`. So any usage on the current model fell through to the `claude-sonnet-4` default ($3/$15 per million tokens) and was costed as if it were Sonnet, when Opus 4.8 is actually $5/$25. Added `claude-opus-4-8` and `claude-sonnet-4-6` rows to both maps, plus matching substring branches in their `getModelPricing` fallbacks (and the Telegram display-name helper) so a dated/aliased ID still resolves correctly.

**Also fixed the third copy.** The same pricing table is duplicated a third time in `src/app/usage/page.tsx` (it already had Sonnet 4.6 but was missing Opus 4.8 and labelled 4.6 as the top model). Added the same Opus 4.8 row, fallback branch, and price-table entry there too, so all three divergent tables now agree rather than fixing two and leaving one stale.

Pricing sourced from the canonical Anthropic model table: Opus 4.8 = `$5` in / `$25` out, Sonnet 4.6 = `$3` in / `$15` out (per million tokens). Cache columns follow the existing convention already used by the equal-tier rows (read = input x 0.1, 5-minute write = input x 1.25, 1-hour write = input x 2).

## Scope notes (found but deliberately not touched)

- **DRY debt:** three near-identical `MODEL_PRICING` tables now exist (two in `electron/`, one in `src/`). Consolidating into one shared module would be the right next step, but it spans the Electron main process and the Next bundler (different module systems / import paths) — a larger refactor than this currency fix warrants. Kept atomic; flagging for a follow-up.
- **Pre-existing lint:** `eslint` reports 18 errors / 7 warnings across these files (`no-explicit-any`, unused imports, hook-memoization, `prefer-const`). Verified identical on `main` with my changes stashed — this PR introduces zero new lint issues; the debt is long-standing and out of scope here.

## Test plan
- [x] `npm run lint` — lint-neutral (same 18/7 as `main`, none on changed lines)
- [x] `npm run test` — 1014 passed, 0 failed
- [x] `npm run build` — exit 0, `.next` produced (Node 22)
- [ ] No native deps touched, so `@electron/rebuild` not required