### PR TITLE
feat(hal): make GRIP-GUI HAPPI/1.1 envelope-aware

### DIFF
--- a/__tests__/lib/happi-envelope.test.ts
+++ b/__tests__/lib/happi-envelope.test.ts
@@ -1,0 +1,158 @@
+/**
+ * HAPPI/1.1 envelope helper tests.
+ *
+ * Locks the GUI-side half of the HAPPI envelope contract: the shape GRIP-GUI
+ * builds must mirror the canonical Python builder
+ * (`skills/donna/_happi_dispatch.py::build_envelope` /
+ * `lib/hal/happi/envelope.py`), and the `/api/infer` wire body must be derived
+ * FROM the envelope (prompt from `content`, model from `flags.model`).
+ *
+ * Goodhart-proof: asserts the real field values + the real derivation, not that
+ * a function was merely called. Each assertion fails under an obvious mutation
+ * (wrong version, prompt smuggled into flags.message, model dropped, etc.).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  HAPPI_VERSION,
+  buildHappiEnvelope,
+  halInferBodyFromEnvelope,
+  type HappiEnvelope,
+} from '@/lib/happi-envelope';
+
+describe('HAPPI_VERSION', () => {
+  it('is the HAPPI/1.1 contract HAL implements', () => {
+    expect(HAPPI_VERSION).toBe('happi/1.1');
+  });
+});
+
+describe('buildHappiEnvelope — canonical shape', () => {
+  it('stamps the version, a default cmd of chat, and empty args', () => {
+    const env = buildHappiEnvelope({ content: 'hello' });
+    expect(env.v).toBe('happi/1.1');
+    expect(env.cmd).toBe('chat');
+    expect(env.args).toEqual([]);
+  });
+
+  it('carries the user message in content (the canonical primary slot)', () => {
+    const env = buildHappiEnvelope({ content: 'What is GRIP?' });
+    expect(env.content).toBe('What is GRIP?');
+    // NEVER smuggled into flags.message — the #2697 envelope-content contract.
+    expect(env.flags).not.toHaveProperty('message');
+  });
+
+  it('puts the model in flags (provider-agnostic directive)', () => {
+    const env = buildHappiEnvelope({ content: 'hi', flags: { model: 'sonnet' } });
+    expect(env.flags.model).toBe('sonnet');
+  });
+
+  it('carries the session id in ctx, not in content or flags', () => {
+    const env = buildHappiEnvelope({
+      content: 'hi',
+      ctx: { session_id: 'abc-123' },
+    });
+    expect(env.ctx).toEqual({ session_id: 'abc-123' });
+    expect(env.content).toBe('hi');
+  });
+
+  it('omits content, ctx, and auth when not supplied (no empty slots)', () => {
+    const env = buildHappiEnvelope({});
+    expect(env).not.toHaveProperty('content');
+    expect(env).not.toHaveProperty('ctx');
+    expect(env).not.toHaveProperty('auth');
+  });
+
+  it('omits an empty ctx object', () => {
+    const env = buildHappiEnvelope({ content: 'hi', ctx: {} });
+    expect(env).not.toHaveProperty('ctx');
+  });
+
+  it('folds audit:true into flags.audit', () => {
+    const env = buildHappiEnvelope({ content: 'hi', audit: true });
+    expect(env.flags.audit).toBe(true);
+  });
+
+  it('does not set flags.audit when audit is false', () => {
+    const env = buildHappiEnvelope({ content: 'hi', audit: false });
+    expect(env.flags).not.toHaveProperty('audit');
+  });
+
+  it('carries an auth descriptor when supplied', () => {
+    const env = buildHappiEnvelope({
+      content: 'hi',
+      auth: { scheme: 'apikey', token: 'keychain:grip-gemini' },
+    });
+    expect(env.auth).toEqual({ scheme: 'apikey', token: 'keychain:grip-gemini' });
+  });
+
+  it('generates a stable, prefixed correlation id by default', () => {
+    const env = buildHappiEnvelope({ content: 'hi' });
+    expect(env.id).toMatch(/^gui-[0-9a-f]{12}$/);
+  });
+
+  it('honours an explicit id override (deterministic tests)', () => {
+    const env = buildHappiEnvelope({ content: 'hi', id: 'fixed-id' });
+    expect(env.id).toBe('fixed-id');
+  });
+
+  it('produces unique ids across calls', () => {
+    const a = buildHappiEnvelope({ content: 'x' });
+    const b = buildHappiEnvelope({ content: 'y' });
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it('does not mutate the caller-supplied flags object', () => {
+    const flags = { model: 'sonnet' };
+    buildHappiEnvelope({ content: 'hi', flags, audit: true });
+    expect(flags).not.toHaveProperty('audit');
+  });
+});
+
+describe('halInferBodyFromEnvelope — /api/infer wire-body derivation', () => {
+  it('derives prompt from content, model from flags.model, audit from flags.audit', () => {
+    const env = buildHappiEnvelope({
+      content: 'What is GRIP?',
+      flags: { model: 'groq/llama-3.3-70b' },
+      audit: true,
+    });
+    const body = halInferBodyFromEnvelope(env);
+    expect(body).toEqual({
+      prompt: 'What is GRIP?',
+      model: 'groq/llama-3.3-70b',
+      audit: true,
+    });
+  });
+
+  it('matches the exact hal-server contract: prompt + model + audit only', () => {
+    // The old, incorrect body used `message`/`session_id`. Guard against drift.
+    const body = halInferBodyFromEnvelope(
+      buildHappiEnvelope({ content: 'hi', flags: { model: 'sonnet' } }),
+    );
+    expect(Object.keys(body).sort()).toEqual(['audit', 'model', 'prompt']);
+    expect(body).not.toHaveProperty('message');
+    expect(body).not.toHaveProperty('session_id');
+  });
+
+  it('falls back to empty strings when content/model are absent', () => {
+    const env: HappiEnvelope = {
+      v: 'happi/1.1',
+      id: 'x',
+      cmd: 'chat',
+      args: [],
+      flags: {},
+    };
+    const body = halInferBodyFromEnvelope(env);
+    expect(body.prompt).toBe('');
+    expect(body.model).toBe('');
+    expect(body.audit).toBe(false);
+  });
+
+  it('does not leak the session id from ctx into the wire body', () => {
+    const env = buildHappiEnvelope({
+      content: 'hi',
+      flags: { model: 'sonnet' },
+      ctx: { session_id: 'should-not-appear' },
+    });
+    const body = halInferBodyFromEnvelope(env);
+    expect(JSON.stringify(body)).not.toContain('should-not-appear');
+  });
+});

--- a/src/lib/grip-session.ts
+++ b/src/lib/grip-session.ts
@@ -15,6 +15,8 @@
  * - Parse stream events to extract text deltas in real-time
  */
 
+import { buildHappiEnvelope, halInferBodyFromEnvelope } from '@/lib/happi-envelope';
+
 export interface ToolUseEvent {
   toolName: string;
   toolId: string;
@@ -624,8 +626,12 @@ export interface HalInferResult {
  * HAL backend path — calls hal-server's canonical AI syscall `/api/infer`
  * (HAL #331), the route `lib/hal_llm_adapter.py` POSTs to in live GRIP.
  *
- * Request (HAPPI-shaped, matches `_grip_infer_call`):
- *   { prompt: string, model: string, audit: boolean }
+ * The request is composed as a HAPPI/1.1 envelope first (prompt → `content`,
+ * session → `ctx`, model → `flags.model`), so GRIP-GUI speaks the same
+ * provider-agnostic contract as the rest of the substrate. `/api/infer` itself
+ * re-wraps the call in a HAPPI envelope server-side and accepts the flat
+ * `{prompt, model, audit}` wire body, which we derive from the envelope via
+ * `halInferBodyFromEnvelope` — single source of truth in `lib/happi-envelope`.
  *
  * Response is a single JSON object (NOT a JSONL/SSE stream):
  *   { ok, text, provider, model, idr_ref, usage: { input_tokens, output_tokens } }
@@ -644,10 +650,16 @@ async function* sendToGripHAL(
 ): AsyncGenerator<GripStreamEvent> {
   if (sessionId) onPromptSessionId?.(sessionId);
   try {
+    const envelope = buildHappiEnvelope({
+      content: prompt,
+      flags: { model },
+      ctx: sessionId ? { session_id: sessionId } : undefined,
+      audit: false,
+    });
     const response = await fetch(`${halUrl}/api/infer`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ prompt, model, audit: false }),
+      body: JSON.stringify(halInferBodyFromEnvelope(envelope)),
     });
 
     if (!response.ok) {

--- a/src/lib/happi-envelope.ts
+++ b/src/lib/happi-envelope.ts
@@ -1,0 +1,125 @@
+/**
+ * HAPPI/1.1 envelope — the single source of truth for the provider-agnostic
+ * request shape GRIP-GUI uses to talk to the HAL substrate.
+ *
+ * Why this exists: live GRIP's AI substrate is HAPPI-based. Every LLM call in
+ * the harness is wrapped in a HAPPI envelope before it reaches a provider
+ * (`lib/hal_llm_adapter.py` → hal-server, `skills/donna/_happi_dispatch.py` →
+ * `bash happi.md run`). The GUI used to construct an ad-hoc request body, so
+ * the envelope contract lived nowhere in the TS codebase. Defining it here —
+ * in ONE place — keeps GRIP-GUI a first-class HAPPI speaker and lets the shape
+ * track HAPPI revisions without touching every call site.
+ *
+ * Canonical shape (mirrors `skills/donna/_happi_dispatch.py::build_envelope`
+ * and `lib/hal/happi/envelope.py`, verified against ~/.claude on 2026-06-23):
+ *
+ *   { v, id, cmd, args, flags, content?, ctx?, auth? }
+ *
+ * User-message resolution precedence inside HAL is: content > flags.message >
+ * args. GRIP always carries the prompt in `content` (the documented primary
+ * slot — see the #2697 envelope-content contract), never `flags.message`.
+ */
+
+export const HAPPI_VERSION = 'happi/1.1' as const;
+
+/** Auth descriptor — mirrors the HAPPI `auth` object HAL adapters consume. */
+export interface HappiAuth {
+  /** e.g. 'apikey' | 'subscription' | 'bearer'. */
+  scheme: string;
+  /** Token or a `keychain:<entry>` reference; optional for subscription auth. */
+  token?: string;
+}
+
+/**
+ * A HAPPI/1.1 envelope. `content` carries the user message; `flags` carries
+ * provider/model/system directives; `ctx` carries session/correlation state;
+ * `auth` is added only when the caller has a credential descriptor.
+ */
+export interface HappiEnvelope {
+  v: typeof HAPPI_VERSION;
+  /** Correlation id (stable per request). */
+  id: string;
+  /** Command verb, e.g. 'chat'. */
+  cmd: string;
+  /** Positional args (lowest user-message precedence). */
+  args: string[];
+  /** Provider-agnostic directives: provider, model, system, max_tokens, audit… */
+  flags: Record<string, unknown>;
+  /** Primary user-message slot (highest precedence). */
+  content?: string;
+  /** Session/correlation context, e.g. { session_id }. */
+  ctx?: Record<string, unknown>;
+  /** Optional auth descriptor. */
+  auth?: HappiAuth;
+}
+
+export interface BuildHappiEnvelopeOptions {
+  /** Command verb (default 'chat'). */
+  cmd?: string;
+  /** User message — placed in `content`, the canonical primary slot. */
+  content?: string;
+  /** Provider-agnostic flags (model, provider, system, max_tokens…). */
+  flags?: Record<string, unknown>;
+  /** Positional args. */
+  args?: string[];
+  /** Session/correlation context. */
+  ctx?: Record<string, unknown>;
+  /** Auth descriptor. */
+  auth?: HappiAuth;
+  /** When true, sets `flags.audit = true` (HAL audit-chain opt-in). */
+  audit?: boolean;
+  /** Override the generated correlation id (mainly for deterministic tests). */
+  id?: string;
+}
+
+/** Generate a correlation id (uuid4, prefixed for traceability). */
+function newEnvelopeId(): string {
+  return `gui-${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}`;
+}
+
+/**
+ * Build a minimal HAPPI/1.1 envelope. Mirrors the canonical Python builder:
+ * `content` and `ctx`/`auth` are added only when present (so a bare envelope
+ * never carries empty slots), and `audit` folds into `flags`.
+ */
+export function buildHappiEnvelope(opts: BuildHappiEnvelopeOptions = {}): HappiEnvelope {
+  const flags: Record<string, unknown> = { ...(opts.flags ?? {}) };
+  if (opts.audit) flags.audit = true;
+
+  const envelope: HappiEnvelope = {
+    v: HAPPI_VERSION,
+    id: opts.id ?? newEnvelopeId(),
+    cmd: opts.cmd ?? 'chat',
+    args: [...(opts.args ?? [])],
+    flags,
+  };
+  if (opts.content) envelope.content = opts.content;
+  if (opts.ctx && Object.keys(opts.ctx).length > 0) envelope.ctx = opts.ctx;
+  if (opts.auth) envelope.auth = opts.auth;
+  return envelope;
+}
+
+/** The `/api/infer` wire body hal-server accepts (HAL #331). */
+export interface HalInferBody {
+  prompt: string;
+  model: string;
+  audit: boolean;
+}
+
+/**
+ * Derive the hal-server `/api/infer` wire body from a HAPPI envelope.
+ *
+ * `/api/infer` wraps `grip_infer`/RAILLM, which re-wraps the call in a HAPPI
+ * envelope server-side, so its HTTP contract is the flat `{prompt, model,
+ * audit}` shape (`lib/hal_llm_adapter.py::_grip_infer_call`). This adapter
+ * lets the GUI think in envelopes while still speaking that route's exact
+ * contract — the prompt comes from `content` (canonical precedence), the model
+ * from `flags.model`, and audit from `flags.audit`.
+ */
+export function halInferBodyFromEnvelope(env: HappiEnvelope): HalInferBody {
+  return {
+    prompt: env.content ?? '',
+    model: typeof env.flags.model === 'string' ? (env.flags.model as string) : '',
+    audit: env.flags.audit === true,
+  };
+}


### PR DESCRIPTION
## What this does (plain English)

GRIP talks to its AI brains (the HAL substrate) using a standard, provider-agnostic message format called a **HAPPI envelope**. Every part of live GRIP wraps its AI requests in this envelope before sending them, so the same request can reach any provider (Claude, Groq, Gemini, a local model) without rewriting it.

GRIP-GUI's HAL connection was the odd one out: it hand-built a one-off request body (`{ prompt, model, audit }`) and had no idea the envelope format even existed. There were zero `happi` references anywhere in its TypeScript. That meant the GUI was a generation behind the contract the rest of the system speaks.

This PR teaches the GUI to think in HAPPI envelopes, **without changing what actually goes over the wire** to the working `/api/infer` endpoint.

## How

- **New file `src/lib/happi-envelope.ts`** — one place that defines the HAPPI/1.1 envelope shape (`v, id, cmd, args, flags, content, ctx, auth`), mirroring the canonical Python builder in `~/.claude` (`skills/donna/_happi_dispatch.py::build_envelope`). It exposes:
  - `buildHappiEnvelope(...)` — builds a minimal envelope (the prompt goes in `content`, the session id in `ctx`, the model in `flags` — exactly as the item asked).
  - `halInferBodyFromEnvelope(...)` — derives the flat `{ prompt, model, audit }` body that `hal-server`'s `/api/infer` route accepts.
- **`src/lib/grip-session.ts`** — `sendToGripHAL` now composes the request as an envelope first, then derives the wire body from it.

### Why the endpoint contract is safe

`/api/infer` wraps `grip_infer`/RAILLM, which itself re-wraps the call in a HAPPI envelope server-side, so its HTTP contract is the flat `{ prompt, model, audit }` shape. The derived body is **byte-identical** to the previous one — so the existing `hal-integration.test.ts` `/api/infer` contract still holds. The win is that the envelope shape now lives in **one** TypeScript place and can track HAPPI revisions without touching call sites.

## Test plan

- [x] `npm test` — 51 files / 1032 tests pass (includes 27 new Goodhart-resistant envelope tests: real field values, prompt-in-`content`-not-`flags.message` precedence, model-in-`flags`, session-in-`ctx`, and the exact `/api/infer` body derivation).
- [x] `npm run build` — `✓ Compiled successfully` (Next.js type-check passes).
- [x] New source files lint clean (`eslint src/lib/happi-envelope.ts src/lib/grip-session.ts ...` → 0 issues).
- [x] `npm ci` (CI's exact command) succeeds on Node 22.
- No native deps touched, so no `@electron/rebuild` needed.

## Notes

- Local Node v25 (Homebrew) is broken (missing `simdjson` dylib) and is outside the repo's `>=20 <23` engine range; built and tested against the repo-pinned Node 22 (`.nvmrc` already present). No Node-pinning change needed.
- Pre-existing: `npm run lint` exits non-zero on the repo as a whole due to minified `mcp-*/dist/bundle.js` build artifacts the eslint config does not ignore. This is unrelated to this change (my files are clean) and lint is not a gated CI check (only `npm test` runs on PRs). Worth a separate tooling item to add those globs to the eslint ignore list.