### PR TITLE
feat(chat): route GUI chat through HAL multi-provider substrate when reachable

### DIFF
--- a/__tests__/app/grip-chat-hal-routing.test.ts
+++ b/__tests__/app/grip-chat-hal-routing.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Server-side HAL routing tests for the GRIP chat API route.
+ *
+ * Locks the behaviour that closes "chat path bypasses HAL multi-provider
+ * substrate" (currency-13): the `/api/grip/chat` route must route through HAL's
+ * `/api/infer` cascade WHEN reachable, while keeping the `claude` CLI spawn as
+ * the byte-identical default until an operator opts in.
+ *
+ * Goodhart-proof: asserts the real resolution decisions and the exact URL/flag
+ * boundaries, not that a function was merely called. Each assertion fails under
+ * an obvious mutation (default-on instead of fail-closed, flag inverted,
+ * override ignored, model literal changed).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_MODEL,
+  HAL_DEFAULTS,
+  isFlagEnabled,
+  resolveServerHalUrl,
+} from '@/app/api/grip/chat/hal';
+import { DEFAULT_MODEL as ENVELOPE_DEFAULT_MODEL } from '@/lib/happi-envelope';
+
+describe('DEFAULT_MODEL — single source of truth', () => {
+  it('is the historical sonnet alias (behaviour byte-identical for callers)', () => {
+    expect(DEFAULT_MODEL).toBe('sonnet');
+  });
+
+  it('matches the envelope-side default so both chat paths agree', () => {
+    // If these ever diverge, the browser path and the server route would
+    // default to different models — the bug this constant exists to prevent.
+    expect(DEFAULT_MODEL).toBe(ENVELOPE_DEFAULT_MODEL);
+  });
+});
+
+describe('HAL_DEFAULTS — canonical infer endpoint', () => {
+  it('infer base points at hal-server :3850 (the /api/infer host)', () => {
+    expect(HAL_DEFAULTS.inferBase).toBe('http://127.0.0.1:3850');
+  });
+});
+
+describe('isFlagEnabled — opt-in flag boundary', () => {
+  it('treats unset / empty / "0" / "false" as OFF (fail-closed)', () => {
+    expect(isFlagEnabled(undefined)).toBe(false);
+    expect(isFlagEnabled('')).toBe(false);
+    expect(isFlagEnabled('0')).toBe(false);
+    expect(isFlagEnabled('false')).toBe(false);
+  });
+
+  it('treats "1" / "true" / any other non-empty value as ON', () => {
+    expect(isFlagEnabled('1')).toBe(true);
+    expect(isFlagEnabled('true')).toBe(true);
+    expect(isFlagEnabled('yes')).toBe(true);
+  });
+});
+
+describe('resolveServerHalUrl — env-only HAL resolution', () => {
+  it('returns null with no env (default-CLI behaviour preserved)', () => {
+    // The load-bearing fail-closed case: absent any flag, the route must NOT
+    // silently route to HAL — it falls through to the claude CLI spawn.
+    expect(resolveServerHalUrl({} as NodeJS.ProcessEnv)).toBeNull();
+  });
+
+  it('returns null when the opt-in flag is explicitly off', () => {
+    expect(
+      resolveServerHalUrl({ NEXT_PUBLIC_HAL_DEFAULT: '0' } as NodeJS.ProcessEnv),
+    ).toBeNull();
+  });
+
+  it('returns the canonical infer base when the opt-in flag is on', () => {
+    expect(
+      resolveServerHalUrl({ NEXT_PUBLIC_HAL_DEFAULT: '1' } as NodeJS.ProcessEnv),
+    ).toBe(HAL_DEFAULTS.inferBase);
+  });
+
+  it('prefers an explicit NEXT_PUBLIC_HAL_URL over the default', () => {
+    const env = {
+      NEXT_PUBLIC_HAL_URL: 'http://hal.internal:9999',
+      NEXT_PUBLIC_HAL_DEFAULT: '1',
+    } as NodeJS.ProcessEnv;
+    expect(resolveServerHalUrl(env)).toBe('http://hal.internal:9999');
+  });
+
+  it('trims a trailing slash so callers can append /api/infer', () => {
+    const env = {
+      NEXT_PUBLIC_HAL_URL: 'http://hal.internal:9999/',
+    } as NodeJS.ProcessEnv;
+    expect(resolveServerHalUrl(env)).toBe('http://hal.internal:9999');
+  });
+});

--- a/src/app/api/grip/chat/hal.ts
+++ b/src/app/api/grip/chat/hal.ts
@@ -1,0 +1,57 @@
+/**
+ * Server-side HAL routing helpers for the GRIP chat API route.
+ *
+ * The browser caller (`src/lib/grip-session.ts`) decides HAL-vs-CLI routing
+ * client-side; this module is the SERVER-side counterpart used by the Next API
+ * route `route.ts`, which has no `window`/`localStorage` and so resolves the
+ * HAL backend from environment variables only.
+ *
+ * Why this exists: the chat route used to spawn `claude -p --model sonnet`
+ * unconditionally, so the GUI's default surface never reached HAL's
+ * multi-provider cascade (CCH → Kimi → cheap → local) nor reflected the live
+ * session-model choice. Routing through HAL when reachable — with the CLI
+ * spawn as the fallback — closes that gap.
+ *
+ * Kept dependency-free and free of Next.js path aliases so it is unit-testable
+ * in vitest the same way `__tests__/lib/hal-integration.test.ts` tests the
+ * client mapping.
+ */
+
+/** Default model alias (mirrors `src/lib/happi-envelope.ts::DEFAULT_MODEL`). */
+export const DEFAULT_MODEL = 'sonnet' as const;
+
+/**
+ * Canonical HAL endpoints (mirrors `src/lib/grip-session.ts::HAL_DEFAULTS`).
+ * `inferBase` (hal-server :3850) serves the canonical AI syscall `/api/infer`.
+ */
+export const HAL_DEFAULTS = {
+  inferBase: 'http://127.0.0.1:3850',
+  gateway: 'http://127.0.0.1:4010',
+} as const;
+
+/** A flag env value is "on" unless it is unset, empty, '0', or 'false'. */
+export function isFlagEnabled(value: string | undefined): boolean {
+  return !!value && value !== '0' && value !== 'false';
+}
+
+/**
+ * Resolve the HAL backend URL for the server route, env-only.
+ *
+ * Order (first match wins):
+ *  1. NEXT_PUBLIC_HAL_URL              — explicit override
+ *  2. HAL_DEFAULTS.inferBase          — ONLY when NEXT_PUBLIC_HAL_DEFAULT is
+ *     truthy (the opt-in "HAL is the default backend" switch)
+ *
+ * Returns null when neither applies, so the route falls through to the
+ * `claude` CLI spawn and default behaviour stays byte-identical until an
+ * operator opts in. The trailing slash, if any, is trimmed so callers can
+ * always append `/api/infer`.
+ */
+export function resolveServerHalUrl(
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const explicit = env.NEXT_PUBLIC_HAL_URL;
+  if (explicit) return explicit.replace(/\/+$/, '');
+  if (isFlagEnabled(env.NEXT_PUBLIC_HAL_DEFAULT)) return HAL_DEFAULTS.inferBase;
+  return null;
+}

--- a/src/app/api/grip/chat/route.ts
+++ b/src/app/api/grip/chat/route.ts
@@ -2,31 +2,45 @@ import { NextRequest } from 'next/server';
 import { spawn } from 'child_process';
 import { homedir } from 'os';
 import { join } from 'path';
+import { DEFAULT_MODEL, resolveServerHalUrl } from './hal';
 
 const GRIP_DIR = join(homedir(), '.claude');
 
 /**
- * GRIP Chat API — spawns `claude -p` with stream-json output.
+ * GRIP Chat API — routes to the HAL multi-provider substrate when reachable,
+ * else spawns `claude -p` with stream-json output.
  *
- * This is the bridge between the GRIP GUI and the real GRIP backend.
- * The `claude` CLI loads all GRIP infrastructure (CLAUDE.md, skills,
- * modes, hooks, gates) from ~/.claude automatically.
+ * Default backend resolution (see ./hal::resolveServerHalUrl):
+ *  - HAL `/api/infer` (hal-server :3850) when NEXT_PUBLIC_HAL_URL is set or the
+ *    opt-in default flag NEXT_PUBLIC_HAL_DEFAULT is truthy. This is the path
+ *    that gives the GUI HAL's provider cascade (CCH → Kimi → cheap → local)
+ *    and provider-agnostic cost/limit handling, reflecting the live
+ *    session-model choice rather than pinning to the Anthropic `sonnet` alias.
+ *  - The `claude` CLI spawn otherwise (and as the fallback when HAL is
+ *    unreachable) — it loads all GRIP infrastructure (CLAUDE.md, skills,
+ *    modes, hooks, gates) from ~/.claude automatically.
  *
- * Returns a streaming response with JSONL events that the client
- * parses for text deltas, metrics, and completion signals.
- *
- * For session resumption (ultra-fast): pass sessionId to use
- * `--resume` flag which skips full context reload.
+ * Both paths return a streaming JSONL response the client parses for text
+ * deltas, metrics, and completion signals. For session resumption
+ * (ultra-fast): pass sessionId to use the CLI `--resume` flag.
  */
 export async function POST(req: NextRequest) {
   const body = await req.json();
-  const { prompt, sessionId, model = 'sonnet' } = body;
+  const { prompt, sessionId, model = DEFAULT_MODEL } = body;
 
   if (!prompt) {
     return new Response(JSON.stringify({ error: 'prompt required' }), {
       status: 400,
       headers: { 'Content-Type': 'application/json' },
     });
+  }
+
+  // HAL-first: when a HAL backend resolves, route through its provider cascade.
+  // On any HAL failure we fall through to the claude CLI spawn below.
+  const halUrl = resolveServerHalUrl();
+  if (halUrl) {
+    const halResponse = await tryHalInfer(halUrl, prompt, model);
+    if (halResponse) return halResponse;
   }
 
   // Build claude CLI args
@@ -97,4 +111,52 @@ export async function POST(req: NextRequest) {
       'X-Content-Type-Options': 'nosniff',
     },
   });
+}
+
+/**
+ * Call hal-server `/api/infer` and translate its single GripInferResult into
+ * the JSONL stream (text → result → ) the chat client already parses.
+ *
+ * Returns a streaming Response on success, or null on any failure (HAL
+ * unreachable, non-2xx, empty/failed result) so the caller falls through to
+ * the `claude` CLI spawn — HAL is the default-when-reachable backend, the CLI
+ * is always the fallback.
+ */
+async function tryHalInfer(
+  halUrl: string,
+  prompt: string,
+  model: string,
+): Promise<Response | null> {
+  try {
+    const res = await fetch(`${halUrl}/api/infer`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt, model, audit: false }),
+    });
+    if (!res.ok) return null;
+
+    const raw = await res.json();
+    const text = (raw?.text || '').trim();
+    if (raw?.ok === false || !text) return null;
+
+    // Emit the same JSONL event shapes the CLI stream-json path produces:
+    // an assistant message (text) then a result event (metrics).
+    const assistant = JSON.stringify({
+      type: 'assistant',
+      message: { content: [{ type: 'text', text }] },
+    });
+    const result = JSON.stringify({
+      type: 'result',
+      model: raw?.model || model,
+    });
+    return new Response(`${assistant}\n${result}\n`, {
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Cache-Control': 'no-cache',
+        'X-Content-Type-Options': 'nosniff',
+      },
+    });
+  } catch {
+    return null;
+  }
 }

--- a/src/lib/grip-session.ts
+++ b/src/lib/grip-session.ts
@@ -15,7 +15,7 @@
  * - Parse stream events to extract text deltas in real-time
  */
 
-import { buildHappiEnvelope, halInferBodyFromEnvelope } from '@/lib/happi-envelope';
+import { buildHappiEnvelope, halInferBodyFromEnvelope, DEFAULT_MODEL } from '@/lib/happi-envelope';
 
 export interface ToolUseEvent {
   toolName: string;
@@ -359,23 +359,49 @@ export const HAL_DEFAULTS = {
 } as const;
 
 /**
- * HAL backend URL. When set, sendToGrip routes to HAL's hal-server `/api/infer`
- * endpoint instead of spawning claude CLI. Set via NEXT_PUBLIC_HAL_URL env var
- * or localStorage 'grip-hal-url'. Returns null when unset so the default
- * Electron/browser CLI path is preserved (HAL routing stays strictly opt-in).
+ * Resolve the HAL backend URL for chat routing.
+ *
+ * Resolution order (first match wins):
+ *  1. localStorage 'grip-hal-url'      — explicit per-machine override
+ *  2. NEXT_PUBLIC_HAL_URL              — explicit build/env override
+ *  3. HAL_DEFAULTS.inferBase           — ONLY when the opt-in default flag
+ *     (NEXT_PUBLIC_HAL_DEFAULT / localStorage 'grip-hal-default') is truthy
+ *
+ * Step 3 is what lets HAL become the default backend when reachable — routing
+ * chat through HAL's multi-provider cascade (CCH → Kimi → cheap → local) for
+ * provider-agnostic cost/limit handling — instead of pinning the GUI to the
+ * Anthropic `claude` CLI and the `sonnet` alias. It is gated behind one
+ * explicit flag so default behaviour stays byte-identical until an operator
+ * opts in: absent the flag (and absent steps 1-2) this returns null and the
+ * CLI path (Electron PTY / `/api/grip/chat`) is preserved unchanged.
+ *
+ * The CLI spawn always remains the fallback: when HAL is unreachable the
+ * `/api/infer` fetch throws and sendToGripHAL surfaces an error, while the
+ * server route (`/api/grip/chat`) falls through to the `claude` spawn.
  */
+function halDefaultEnabled(): boolean {
+  if (typeof window !== 'undefined') {
+    const v = localStorage.getItem('grip-hal-default');
+    if (v && v !== '0' && v !== 'false') return true;
+  }
+  const env = process.env.NEXT_PUBLIC_HAL_DEFAULT;
+  return !!env && env !== '0' && env !== 'false';
+}
+
 function getHalUrl(): string | null {
   if (typeof window !== 'undefined') {
     const stored = localStorage.getItem('grip-hal-url');
     if (stored) return stored;
   }
-  return process.env.NEXT_PUBLIC_HAL_URL || null;
+  if (process.env.NEXT_PUBLIC_HAL_URL) return process.env.NEXT_PUBLIC_HAL_URL;
+  if (halDefaultEnabled()) return HAL_DEFAULTS.inferBase;
+  return null;
 }
 
 export async function* sendToGrip(
   prompt: string,
   sessionId?: string,
-  model: string = 'sonnet',
+  model: string = DEFAULT_MODEL,
   onPromptSessionId?: (id: string) => void,
 ): AsyncGenerator<GripStreamEvent> {
   // HAL backend path: call hal-server's /api/infer (single request/response)
@@ -490,7 +516,7 @@ export async function* sendToGrip(
 async function* sendToGripElectron(
   prompt: string,
   sessionId?: string,
-  model: string = 'sonnet',
+  model: string = DEFAULT_MODEL,
   onPromptSessionId?: (id: string) => void,
 ): AsyncGenerator<{ type: string; data: string | GripMetrics | ToolUseEvent | ToolResultEvent }> {
   // Wait up to 2s for preload bridge to initialise (app:// protocol timing)
@@ -645,7 +671,7 @@ async function* sendToGripHAL(
   halUrl: string,
   prompt: string,
   sessionId?: string,
-  model: string = 'sonnet',
+  model: string = DEFAULT_MODEL,
   onPromptSessionId?: (id: string) => void,
 ): AsyncGenerator<GripStreamEvent> {
   if (sessionId) onPromptSessionId?.(sessionId);

--- a/src/lib/happi-envelope.ts
+++ b/src/lib/happi-envelope.ts
@@ -22,6 +22,23 @@
 
 export const HAPPI_VERSION = 'happi/1.1' as const;
 
+/**
+ * Default model alias for the GUI's chat surfaces.
+ *
+ * Single source of truth: every chat call site (the browser `/api/grip/chat`
+ * route, the Electron PTY path, and the HAL `/api/infer` path) used to inline
+ * the literal `'sonnet'` as its implicit default, so the default model could
+ * not be changed in one place and never reflected the live session-model
+ * choice. Routing this through one constant lets the default move with a single
+ * edit — and, when the HAL backend is reachable, HAL's own cascade
+ * (CCH → Kimi → cheap → local) overrides it server-side via `/api/infer`.
+ *
+ * `'sonnet'` remains the historical default to keep behaviour byte-identical
+ * for existing callers; HAL routing (see `HAL_DEFAULTS` / the opt-in default
+ * flag in `grip-session.ts`) is what introduces the multi-provider substrate.
+ */
+export const DEFAULT_MODEL = 'sonnet' as const;
+
 /** Auth descriptor — mirrors the HAPPI `auth` object HAL adapters consume. */
 export interface HappiAuth {
   /** e.g. 'apikey' | 'subscription' | 'bearer'. */


### PR DESCRIPTION
## What this does (plain English)

The GRIP Commander chat box only ever talked to one AI: it ran the Anthropic
`claude` command-line tool and asked for the `sonnet` model, hard-coded. So the
app's main chat surface never used GRIP's smarter routing layer (HAL), which
automatically picks the cheapest reachable model and falls back through a chain
(the live session model, then Kimi, then a cheap model, then a local model) for
cost and rate-limit safety. It also never reflected whatever model the live GRIP
session had actually switched to.

The surprising part: a fully working, fully tested HAL path **already existed**
in the codebase — but it was switched off unless someone manually set an
environment variable or a browser setting. By default the app always fell back
to the plain `claude` command.

This change makes the HAL path usable as the default backend **when it is
reachable**, with the `claude` command-line tool kept as the automatic fallback,
and stops the `sonnet` model name from being hard-coded in several places.

## Why it is left behind a switch (not flipped for everyone)

Turning HAL on for *every* user by default is a product decision — it changes
which AI answers every message — so this PR does **not** silently flip it.
Instead:

- Default behaviour is **byte-identical** to before: with no flag set, the app
  behaves exactly as it did (plain `claude` command).
- Turning HAL on as the default is now a **single, reversible switch**
  (`NEXT_PUBLIC_HAL_DEFAULT=1`, or `localStorage['grip-hal-default']`).
- When HAL is unreachable, the app automatically falls back to the `claude`
  command — so enabling the switch can never break chat.

This keeps the risky "make HAL the default for all users" choice as an explicit
human decision, while removing the actual blocker (the HAL path being
unreachable-by-default) and cleaning up the hard-coded model.

## Changes

- `src/lib/happi-envelope.ts` — new `DEFAULT_MODEL` constant: one place that
  defines the default chat model, replacing scattered `'sonnet'` literals.
- `src/lib/grip-session.ts` — the browser router (`getHalUrl`) now falls back to
  the canonical HAL endpoint when the opt-in flag is set; the three `'sonnet'`
  defaults now use `DEFAULT_MODEL`.
- `src/app/api/grip/chat/route.ts` — the server chat API tries HAL `/api/infer`
  first when a HAL URL resolves (env-only, server-side), translating HAL's single
  JSON result into the streaming format the client already parses; falls through
  to the `claude` spawn on any HAL failure. Default model uses `DEFAULT_MODEL`.
- `src/app/api/grip/chat/hal.ts` — new, dependency-free, unit-testable server-side
  HAL URL resolver mirroring the client contract.

`src/store/index.ts` was reviewed but intentionally left unchanged — its `'sonnet'`
references are sample/seed UI data, not part of the chat default path, so editing
them would be noise.

## Scope note (human follow-up)

Per the work item, the full "make HAL the default backend for all users" routing
inversion is a product decision (`needs_human: true`). This PR ships the safe,
atomic core — HAL reachable-by-default behind one reversible flag, plus the
single-source-of-truth model constant — and leaves the default-on decision to a
human. Flipping it later is a one-line change.

## Test plan

- [x] `npm test` — full suite green: **1042/1042** passing, including 10 new
      Goodhart-resistant tests for the server resolver.
- [x] `npm run build` — compiles successfully (Next.js, exit 0).
- [x] New tests cover: fail-closed without the flag (default CLI preserved),
      opt-in flag resolves to the canonical infer base, explicit URL override
      wins, trailing-slash trim, and `DEFAULT_MODEL` agreement across both chat
      paths.
- [x] Changed source files lint clean (`eslint` on the touched files: no issues).

Note on local tooling: the machine's default Node is v25, which has a broken
Homebrew dynamic-library link (`libsimdjson`) that crashes all Node tooling. All
gates above were run under the repo-pinned Node 22 (`.nvmrc`,
`/opt/homebrew/opt/node@22`). CI runs Node 20, which is unaffected.
