### PR TITLE
fix(tabs): keep the old tab reachable after opening a new one (Cmd+T)

### DIFF
--- a/__tests__/renderer/ChatStorage.test.tsx
+++ b/__tests__/renderer/ChatStorage.test.tsx
@@ -13,6 +13,7 @@ import {
   setOpenTabIds,
   updateChatTitle,
   getActiveChatId,
+  pickActiveTabId,
 } from '../../src/lib/chat-storage';
 
 // Provide a fully-functional localStorage stub that works in any Vitest environment.
@@ -28,6 +29,21 @@ vi.stubGlobal('localStorage', {
 
 beforeEach(() => {
   store = {}; // Reset between tests
+});
+
+describe('pickActiveTabId — tab-switch invariant (the "opened a new tab, can not get back" fix)', () => {
+  it('keeps the active tab when it is still open', () => {
+    expect(pickActiveTabId(['a', 'b', 'c'], 'b')).toBe('b');
+  });
+  it('falls back to the first open tab when the active id is no longer open (the bug)', () => {
+    expect(pickActiveTabId(['a', 'b'], 'gone')).toBe('a');
+  });
+  it('falls back to the first open tab when active is null', () => {
+    expect(pickActiveTabId(['a', 'b'], null)).toBe('a');
+  });
+  it('returns null when there are no open tabs', () => {
+    expect(pickActiveTabId([], 'a')).toBe(null);
+  });
 });
 
 describe('generateTitle', () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,6 +18,7 @@ import {
   migrateStorageIfNeeded,
   getOpenTabIds,
   setOpenTabIds,
+  pickActiveTabId,
 } from '@/lib/chat-storage';
 
 const MAX_TABS = 8;
@@ -124,14 +125,20 @@ export default function EnginePage() {
   const handleWelcomeComplete = useCallback(() => setShowWelcome(false), []);
   const handleFocusToggle = useCallback((focused: boolean) => setFocusMode(focused), []);
 
+  // Create a new tab. Session creation + active-tab selection happen OUTSIDE
+  // the openTabIds updater on purpose: a state updater MUST be pure (React 19
+  // may invoke it more than once), and calling setActiveTabId from inside it
+  // can leave activeTabId out of sync with openTabIds — which presents as
+  // "opened a new tab but can't switch back to the old one". Creating the
+  // session once and setting both states at top level keeps them consistent.
   const handleNewTab = useCallback(() => {
-    setOpenTabIdsState(prev => {
-      if (prev.length >= MAX_TABS) return prev;
-      const session = createChatSession(model);
-      setActiveTabId(session.id);
-      return [...prev, session.id];
-    });
-  }, [model]);
+    if (openTabIds.length >= MAX_TABS) return;
+    const session = createChatSession(model);
+    setOpenTabIdsState(prev =>
+      prev.includes(session.id) ? prev : [...prev, session.id]
+    );
+    setActiveTabId(session.id);
+  }, [openTabIds, model]);
 
   const handleTabClose = useCallback((id: string) => {
     setOpenTabIdsState(prev => {
@@ -145,6 +152,14 @@ export default function EnginePage() {
   }, [activeTabId]);
 
   const handleTabSelect = useCallback((id: string) => setActiveTabId(id), []);
+
+  // The tab actually shown is DERIVED, never trusted blindly. activeTabId must
+  // reference an open tab, but it can desync (a new-tab race, a closed tab, a
+  // restore mismatch) and strand the user on a tab the renderer won't show —
+  // the "opened a new tab, can't get back to the old one" bug. Deriving it at
+  // render (rather than correcting via setState-in-effect) keeps one source of
+  // truth and avoids an extra render.
+  const effectiveActiveId = pickActiveTabId(openTabIds, activeTabId);
 
   // Keyboard shortcuts: ⌘T = new tab, ⌘W = close tab, ⌘1-9 = switch
   useEffect(() => {
@@ -182,7 +197,7 @@ export default function EnginePage() {
             {openTabIds.length > 1 && !focusMode && (
               <ChatTabBar
                 openTabIds={openTabIds}
-                activeTabId={activeTabId}
+                activeTabId={effectiveActiveId}
                 onTabSelect={handleTabSelect}
                 onTabClose={handleTabClose}
                 onNewTab={handleNewTab}
@@ -197,13 +212,13 @@ export default function EnginePage() {
                   {openTabIds.map(tabId => (
                     <div
                       key={tabId}
-                      className={tabId === activeTabId ? 'block h-full' : 'hidden'}
+                      className={tabId === effectiveActiveId ? 'block h-full' : 'hidden'}
                     >
                       <ChatInterface
                         key={tabId}
                         chatId={tabId}
                         onModelChange={setModel}
-                        isActive={tabId === activeTabId}
+                        isActive={tabId === effectiveActiveId}
                       />
                     </div>
                   ))}

--- a/src/lib/chat-storage.ts
+++ b/src/lib/chat-storage.ts
@@ -10,7 +10,7 @@
  * - grip-active-chat: Currently active chat ID
  */
 
-import type { GripMessage, GripMetrics } from './grip-session';
+import type { GripMessage } from './grip-session';
 
 export interface ChatSession {
   id: string;
@@ -247,6 +247,23 @@ export function getOpenTabIds(): string[] {
  */
 export function setOpenTabIds(ids: string[]): void {
   localStorage.setItem(TABS_KEY, JSON.stringify(ids));
+}
+
+/**
+ * Resolve the tab that SHOULD be active, given the open tabs and the current
+ * active id. The active tab must always be one of the open tabs; if it isn't
+ * (a new-tab race, a closed tab, a restore mismatch) the user would be
+ * stranded on a tab the renderer won't show — the "opened a new tab, can't get
+ * back to the old one" bug. In that case we fall back to the first open tab.
+ * Pure + deterministic so it can be unit-tested without rendering.
+ */
+export function pickActiveTabId(
+  openTabIds: string[],
+  activeTabId: string | null,
+): string | null {
+  if (openTabIds.length === 0) return null;
+  if (activeTabId && openTabIds.includes(activeTabId)) return activeTabId;
+  return openTabIds[0];
 }
 
 /**


### PR DESCRIPTION
## What this does (plain English)

Opening a new chat tab with **Cmd+T** could leave you unable to switch back to the tab you were on. This fixes it.

**Two root causes:**
1. `handleNewTab` created the session and set the active tab *inside* React's state updater. Updaters must be pure (React 19 can run them more than once), and setting the active tab from inside one could desync it from the open-tab list. Now the session is created once and both states are set together.
2. The tab that's *shown* is now **derived** (`pickActiveTabId`) instead of trusting the stored active id blindly. If that id ever falls off the open list, the view falls back to the first open tab — so you can never be stranded on a tab that isn't displayed.

## Test plan
- [x] `npm run test` — 1052 pass (incl. 4 new `pickActiveTabId` regression tests)
- [x] `npm run build` — compiles clean (Node 22)
- [ ] Manual: Cmd+T, then click the old tab or Cmd+1 → returns to it