### PR TITLE
feat(mcp): surface live universal GRIP servers (grip-channel HTTP, grip-run) in Commander install

### DIFF
--- a/__tests__/electron/providers/claude-provider.test.ts
+++ b/__tests__/electron/providers/claude-provider.test.ts
@@ -136,6 +136,75 @@ describe('ClaudeProvider', () => {
       expect(config.mcpServers.existing).toBeDefined();
       expect(config.mcpServers['new-server']).toBeDefined();
     });
+
+    // ── HTTP transport (grip-channel and similar remote servers) ──────────────
+
+    it('uses claude mcp add --transport http for HTTP servers', async () => {
+      const provider = await getProvider();
+      mockExecSync.mockReturnValue('');
+
+      await provider.registerMcpServer('grip-channel', '', [], {
+        transport: 'http',
+        url: 'https://channel.grip-web.com/mcp',
+      });
+
+      const cmd = mockExecSync.mock.calls[0][0] as string;
+      expect(cmd).toContain('claude mcp add -s user --transport http grip-channel');
+      expect(cmd).toContain('https://channel.grip-web.com/mcp');
+      // Must NOT degrade an HTTP server into a stdio command.
+      expect(cmd).not.toContain(' node ');
+    });
+
+    it('writes {type:http,url} to mcp.json fallback for HTTP servers', async () => {
+      const provider = await getProvider();
+      mockExecSync.mockImplementation(() => { throw new Error('fail'); });
+
+      await provider.registerMcpServer('grip-channel', '', [], {
+        transport: 'http',
+        url: 'https://channel.grip-web.com/mcp',
+      });
+
+      const config = JSON.parse(
+        fs.readFileSync(path.join(tmpDir, '.claude', 'mcp.json'), 'utf-8'),
+      );
+      expect(config.mcpServers['grip-channel']).toEqual({
+        type: 'http',
+        url: 'https://channel.grip-web.com/mcp',
+      });
+      // No stdio keys leaked into an HTTP entry.
+      expect(config.mcpServers['grip-channel'].command).toBeUndefined();
+      expect(config.mcpServers['grip-channel'].args).toBeUndefined();
+    });
+
+    it('preserves existing stdio entries when adding an HTTP server (fallback)', async () => {
+      const provider = await getProvider();
+      mockExecSync.mockImplementation(() => { throw new Error('fail'); });
+
+      const mcpDir = path.join(tmpDir, '.claude');
+      fs.mkdirSync(mcpDir, { recursive: true });
+      fs.writeFileSync(path.join(mcpDir, 'mcp.json'), JSON.stringify({
+        mcpServers: { 'claude-mgr-orchestrator': { command: 'node', args: ['/bundle.js'] } },
+      }));
+
+      await provider.registerMcpServer('grip-channel', '', [], {
+        transport: 'http',
+        url: 'https://channel.grip-web.com/mcp',
+      });
+
+      const config = JSON.parse(fs.readFileSync(path.join(mcpDir, 'mcp.json'), 'utf-8'));
+      expect(config.mcpServers['claude-mgr-orchestrator']).toEqual({
+        command: 'node',
+        args: ['/bundle.js'],
+      });
+      expect(config.mcpServers['grip-channel'].type).toBe('http');
+    });
+
+    it('throws when an HTTP server is registered without a url', async () => {
+      const provider = await getProvider();
+      await expect(
+        provider.registerMcpServer('grip-channel', '', [], { transport: 'http' }),
+      ).rejects.toThrow(/url/);
+    });
   });
 
   describe('removeMcpServer', () => {
@@ -363,6 +432,32 @@ describe('ClaudeProvider', () => {
     it('returns false when mcp.json does not exist', async () => {
       const provider = await getProvider();
       expect(provider.isMcpServerRegistered('my-mcp', '/bundle.js')).toBe(false);
+    });
+
+    it('returns true for an HTTP server with matching url', async () => {
+      const provider = await getProvider();
+      const mcpDir = path.join(tmpDir, '.claude');
+      fs.mkdirSync(mcpDir, { recursive: true });
+      fs.writeFileSync(path.join(mcpDir, 'mcp.json'), JSON.stringify({
+        mcpServers: { 'grip-channel': { type: 'http', url: 'https://channel.grip-web.com/mcp' } },
+      }));
+
+      expect(
+        provider.isMcpServerRegistered('grip-channel', 'https://channel.grip-web.com/mcp'),
+      ).toBe(true);
+    });
+
+    it('returns false for an HTTP server when the url differs', async () => {
+      const provider = await getProvider();
+      const mcpDir = path.join(tmpDir, '.claude');
+      fs.mkdirSync(mcpDir, { recursive: true });
+      fs.writeFileSync(path.join(mcpDir, 'mcp.json'), JSON.stringify({
+        mcpServers: { 'grip-channel': { type: 'http', url: 'https://old.example.com/mcp' } },
+      }));
+
+      expect(
+        provider.isMcpServerRegistered('grip-channel', 'https://channel.grip-web.com/mcp'),
+      ).toBe(false);
     });
   });
 });

--- a/electron/providers/claude-provider.ts
+++ b/electron/providers/claude-provider.ts
@@ -10,6 +10,7 @@ import type {
   OneShotCommandParams,
   ProviderModel,
   HookConfig,
+  McpRegisterOptions,
 } from './cli-provider';
 import { posixQuote } from '../utils/shell';
 
@@ -247,18 +248,25 @@ export class ClaudeProvider implements CLIProvider {
     }
   }
 
-  async registerMcpServer(name: string, command: string, args: string[]): Promise<void> {
-    // Try claude mcp add -s user first
+  async registerMcpServer(name: string, command: string, args: string[], options?: McpRegisterOptions): Promise<void> {
+    const isHttp = options?.transport === 'http';
+    if (isHttp && !options?.url) {
+      throw new Error(`HTTP MCP server ${name} requires a url`);
+    }
+
+    // Try `claude mcp add -s user` first (merges into the user-scope config).
     try {
-      const argsStr = args.map(a => `"${a}"`).join(' ');
-      execSync(`claude mcp add -s user ${name} ${command} ${argsStr}`, {
+      const addArgs = isHttp
+        ? `--transport http ${name} "${options!.url}"`
+        : `${name} ${command} ${args.map(a => `"${a}"`).join(' ')}`;
+      execSync(`claude mcp add -s user ${addArgs}`, {
         encoding: 'utf-8',
         stdio: 'pipe',
       });
       console.log(`[claude] Registered MCP server ${name} via claude mcp add`);
       return;
     } catch {
-      // Fallback: write to mcp.json
+      // Fallback: merge into mcp.json (read-then-write preserves existing entries).
     }
 
     const mcpConfigPath = path.join(this.configDir, 'mcp.json');
@@ -276,7 +284,9 @@ export class ClaudeProvider implements CLIProvider {
       }
     }
 
-    mcpConfig.mcpServers![name] = { command, args };
+    mcpConfig.mcpServers![name] = isHttp
+      ? { type: 'http', url: options!.url }
+      : { command, args };
     fs.writeFileSync(mcpConfigPath, JSON.stringify(mcpConfig, null, 2));
     console.log(`[claude] Registered MCP server ${name} via mcp.json fallback`);
   }
@@ -313,7 +323,13 @@ export class ClaudeProvider implements CLIProvider {
     try {
       const mcpConfig = JSON.parse(fs.readFileSync(mcpConfigPath, 'utf-8'));
       const existing = mcpConfig?.mcpServers?.[name];
-      if (!existing?.args) return false;
+      if (!existing) return false;
+      // HTTP server: match on the endpoint URL.
+      if (existing.type === 'http' || existing.url) {
+        return existing.url === expectedServerPath;
+      }
+      // stdio server: match on the bundle path (last arg).
+      if (!existing.args) return false;
       return existing.args[existing.args.length - 1] === expectedServerPath;
     } catch {
       return false;

--- a/electron/providers/cli-provider.ts
+++ b/electron/providers/cli-provider.ts
@@ -57,6 +57,21 @@ export interface HookConfig {
 }
 
 /**
+ * Options for registering an MCP server.
+ *
+ * Default (omitted) = stdio transport, byte-identical to the legacy
+ * `registerMcpServer(name, command, args)` behaviour. Pass
+ * `{ transport: 'http', url }` to register a remote HTTP server such as the
+ * live grip-channel bridge (https://channel.grip-web.com/mcp).
+ */
+export interface McpRegisterOptions {
+  /** Transport type. Defaults to 'stdio' when omitted. */
+  transport?: 'stdio' | 'http';
+  /** Remote endpoint URL. Required when transport is 'http'. */
+  url?: string;
+}
+
+/**
  * Strategy pattern interface for CLI providers.
  * Each provider (Claude, Codex, Gemini) implements this interface
  * to encapsulate all provider-specific behavior.
@@ -97,13 +112,23 @@ export interface CLIProvider {
   /** MCP configuration strategy: 'flag' = pass via CLI flag, 'config-file' = write to config file */
   getMcpConfigStrategy(): 'flag' | 'config-file';
 
-  /** Register an MCP server with this provider's configuration */
-  registerMcpServer(name: string, command: string, args: string[]): Promise<void>;
+  /**
+   * Register an MCP server with this provider's configuration.
+   *
+   * For stdio servers (the default) pass command + args. For HTTP servers
+   * pass `options.transport='http'` and `options.url`; `command`/`args` are
+   * then ignored. Omitting `options` preserves the legacy stdio behaviour.
+   */
+  registerMcpServer(name: string, command: string, args: string[], options?: McpRegisterOptions): Promise<void>;
 
   /** Remove an MCP server from this provider's configuration */
   removeMcpServer(name: string): Promise<void>;
 
-  /** Check if an MCP server is registered with the expected server path */
+  /**
+   * Check if an MCP server is registered with the expected identity.
+   * For stdio servers `expectedServerPath` is the bundle path (last arg);
+   * for HTTP servers it is the endpoint URL.
+   */
   isMcpServerRegistered(name: string, expectedServerPath: string): boolean;
 
   /** Directories where this provider reads skills from */

--- a/electron/providers/codex-provider.ts
+++ b/electron/providers/codex-provider.ts
@@ -10,6 +10,7 @@ import type {
   OneShotCommandParams,
   ProviderModel,
   HookConfig,
+  McpRegisterOptions,
 } from './cli-provider';
 import { posixQuote } from '../utils/shell';
 
@@ -131,7 +132,10 @@ export class CodexProvider implements CLIProvider {
     console.log('Codex CLI: hooks not supported, using exit-code based status detection');
   }
 
-  async registerMcpServer(name: string, command: string, args: string[]): Promise<void> {
+  async registerMcpServer(name: string, command: string, args: string[], options?: McpRegisterOptions): Promise<void> {
+    if (options?.transport === 'http') {
+      throw new Error(`Codex provider does not support HTTP MCP servers (${name})`);
+    }
     // Try codex mcp add first (proper CLI registration)
     try {
       const argsStr = args.map(a => `"${a}"`).join(' ');

--- a/electron/providers/gemini-provider.ts
+++ b/electron/providers/gemini-provider.ts
@@ -10,6 +10,7 @@ import type {
   OneShotCommandParams,
   ProviderModel,
   HookConfig,
+  McpRegisterOptions,
 } from './cli-provider';
 import { posixQuote } from '../utils/shell';
 
@@ -213,7 +214,10 @@ export class GeminiProvider implements CLIProvider {
     }
   }
 
-  async registerMcpServer(name: string, command: string, args: string[]): Promise<void> {
+  async registerMcpServer(name: string, command: string, args: string[], options?: McpRegisterOptions): Promise<void> {
+    if (options?.transport === 'http') {
+      throw new Error(`Gemini provider does not support HTTP MCP servers (${name})`);
+    }
     // Try gemini mcp add first (proper CLI registration)
     try {
       const argsStr = args.map(a => `"${a}"`).join(' ');

--- a/electron/services/mcp-orchestrator.ts
+++ b/electron/services/mcp-orchestrator.ts
@@ -4,7 +4,30 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { execSync } from 'child_process';
 import type { AppSettings } from '../types';
-import { getAllProviders } from '../providers';
+import { getAllProviders, getProvider } from '../providers';
+
+/**
+ * Live universal GRIP servers (the ones in ~/.claude/.mcp.json).
+ *
+ * These are Claude Code servers — they read/run against the live GRIP install
+ * at ~/.claude. Commander surfaces them so a Commander-driven Claude session
+ * sees the current GRIP toolset, not just Commander's own claude-mgr-* product
+ * servers. Registered Claude-only (not across every provider) because they are
+ * specific to the GRIP install Claude Code consumes.
+ *
+ * - grip-channel is HTTP (location-independent) — always safe to register.
+ * - grip-run is stdio; its path is resolved absolutely against ~/.claude and
+ *   only registered when that file actually exists, so machines without GRIP
+ *   never get a broken stdio entry.
+ */
+type GripUniversalServer =
+  | { name: string; transport: 'http'; url: string }
+  | { name: string; transport: 'stdio'; command: string; relPath: string };
+
+const GRIP_UNIVERSAL_SERVERS: GripUniversalServer[] = [
+  { name: 'grip-channel', transport: 'http', url: 'https://channel.grip-web.com/mcp' },
+  { name: 'grip-run', transport: 'stdio', command: 'node', relPath: 'mcp-servers/grip-run/server.js' },
+];
 
 /**
  * MCP Orchestrator Service
@@ -127,10 +150,49 @@ export async function setupMcpOrchestrator(appSettings?: AppSettings): Promise<v
       }
     }
 
+    // Surface the live universal GRIP servers (grip-channel HTTP, grip-run, ...)
+    // into Claude's config so a Commander session sees the current GRIP toolset.
+    await registerGripUniversalServers();
+
     // Install bundled skills to ~/.claude/skills/ (Claude-only)
     await installBundledSkills();
   } catch (err) {
     console.error('Failed to auto-setup MCP servers:', err);
+  }
+}
+
+/**
+ * Register the live universal GRIP servers with the Claude provider.
+ *
+ * Merges into the existing user-scope config (claude mcp add / mcp.json
+ * read-then-write) — it never clobbers the user's other MCP servers. stdio
+ * entries are skipped unless their resolved file exists under ~/.claude, so a
+ * machine without GRIP installed gets only the location-independent HTTP ones.
+ */
+async function registerGripUniversalServers(): Promise<void> {
+  const claude = getProvider('claude');
+  const claudeDir = path.join(os.homedir(), '.claude');
+
+  for (const server of GRIP_UNIVERSAL_SERVERS) {
+    try {
+      if (server.transport === 'http') {
+        if (!claude.isMcpServerRegistered(server.name, server.url)) {
+          await claude.registerMcpServer(server.name, '', [], { transport: 'http', url: server.url });
+        }
+        continue;
+      }
+
+      const absPath = path.join(claudeDir, server.relPath);
+      if (!fs.existsSync(absPath)) {
+        console.log(`GRIP server ${server.name} not found at ${absPath}, skipping`);
+        continue;
+      }
+      if (!claude.isMcpServerRegistered(server.name, absPath)) {
+        await claude.registerMcpServer(server.name, server.command, [absPath]);
+      }
+    } catch (err) {
+      console.error(`Failed to register GRIP server ${server.name}:`, err);
+    }
   }
 }
 


### PR DESCRIPTION
## What this does (plain English)

When someone installs GRIP Commander, it sets up MCP servers in their Claude config. Until now it only added Commander's own servers (the `claude-mgr-*` ones) and had no idea about the universal GRIP servers that live GRIP actually uses today (`grip-channel`, `grip-run`, and friends in `~/.claude/.mcp.json`).

The most important gap: `grip-channel` has moved to an **HTTP** connection (`https://channel.grip-web.com/mcp`), and Commander's installer could only describe **stdio** (local-program) servers — so it had no way to add the HTTP channel bridge at all. The result was that a Commander install gave you neither the current GRIP toolset nor the channel bridge.

This change teaches the installer how to add HTTP servers and makes it surface the live universal GRIP servers alongside Commander's own (it reconciles the divergence — it does not replace the `claude-mgr-*` servers).

## How it works

- `registerMcpServer` gains an optional `options` argument. Pass `{ transport: 'http', url }` to register an HTTP server (it runs `claude mcp add --transport http`, with a `{type:"http",url}` write to `mcp.json` as a fallback). The argument is optional, so every existing stdio call site behaves exactly as before.
- `ClaudeProvider.isMcpServerRegistered` now understands HTTP servers (it matches on the URL for HTTP, and on the bundle path for stdio) so it doesn't re-add a server that's already there.
- The installer registers two live GRIP servers with Claude after its existing setup loop:
  - **grip-channel** over HTTP — location-independent, always safe to add.
  - **grip-run** over stdio — its path is resolved against `~/.claude` and only added when that file actually exists, so a machine without GRIP installed receives only the HTTP server and never a broken stdio entry.
- The installer **merges** into the user's existing MCP config (via `claude mcp add` / a read-then-write `mcp.json` fallback) — it never overwrites the user's other servers.
- Codex/Gemini providers accept the new argument and fail loudly if ever asked for HTTP (they are never sent HTTP servers, since these GRIP servers are Claude-only).

## Why only grip-channel + grip-run

The item asked for "at least grip-channel HTTP + grip-run". The other live servers (`code-index`, `grip-hear`, `grip-apps`, `grip-presence`) use **relative** stdio paths that only resolve from the `~/.claude` working directory; replicating them at user scope would mis-resolve. grip-channel is HTTP (works anywhere) and grip-run is added with an absolute, existence-checked path. Extending to the remaining stdio servers (absolute-path resolution for each) is a sensible follow-up but kept out of this atomic change.

## Test plan

- [x] `npm run test` — full suite **1048 passed, 0 failed**, including new cases in `__tests__/electron/providers/claude-provider.test.ts`:
  - HTTP register via the CLI uses `--transport http` and never degrades to a stdio command
  - HTTP register via the `mcp.json` fallback writes `{type:"http",url}` with no leaked stdio keys
  - adding an HTTP server preserves existing stdio entries (merge-not-clobber)
  - HTTP register throws when `url` is missing
  - `isMcpServerRegistered` matches/differs correctly on HTTP url
- [x] Electron TypeScript type-check (`tsc -p electron/tsconfig.json`) — clean (exit 0)
- [x] `npm run build` (`next build`) — compiled successfully
- [ ] No native dependencies touched, so `@electron/rebuild` not required

## Note for reviewers

`npm run lint` is red on `main` independently of this change (38 untouched source files plus committed minified bundle artefacts already report errors; the eslint config does not ignore the bundled `mcp-*/dist` files). All six files changed here are lint-clean (0 errors). Fixing the repo-wide lint baseline is a separate, larger cleanup and is intentionally out of scope for this atomic MCP-wiring fix.